### PR TITLE
feat: add Docker support with MCPO for cloud deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -63,6 +63,9 @@ Dockerfile*
 .dockerignore
 docker-compose*.yml
 
+# MCPO generated configs (if any exist locally)
+mcpo-config*.json
+
 # CI/CD
 .github/
 .gitlab-ci.yml

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,77 @@
+# Node.js
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+.pnpm-store/
+
+# Build outputs (we'll rebuild inside container)
+dist/
+build/
+*.tsbuildinfo
+
+# Development files
+.env
+.env.local
+.env.development
+.env.test
+.env.production
+
+# IDE and editor files
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS generated files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Git
+.git/
+.gitignore
+
+# Testing
+coverage/
+.nyc_output/
+*.lcov
+
+# Logs
+logs/
+*.log
+
+# Runtime data
+pids/
+*.pid
+*.seed
+*.pid.lock
+
+# Documentation (unless needed in container)
+docs/
+*.md
+!README.md
+
+# Docker
+Dockerfile*
+.dockerignore
+docker-compose*.yml
+
+# CI/CD
+.github/
+.gitlab-ci.yml
+.travis.yml
+
+# Misc
+.cache/
+.parcel-cache/
+.next/
+.nuxt/
+.tmp/
+.temp/

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,12 @@ FROM node:20-alpine
 # Set working directory
 WORKDIR /app
 
-# Install pnpm globally and uvx for mcpo
-RUN npm install -g pnpm && npm install -g @antfu/ni
+# Install system dependencies including Python and uv
+RUN apk add --no-cache python3 py3-pip gettext && \
+    pip3 install uv
+
+# Install pnpm globally
+RUN npm install -g pnpm
 
 # Copy package files for dependency installation
 COPY package.json pnpm-lock.yaml ./
@@ -46,11 +50,8 @@ RUN echo '#!/bin/sh\n\
 envsubst < /app/mcpo-config.json > /app/mcpo-config-final.json\n\
 \n\
 # Start MCPO with the config\n\
-exec uvx mcpo --port ${PORT:-8000} --config /app/mcpo-config-final.json' > /app/start.sh && \
+exec uv tool run mcpo --port ${PORT:-8000} --config /app/mcpo-config-final.json' > /app/start.sh && \
 chmod +x /app/start.sh
-
-# Install envsubst for environment variable substitution
-RUN apk add --no-cache gettext
 
 # Expose port for MCPO
 EXPOSE 8000

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,5 +28,5 @@ EXPOSE 3000
 # Set environment to production
 ENV NODE_ENV=production
 
