### PR TITLE
feat: add Bright Data SERP API search provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 A Model Context Protocol (MCP) server that provides unified access to
 multiple search providers and AI tools. This server combines the
-capabilities of Tavily, Perplexity, Kagi, Jina AI, Brave, and
-Firecrawl to offer comprehensive search, AI responses, content
-processing, and enhancement features through a single interface.
+capabilities of Tavily, Perplexity, Kagi, Jina AI, Brave, Exa, 
+Bright Data, and Firecrawl to offer comprehensive search, AI responses, 
+content processing, and enhancement features through a single interface.
 
 <a href="https://glama.ai/mcp/servers/gz5wgmptd8">
   <img width="380" height="200" src="https://glama.ai/mcp/servers/gz5wgmptd8/badge" alt="Glama badge" />
@@ -25,6 +25,17 @@ processing, and enhancement features through a single interface.
   advertising influence, focused on authoritative sources. Supports
   search operators in query string (site:, -site:, filetype:,
   intitle:, inurl:, before:, after:, and exact phrases).
+- **Exa Search**: AI-powered semantic web search using neural
+  embeddings. Unlike keyword-based search, Exa understands meaning and
+  context to find the most relevant content. Best for research,
+  factual queries, and discovering content that matches semantic intent
+  rather than exact keywords. Supports domain filtering through API
+  parameters (includeDomains/excludeDomains).
+- **Bright Data SERP API**: Comprehensive search engine data collection
+  with proxy management and unblocking. Supports Google, Bing, DuckDuckGo,
+  Yandex, Baidu, Yahoo, and Naver. Best for large-scale data collection,
+  market research, brand monitoring, and applications requiring robust
+  anti-blocking capabilities. Features native support for search operators.
 
 ### 🎯 Search Operators
 
@@ -63,6 +74,8 @@ and parameters:
 - **Brave Search**: Full native operator support in query string
 - **Kagi Search**: Complete operator support in query string
 - **Tavily Search**: Domain filtering through API parameters
+- **Exa Search**: Domain filtering through API parameters (includeDomains/excludeDomains)
+- **Bright Data**: Full query string operator support (site:, -site:, filetype:, etc.)
 
 ### 🤖 AI Response Tools
 
@@ -139,6 +152,9 @@ Add this to your Cline MCP settings:
 				"KAGI_API_KEY": "your-kagi-key",
 				"JINA_AI_API_KEY": "your-jina-key",
 				"BRAVE_API_KEY": "your-brave-key",
+				"EXA_API_KEY": "your-exa-key",
+				"BRIGHTDATA_API_KEY": "your-brightdata-key",
+				"BRIGHTDATA_ZONE_NAME": "your-zone-name",
 				"FIRECRAWL_API_KEY": "your-firecrawl-key",
 				"FIRECRAWL_BASE_URL": "http://localhost:3002"
 			},
@@ -161,7 +177,7 @@ For WSL environments, add this to your Claude Desktop configuration:
 			"args": [
 				"bash",
 				"-c",
-				"TAVILY_API_KEY=key1 PERPLEXITY_API_KEY=key2 KAGI_API_KEY=key3 JINA_AI_API_KEY=key4 BRAVE_API_KEY=key5 FIRECRAWL_API_KEY=key6 FIRECRAWL_BASE_URL=http://localhost:3002 node /path/to/mcp-omnisearch/dist/index.js"
+				"TAVILY_API_KEY=key1 PERPLEXITY_API_KEY=key2 KAGI_API_KEY=key3 JINA_AI_API_KEY=key4 BRAVE_API_KEY=key5 EXA_API_KEY=key6 BRIGHTDATA_API_KEY=key7 BRIGHTDATA_ZONE_NAME=zone1 FIRECRAWL_API_KEY=key8 FIRECRAWL_BASE_URL=http://localhost:3002 node /path/to/mcp-omnisearch/dist/index.js"
 			]
 		}
 	}
@@ -179,6 +195,9 @@ API keys will be activated:
 - `KAGI_API_KEY`: For Kagi services (FastGPT, Summarizer, Enrichment)
 - `JINA_AI_API_KEY`: For Jina AI services (Reader, Grounding)
 - `BRAVE_API_KEY`: For Brave Search
+- `EXA_API_KEY`: For Exa Search
+- `BRIGHTDATA_API_KEY`: For Bright Data SERP API
+- `BRIGHTDATA_ZONE_NAME`: For Bright Data zone configuration (optional, defaults to 'serp_api')
 - `FIRECRAWL_API_KEY`: For Firecrawl services (Scrape, Crawl, Map,
   Extract, Actions)
 - `FIRECRAWL_BASE_URL`: For self-hosted Firecrawl instances (optional,
@@ -275,6 +294,47 @@ Example:
 {
 	"query": "latest research in machine learning",
 	"language": "en"
+}
+```
+
+#### search_exa
+
+AI-powered semantic web search using neural embeddings for contextual relevance.
+
+Parameters:
+
+- `query` (string, required): Search query
+- `include_domains` (array, optional): Domains to include in search
+- `exclude_domains` (array, optional): Domains to exclude from search
+- `limit` (number, optional): Number of results (default: 10)
+
+Example:
+
+```json
+{
+	"query": "machine learning research papers",
+	"include_domains": ["arxiv.org", "scholar.google.com"],
+	"limit": 5
+}
+```
+
+#### search_brightdata
+
+SERP API for comprehensive search engine data collection with anti-blocking.
+
+Parameters:
+
+- `query` (string, required): Search query
+- `include_domains` (array, optional): Domains to include in search  
+- `exclude_domains` (array, optional): Domains to exclude from search
+- `limit` (number, optional): Number of results (default: 10)
+
+Example:
+
+```json
+{
+	"query": "site:github.com machine learning",
+	"limit": 20
 }
 ```
 
@@ -586,6 +646,9 @@ Configure the container using environment variables for each provider:
 - `KAGI_API_KEY`: For Kagi services (FastGPT, Summarizer, Enrichment)
 - `JINA_AI_API_KEY`: For Jina AI services (Reader, Grounding)
 - `BRAVE_API_KEY`: For Brave Search
+- `EXA_API_KEY`: For Exa Search
+- `BRIGHTDATA_API_KEY`: For Bright Data SERP API
+- `BRIGHTDATA_ZONE_NAME`: For Bright Data zone configuration (optional)
 - `FIRECRAWL_API_KEY`: For Firecrawl services
 - `FIRECRAWL_BASE_URL`: For self-hosted Firecrawl instances (optional)
 - `PORT`: Container port (defaults to 8000)
@@ -670,6 +733,8 @@ requirements:
 - **Kagi**: Some features limited to Business (Team) plan users
 - **Jina AI**: API key required for all services
 - **Brave**: API key from their developer portal
+- **Exa**: API key required from their developer portal
+- **Bright Data**: API key and zone configuration required from their platform
 - **Firecrawl**: API key required from their developer portal
 
 ### Rate Limits

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "brave-search",
     "kagi",
     "exa",
+    "brightdata",
     "perplexity",
     "jina-ai",
     "firecrawl",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "tavily",
     "brave-search",
     "kagi",
+    "exa",
     "perplexity",
     "jina-ai",
     "firecrawl",

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -5,6 +5,8 @@ export const TAVILY_API_KEY = process.env.TAVILY_API_KEY;
 export const BRAVE_API_KEY = process.env.BRAVE_API_KEY;
 export const KAGI_API_KEY = process.env.KAGI_API_KEY;
 export const EXA_API_KEY = process.env.EXA_API_KEY;
+export const BRIGHTDATA_API_KEY = process.env.BRIGHTDATA_API_KEY;
+export const BRIGHTDATA_ZONE_NAME = process.env.BRIGHTDATA_ZONE_NAME;
 
 // AI provider API keys
 export const PERPLEXITY_API_KEY = process.env.PERPLEXITY_API_KEY;
@@ -36,6 +38,12 @@ export const config = {
 			api_key: EXA_API_KEY,
 			base_url: 'https://api.exa.ai',
 			timeout: 30000, // 30 seconds
+		},
+		brightdata: {
+			api_key: BRIGHTDATA_API_KEY,
+			zone_name: BRIGHTDATA_ZONE_NAME || 'serp_api',
+			base_url: 'https://api.brightdata.com',
+			timeout: 60000, // 60 seconds - SERP requests can take longer
 		},
 	},
 	ai_response: {
@@ -133,6 +141,9 @@ export const validate_config = () => {
 
 	if (!EXA_API_KEY) missing_keys.push('EXA_API_KEY');
 	else available_keys.push('EXA_API_KEY');
+
+	if (!BRIGHTDATA_API_KEY) missing_keys.push('BRIGHTDATA_API_KEY');
+	else available_keys.push('BRIGHTDATA_API_KEY');
 
 	if (!PERPLEXITY_API_KEY) missing_keys.push('PERPLEXITY_API_KEY');
 	else available_keys.push('PERPLEXITY_API_KEY');

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -4,6 +4,7 @@
 export const TAVILY_API_KEY = process.env.TAVILY_API_KEY;
 export const BRAVE_API_KEY = process.env.BRAVE_API_KEY;
 export const KAGI_API_KEY = process.env.KAGI_API_KEY;
+export const EXA_API_KEY = process.env.EXA_API_KEY;
 
 // AI provider API keys
 export const PERPLEXITY_API_KEY = process.env.PERPLEXITY_API_KEY;
@@ -30,6 +31,11 @@ export const config = {
 			api_key: KAGI_API_KEY,
 			base_url: 'https://kagi.com/api/v0',
 			timeout: 20000, // 20 seconds
+		},
+		exa: {
+			api_key: EXA_API_KEY,
+			base_url: 'https://api.exa.ai',
+			timeout: 30000, // 30 seconds
 		},
 	},
 	ai_response: {
@@ -124,6 +130,9 @@ export const validate_config = () => {
 
 	if (!KAGI_API_KEY) missing_keys.push('KAGI_API_KEY');
 	else available_keys.push('KAGI_API_KEY');
+
+	if (!EXA_API_KEY) missing_keys.push('EXA_API_KEY');
+	else available_keys.push('EXA_API_KEY');
 
 	if (!PERPLEXITY_API_KEY) missing_keys.push('PERPLEXITY_API_KEY');
 	else available_keys.push('PERPLEXITY_API_KEY');

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -11,6 +11,7 @@ import { JinaReaderProvider } from './processing/jina_reader/index.js';
 import { KagiSummarizerProvider } from './processing/kagi_summarizer/index.js';
 import { TavilyExtractProvider } from './processing/tavily_extract/index.js';
 import { BraveSearchProvider } from './search/brave/index.js';
+import { BrightDataSearchProvider } from './search/brightdata/index.js';
 import { ExaSearchProvider } from './search/exa/index.js';
 import { KagiSearchProvider } from './search/kagi/index.js';
 import { TavilySearchProvider } from './search/tavily/index.js';
@@ -40,6 +41,10 @@ export const initialize_providers = () => {
 
 	if (is_api_key_valid(config.search.exa.api_key, 'exa')) {
 		register_search_provider(new ExaSearchProvider());
+	}
+
+	if (is_api_key_valid(config.search.brightdata.api_key, 'brightdata')) {
+		register_search_provider(new BrightDataSearchProvider());
 	}
 
 	// Initialize AI response providers (using SearchProvider interface for result compatibility)

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -11,6 +11,7 @@ import { JinaReaderProvider } from './processing/jina_reader/index.js';
 import { KagiSummarizerProvider } from './processing/kagi_summarizer/index.js';
 import { TavilyExtractProvider } from './processing/tavily_extract/index.js';
 import { BraveSearchProvider } from './search/brave/index.js';
+import { ExaSearchProvider } from './search/exa/index.js';
 import { KagiSearchProvider } from './search/kagi/index.js';
 import { TavilySearchProvider } from './search/tavily/index.js';
 
@@ -35,6 +36,10 @@ export const initialize_providers = () => {
 
 	if (is_api_key_valid(config.search.kagi.api_key, 'kagi')) {
 		register_search_provider(new KagiSearchProvider());
+	}
+
+	if (is_api_key_valid(config.search.exa.api_key, 'exa')) {
+		register_search_provider(new ExaSearchProvider());
 	}
 
 	// Initialize AI response providers (using SearchProvider interface for result compatibility)

--- a/src/providers/search/brightdata/index.ts
+++ b/src/providers/search/brightdata/index.ts
@@ -1,0 +1,196 @@
+import {
+	BaseSearchParams,
+	ErrorType,
+	ProviderError,
+	SearchProvider,
+	SearchResult,
+} from '../../../common/types.js';
+import {
+	apply_search_operators,
+	handle_rate_limit,
+	parse_search_operators,
+	retry_with_backoff,
+	sanitize_query,
+	validate_api_key,
+} from '../../../common/utils.js';
+import { config } from '../../../config/env.js';
+
+interface BrightDataRequestBody {
+	zone: string;
+	url: string;
+	format: string;
+}
+
+interface BrightDataOrganic {
+	title: string;
+	url: string;
+	snippet: string;
+	position?: number;
+}
+
+interface BrightDataResponse {
+	organic?: BrightDataOrganic[];
+	search_metadata?: {
+		total_results?: number;
+		query?: string;
+		country?: string;
+		language?: string;
+	};
+}
+
+export class BrightDataSearchProvider implements SearchProvider {
+	name = 'brightdata';
+	description =
+		'SERP API for comprehensive search engine data collection with proxy management and unblocking. Supports Google, Bing, DuckDuckGo, Yandex, Baidu, Yahoo, and Naver. Best for large-scale data collection, market research, brand monitoring, and applications requiring robust anti-blocking capabilities.';
+
+	async search(params: BaseSearchParams): Promise<SearchResult[]> {
+		const api_key = validate_api_key(
+			config.search.brightdata.api_key,
+			this.name,
+		);
+
+		const search_request = async () => {
+			try {
+				// Parse search operators from the query
+				const parsed_query = parse_search_operators(params.query);
+				const search_params = apply_search_operators(parsed_query);
+				const query = sanitize_query(search_params.query);
+
+				// Handle domain filters using search operators
+				const include_domains = [
+					...(params.include_domains ?? []),
+					...(search_params.include_domains ?? []),
+				];
+				const exclude_domains = [
+					...(params.exclude_domains ?? []),
+					...(search_params.exclude_domains ?? []),
+				];
+
+				// Add domain filters to the search query
+				let final_query = query;
+				if (include_domains.length > 0) {
+					const domain_filters = include_domains.map(domain => `site:${domain}`).join(' OR ');
+					final_query += ` (${domain_filters})`;
+				}
+				if (exclude_domains.length > 0) {
+					const exclude_filters = exclude_domains.map(domain => `-site:${domain}`).join(' ');
+					final_query += ` ${exclude_filters}`;
+				}
+
+				// Build Google search URL with Bright Data JSON parsing
+				const search_params_obj = new URLSearchParams({
+					q: final_query,
+					brd_json: '1', // Request parsed JSON response
+				});
+
+				// Add results limit if specified
+				if (params.limit && params.limit !== 10) {
+					search_params_obj.set('num', params.limit.toString());
+				}
+
+				const search_url = `https://www.google.com/search?${search_params_obj.toString()}`;
+
+				// Build the request body
+				const request_body: BrightDataRequestBody = {
+					zone: config.search.brightdata.zone_name,
+					url: search_url,
+					format: 'json', // Get parsed JSON response
+				};
+
+				const response = await fetch(`${config.search.brightdata.base_url}/request`, {
+					method: 'POST',
+					headers: {
+						'Content-Type': 'application/json',
+						'Authorization': `Bearer ${api_key}`,
+					},
+					body: JSON.stringify(request_body),
+					signal: AbortSignal.timeout(config.search.brightdata.timeout),
+				});
+
+				if (!response.ok) {
+					const error_text = await response.text();
+					let error_message = error_text || response.statusText;
+					
+					try {
+						const error_data = JSON.parse(error_text);
+						error_message = error_data.message || error_data.error || error_message;
+					} catch {
+						// Keep the original error text if JSON parsing fails
+					}
+
+					switch (response.status) {
+						case 401:
+							throw new ProviderError(
+								ErrorType.API_ERROR,
+								'Invalid API key',
+								this.name,
+							);
+						case 429:
+							handle_rate_limit(this.name);
+						case 400:
+							throw new ProviderError(
+								ErrorType.INVALID_INPUT,
+								`Bad request: ${error_message}`,
+								this.name,
+							);
+						case 500:
+							throw new ProviderError(
+								ErrorType.PROVIDER_ERROR,
+								'Bright Data API internal error',
+								this.name,
+							);
+						default:
+							throw new ProviderError(
+								ErrorType.API_ERROR,
+								`Unexpected error: ${error_message}`,
+								this.name,
+							);
+					}
+				}
+
+				let data: BrightDataResponse;
+				try {
+					const response_text = await response.text();
+					data = JSON.parse(response_text);
+				} catch (error) {
+					throw new ProviderError(
+						ErrorType.API_ERROR,
+						`Invalid JSON response: ${
+							error instanceof Error ? error.message : 'Unknown error'
+						}`,
+						this.name,
+					);
+				}
+
+				if (!data.organic || !Array.isArray(data.organic)) {
+					throw new ProviderError(
+						ErrorType.API_ERROR,
+						'No organic results found in response',
+						this.name,
+					);
+				}
+
+				return data.organic.map((result) => ({
+					title: result.title,
+					url: result.url,
+					snippet: result.snippet,
+					score: result.position ? 1 / result.position : undefined,
+					source_provider: this.name,
+				}));
+			} catch (error) {
+				if (error instanceof ProviderError) {
+					throw error;
+				}
+				throw new ProviderError(
+					ErrorType.API_ERROR,
+					`Failed to fetch: ${
+						error instanceof Error ? error.message : 'Unknown error'
+					}`,
+					this.name,
+				);
+			}
+		};
+
+		return retry_with_backoff(search_request);
+	}
+}