-# Run the MCP server
-CMD ["node", "dist/index.js"]
+# Run the MCP server & stay alive
+CMD ["sh", "-c", "node dist/index.js & wait"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,17 +44,9 @@ RUN echo '{\
   }\
 }' > /app/mcpo-config.json
 
-# Create startup script that substitutes environment variables
-COPY <<EOF /app/start.sh
-#!/bin/sh
-# Substitute environment variables in config
-envsubst < /app/mcpo-config.json > /app/mcpo-config-final.json
-
-# Start MCPO with the config
-exec uv tool run mcpo --port \${PORT:-8000} --config /app/mcpo-config-final.json
-EOF
-
-RUN chmod +x /app/start.sh
+# Create startup script file
+RUN printf '#!/bin/sh\n# Substitute environment variables in config\nenvsubst < /app/mcpo-config.json > /app/mcpo-config-final.json\n\n# Start MCPO with the config\nexec uv tool run mcpo --port ${PORT:-8000} --config /app/mcpo-config-final.json\n' > /app/start.sh && \
+    chmod +x /app/start.sh
 
 # Expose port for MCPO
 EXPOSE 8000

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,4 +29,4 @@ EXPOSE 3000
 ENV NODE_ENV=production
 
 # Run the MCP server & stay alive
-CMD ["sh", "-c", "node dist/index.js & wait"]
+CMD ["sh", "-c", "node dist/index.js < /dev/null & sleep infinity"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,13 +45,16 @@ RUN echo '{\
 }' > /app/mcpo-config.json
 
 # Create startup script that substitutes environment variables
-RUN echo '#!/bin/sh\n\
-# Substitute environment variables in config\n\
-envsubst < /app/mcpo-config.json > /app/mcpo-config-final.json\n\
-\n\
-# Start MCPO with the config\n\
-exec uv tool run mcpo --port ${PORT:-8000} --config /app/mcpo-config-final.json' > /app/start.sh && \
-chmod +x /app/start.sh
+COPY <<EOF /app/start.sh
+#!/bin/sh
+# Substitute environment variables in config
+envsubst < /app/mcpo-config.json > /app/mcpo-config-final.json
+
+# Start MCPO with the config
+exec uv tool run mcpo --port \${PORT:-8000} --config /app/mcpo-config-final.json
+EOF
+
+RUN chmod +x /app/start.sh
 
 # Expose port for MCPO
 EXPOSE 8000

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /app
 
 # Install system dependencies including Python and uv
 RUN apk add --no-cache python3 py3-pip gettext && \
-    pip3 install uv
+    pip3 install --break-system-packages uv
 
 # Install pnpm globally
 RUN npm install -g pnpm

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+# Use Node.js 20 LTS Alpine for smallest image size
+FROM node:20-alpine
+
+# Set working directory
+WORKDIR /app
+
+# Install pnpm globally
+RUN npm install -g pnpm
+
+# Copy package files for dependency installation
+COPY package.json pnpm-lock.yaml ./
+
+# Install dependencies
+RUN pnpm install --frozen-lockfile --prod=false
+
+# Copy source code
+COPY . .
+
+# Build the TypeScript project
+RUN pnpm run build
+
+# Remove development dependencies to reduce image size
+RUN pnpm prune --prod
+
+# Expose port
+EXPOSE 3000
+
+# Set environment to production
+ENV NODE_ENV=production
+
+# Run the MCP server
+CMD ["node", "dist/index.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3.8'
+
+services:
+  mcp-omnisearch:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: mcp-omnisearch
+    restart: unless-stopped
+    ports:
+      - "3000:3000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,5 +7,16 @@ services:
       dockerfile: Dockerfile
     container_name: mcp-omnisearch
     restart: unless-stopped
+    # Environment variables can be set via .env file or passed directly
+    # Uncomment and customize as needed:
+    # environment:
+    #   - BRAVE_API_KEY=${BRAVE_API_KEY}
+    #   - TAVILY_API_KEY=${TAVILY_API_KEY}
+    #   - KAGI_API_KEY=${KAGI_API_KEY}
+    #   - PERPLEXITY_API_KEY=${PERPLEXITY_API_KEY}
+    #   - JINA_AI_API_KEY=${JINA_AI_API_KEY}
+    #   - FIRECRAWL_API_KEY=${FIRECRAWL_API_KEY}
+    
+    # Expose port for MCPO
     ports:
-      - "3000:3000"
+      - "8000:8000"


### PR DESCRIPTION
## Summary
Adds Docker containerisation with MCPO integration to enable cloud deployment of the mcp-omnisearch server.

## Changes
- Add Dockerfile with Alpine Linux base for minimal image size
- Add .dockerignore for efficient builds  
- Add docker-compose.yml for local development
- Integrate MCPO to bridge stdio MCP server to HTTP/OpenAPI
- Support environment variable configuration for all search providers
- Enable deployment to cloud platforms (tested on Sliplane)

## Usage
Deploy to any container platform with environment variables for API keys:
- `BRAVE_API_KEY`, `TAVILY_API_KEY`, `KAGI_API_KEY`, etc.
- Access via OpenAPI at `/omnisearch` endpoint
- Compatible with OpenWebUI and other tools expecting OpenAPI

Resolves the challenge of deploying stdio-based MCP servers as web services.