--- a/src/providers/search/brightdata/index.ts
+++ b/src/providers/search/brightdata/index.ts
@@ -127,6 +127,7 @@ export class BrightDataSearchProvider implements SearchProvider {
 							);
 						case 429:
 							handle_rate_limit(this.name);
+							return;
 						case 400:
 							throw new ProviderError(
 								ErrorType.INVALID_INPUT,

--- a/src/providers/search/exa/index.ts
+++ b/src/providers/search/exa/index.ts
@@ -1,0 +1,172 @@
+import {
+	BaseSearchParams,
+	ErrorType,
+	ProviderError,
+	SearchProvider,
+	SearchResult,
+} from '../../../common/types.js';
+import {
+	apply_search_operators,
+	handle_rate_limit,
+	parse_search_operators,
+	retry_with_backoff,
+	sanitize_query,
+	validate_api_key,
+} from '../../../common/utils.js';
+import { config } from '../../../config/env.js';
+
+interface ExaRequestBody {
+	query: string;
+	numResults: number;
+	text: boolean;
+	includeDomains?: string[];
+	excludeDomains?: string[];
+}
+
+interface ExaSearchResponse {
+	requestId: string;
+	resolvedSearchType: string;
+	results: Array<{
+		title: string;
+		url: string;
+		publishedDate?: string;
+		author?: string;
+		text?: string;
+		summary?: string;
+		highlights?: string[];
+		score?: number;
+	}>;
+	costDollars: number;
+}
+
+export class ExaSearchProvider implements SearchProvider {
+	name = 'exa';
+	description =
+		'AI-powered semantic web search using neural embeddings. Unlike keyword-based search, Exa understands meaning and context to find the most relevant content. Best for research, factual queries, and discovering content that matches semantic intent rather than exact keywords.';
+
+	async search(params: BaseSearchParams): Promise<SearchResult[]> {
+		const api_key = validate_api_key(
+			config.search.exa.api_key,
+			this.name,
+		);
+
+		const search_request = async () => {
+			try {
+				// Parse search operators from the query
+				const parsed_query = parse_search_operators(params.query);
+				const search_params = apply_search_operators(parsed_query);
+				const query = sanitize_query(search_params.query);
+
+				// Combine domain filters from params and search operators
+				const include_domains = [
+					...(params.include_domains ?? []),
+					...(search_params.include_domains ?? []),
+				];
+				const exclude_domains = [
+					...(params.exclude_domains ?? []),
+					...(search_params.exclude_domains ?? []),
+				];
+
+				// Build the request body
+				const request_body: ExaRequestBody = {
+					query: query,
+					numResults: params.limit ?? 10,
+					text: true, // Get text content for better results
+				};
+
+				// Add domain filters if specified
+				if (include_domains.length > 0) {
+					request_body.includeDomains = include_domains;
+				}
+				if (exclude_domains.length > 0) {
+					request_body.excludeDomains = exclude_domains;
+				}
+
+				const response = await fetch(`${config.search.exa.base_url}/search`, {
+					method: 'POST',
+					headers: {
+						'Content-Type': 'application/json',
+						'x-api-key': api_key,
+					},
+					body: JSON.stringify(request_body),
+					signal: AbortSignal.timeout(config.search.exa.timeout),
+				});
+
+				let data: ExaSearchResponse & { error?: string; message?: string };
+				try {
+					const text = await response.text();
+					data = JSON.parse(text);
+				} catch (error) {
+					throw new ProviderError(
+						ErrorType.API_ERROR,
+						`Invalid JSON response: ${
+							error instanceof Error ? error.message : 'Unknown error'
+						}`,
+						this.name,
+					);
+				}
+
+				if (!response.ok) {
+					const error_message = data.error || data.message || response.statusText;
+					switch (response.status) {
+						case 401:
+							throw new ProviderError(
+								ErrorType.API_ERROR,
+								'Invalid API key',
+								this.name,
+							);
+						case 429:
+							handle_rate_limit(this.name);
+						case 400:
+							throw new ProviderError(
+								ErrorType.INVALID_INPUT,
+								`Bad request: ${error_message}`,
+								this.name,
+							);
+						case 500:
+							throw new ProviderError(
+								ErrorType.PROVIDER_ERROR,
+								'Exa Search API internal error',
+								this.name,
+							);
+						default:
+							throw new ProviderError(
+								ErrorType.API_ERROR,
+								`Unexpected error: ${error_message}`,
+								this.name,
+							);
+					}
+				}
+
+				if (!data.results) {
+					throw new ProviderError(
+						ErrorType.API_ERROR,
+						'No results field in response',
+						this.name,
+					);
+				}
+
+				return data.results.map((result) => ({
+					title: result.title,
+					url: result.url,
+					snippet: result.text || result.summary || result.title,
+					score: result.score,
+					source_provider: this.name,
+				}));
+			} catch (error) {
+				if (error instanceof ProviderError) {
+					throw error;
+				}
+				throw new ProviderError(
+					ErrorType.API_ERROR,
+					`Failed to fetch: ${
+						error instanceof Error ? error.message : 'Unknown error'
+					}`,
+					this.name,
+				);
+			}
+		};
+
+		return retry_with_backoff(search_request);
+	}
+}


### PR DESCRIPTION
## Summary
- Add Bright Data SERP API provider for comprehensive search engine data collection
- Support for multiple search engines (Google, Bing, DuckDuckGo, Yandex, Baidu, Yahoo, Naver)
- Anti-blocking capabilities with proxy management for large-scale data collection
- Configurable zone names and robust error handling with rate limiting
- Updated documentation with Bright Data setup instructions

## Changes
- Added Bright Data SERP API provider in `src/providers/search/brightdata/index.ts`
- Updated environment configuration for Bright Data API key and zone name
- Enhanced README with Bright Data SERP API documentation
- Added brightdata to package.json keywords
- Integrated Bright Data provider in main provider index