### PR TITLE
feat: add Linkup.so as search, AI response, and processing provider

### DIFF
--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -15,6 +15,9 @@ export const JINA_AI_API_KEY = process.env.JINA_AI_API_KEY;
 export const FIRECRAWL_API_KEY = process.env.FIRECRAWL_API_KEY;
 export const FIRECRAWL_BASE_URL = process.env.FIRECRAWL_BASE_URL;
 
+// Linkup API key
+export const LINKUP_API_KEY = process.env.LINKUP_API_KEY;
+
 // Provider configuration
 export const config = {
 	search: {
@@ -43,6 +46,11 @@ export const config = {
 			base_url: 'https://api.exa.ai',
 			timeout: 30000, // 30 seconds
 		},
+		linkup: {
+			api_key: LINKUP_API_KEY,
+			base_url: 'https://api.linkup.so/v1',
+			timeout: 30000, // 30 seconds
+		},
 	},
 	ai_response: {
 		perplexity: {
@@ -59,6 +67,11 @@ export const config = {
 			api_key: EXA_API_KEY,
 			base_url: 'https://api.exa.ai',
 			timeout: 30000, // 30 seconds
+		},
+		linkup_answer: {
+			api_key: LINKUP_API_KEY,
+			base_url: 'https://api.linkup.so/v1',
+			timeout: 60000, // 60 seconds - deep search can take longer
 		},
 	},
 	processing: {
@@ -122,6 +135,11 @@ export const config = {
 			base_url: 'https://api.exa.ai',
 			timeout: 30000, // 30 seconds
 		},
+		linkup_fetch: {
+			api_key: LINKUP_API_KEY,
+			base_url: 'https://api.linkup.so/v1',
+			timeout: 30000, // 30 seconds
+		},
 	},
 	enhancement: {
 		kagi_enrichment: {
@@ -166,6 +184,9 @@ export const validate_config = () => {
 
 	if (!EXA_API_KEY) missing_keys.push('EXA_API_KEY');
 	else available_keys.push('EXA_API_KEY');
+
+	if (!LINKUP_API_KEY) missing_keys.push('LINKUP_API_KEY');
+	else available_keys.push('LINKUP_API_KEY');
 
 	// Log available keys
 	if (available_keys.length > 0) {

--- a/src/providers/ai_response/linkup_answer/index.ts
+++ b/src/providers/ai_response/linkup_answer/index.ts
@@ -29,7 +29,9 @@ export class LinkupAnswerProvider implements SearchProvider {
 	description =
 		'AI-powered sourced answers from Linkup deep search. Uses multi-step agentic retrieval for comprehensive, cited responses. Best for complex queries requiring synthesis across multiple sources.';
 
-	async search(params: BaseSearchParams): Promise<SearchResult[]> {
+	async search(
+		params: BaseSearchParams & { depth?: 'standard' | 'deep' },
+	): Promise<SearchResult[]> {
 		const api_key = validate_api_key(
 			config.ai_response.linkup_answer.api_key,
 			this.name,
@@ -39,7 +41,7 @@ export class LinkupAnswerProvider implements SearchProvider {
 			try {
 				const request_body: Record<string, any> = {
 					q: sanitize_query(params.query),
-					depth: 'deep',
+					depth: params.depth ?? 'deep',
 					outputType: 'sourcedAnswer',
 				};
 

--- a/src/providers/ai_response/linkup_answer/index.ts
+++ b/src/providers/ai_response/linkup_answer/index.ts
@@ -30,7 +30,7 @@ export class LinkupAnswerProvider implements SearchProvider {
 		'AI-powered sourced answers from Linkup deep search. Uses multi-step agentic retrieval for comprehensive, cited responses. Best for complex queries requiring synthesis across multiple sources.';
 
 	async search(
-		params: BaseSearchParams & { depth?: 'standard' | 'deep' },
+		params: BaseSearchParams & { depth?: 'fast' | 'standard' | 'deep' },
 	): Promise<SearchResult[]> {
 		const api_key = validate_api_key(
 			config.ai_response.linkup_answer.api_key,

--- a/src/providers/ai_response/linkup_answer/index.ts
+++ b/src/providers/ai_response/linkup_answer/index.ts
@@ -1,0 +1,122 @@
+import { http_json } from '../../../common/http.js';
+import {
+	BaseSearchParams,
+	SearchProvider,
+	SearchResult,
+} from '../../../common/types.js';
+import {
+	handle_provider_error,
+	retry_with_backoff,
+	sanitize_query,
+	validate_api_key,
+} from '../../../common/utils.js';
+import { config } from '../../../config/env.js';
+
+interface LinkupSource {
+	name: string;
+	url: string;
+	snippet: string;
+	favicon: string;
+}
+
+interface LinkupSourcedAnswerResponse {
+	answer: string;
+	sources: LinkupSource[];
+}
+
+export class LinkupAnswerProvider implements SearchProvider {
+	name = 'linkup_answer';
+	description =
+		'AI-powered sourced answers from Linkup deep search. Uses multi-step agentic retrieval for comprehensive, cited responses. Best for complex queries requiring synthesis across multiple sources.';
+
+	async search(params: BaseSearchParams): Promise<SearchResult[]> {
+		const api_key = validate_api_key(
+			config.ai_response.linkup_answer.api_key,
+			this.name,
+		);
+
+		const search_request = async () => {
+			try {
+				const request_body: Record<string, any> = {
+					q: sanitize_query(params.query),
+					depth: 'deep',
+					outputType: 'sourcedAnswer',
+				};
+
+				if (
+					params.include_domains &&
+					params.include_domains.length > 0
+				) {
+					request_body.includeDomains =
+						params.include_domains.slice(0, 50);
+				}
+
+				if (
+					params.exclude_domains &&
+					params.exclude_domains.length > 0
+				) {
+					request_body.excludeDomains =
+						params.exclude_domains.slice(0, 50);
+				}
+
+				const data =
+					await http_json<LinkupSourcedAnswerResponse>(
+						this.name,
+						`${config.ai_response.linkup_answer.base_url}/search`,
+						{
+							method: 'POST',
+							headers: {
+								Authorization: `Bearer ${api_key}`,
+								'Content-Type': 'application/json',
+							},
+							body: JSON.stringify(request_body),
+							signal: AbortSignal.timeout(
+								config.ai_response.linkup_answer.timeout,
+							),
+						},
+					);
+
+				const results: SearchResult[] = [
+					{
+						title: 'Linkup Answer',
+						url: 'https://linkup.so',
+						snippet: data.answer,
+						score: 1.0,
+						source_provider: this.name,
+					},
+				];
+
+				if (data.sources?.length) {
+					results.push(
+						...data.sources.map((source, index) => ({
+							title: source.name,
+							url: source.url,
+							snippet: source.snippet,
+							score: 0.9 - index * 0.1,
+							source_provider: this.name,
+							metadata: {
+								favicon: source.favicon,
+							},
+						})),
+					);
+				}
+
+				const filtered = results.filter(
+					(r) => r.title && r.url && r.snippet,
+				);
+
+				return params.limit && params.limit > 0
+					? filtered.slice(0, params.limit)
+					: filtered;
+			} catch (error) {
+				handle_provider_error(
+					error,
+					this.name,
+					'fetch AI response',
+				);
+			}
+		};
+
+		return retry_with_backoff(search_request);
+	}
+}

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,6 +1,7 @@
 import { JinaGroundingProvider } from './enhancement/jina_grounding/index.js';
 import { KagiEnrichmentProvider } from './enhancement/kagi_enrichment/index.js';
 import { KagiSummarizerProvider } from './processing/kagi_summarizer/index.js';
+import { LinkupFetchProvider } from './processing/linkup_fetch/index.js';
 import { TavilyExtractProvider } from './processing/tavily_extract/index.js';
 import { UnifiedAISearchProvider } from './unified/ai_search.js';
 import { UnifiedExaProcessProvider } from './unified/exa_process.js';
@@ -27,7 +28,8 @@ export const initialize_providers = () => {
 		is_api_key_valid(config.search.tavily.api_key, 'tavily') ||
 		is_api_key_valid(config.search.brave.api_key, 'brave') ||
 		is_api_key_valid(config.search.kagi.api_key, 'kagi') ||
-		is_api_key_valid(config.search.exa.api_key, 'exa');
+		is_api_key_valid(config.search.exa.api_key, 'exa') ||
+		is_api_key_valid(config.search.linkup.api_key, 'linkup');
 
 	if (has_web_search) {
 		register_web_search_provider(new UnifiedWebSearchProvider());
@@ -53,6 +55,10 @@ export const initialize_providers = () => {
 		is_api_key_valid(
 			config.ai_response.exa_answer.api_key,
 			'exa_answer',
+		) ||
+		is_api_key_valid(
+			config.ai_response.linkup_answer.api_key,
+			'linkup_answer',
 		);
 
 	if (has_ai_search) {
@@ -120,6 +126,15 @@ export const initialize_providers = () => {
 		)
 	) {
 		register_processing_provider(new TavilyExtractProvider());
+	}
+
+	if (
+		is_api_key_valid(
+			config.processing.linkup_fetch.api_key,
+			'linkup_fetch',
+		)
+	) {
+		register_processing_provider(new LinkupFetchProvider());
 	}
 
 	// Initialize enhancement providers

--- a/src/providers/processing/linkup_fetch/index.ts
+++ b/src/providers/processing/linkup_fetch/index.ts
@@ -1,0 +1,106 @@
+import { http_json } from '../../../common/http.js';
+import {
+	ProcessingProvider,
+	ProcessingResult,
+} from '../../../common/types.js';
+import {
+	aggregate_url_results,
+	handle_provider_error,
+	retry_with_backoff,
+	validate_api_key,
+	validate_processing_urls,
+	type ProcessedUrlResult,
+} from '../../../common/utils.js';
+import { config } from '../../../config/env.js';
+
+interface LinkupFetchResponse {
+	markdown: string;
+	rawHtml?: string;
+	images?: string[];
+}
+
+export class LinkupFetchProvider implements ProcessingProvider {
+	name = 'linkup_fetch';
+	description =
+		'Fetch and convert any webpage to clean markdown using Linkup. Supports JavaScript rendering for dynamic pages. Best for content extraction and LLM-ready text conversion.';
+
+	async process_content(
+		url: string | string[],
+		extract_depth: 'basic' | 'advanced' = 'basic',
+	): Promise<ProcessingResult> {
+		const urls = validate_processing_urls(url, this.name);
+
+		const fetch_request = async () => {
+			const api_key = validate_api_key(
+				config.processing.linkup_fetch.api_key,
+				this.name,
+			);
+
+			try {
+				const results: ProcessedUrlResult[] = await Promise.all(
+					urls.map(async (single_url) => {
+						try {
+							const data =
+								await http_json<LinkupFetchResponse>(
+									this.name,
+									`${config.processing.linkup_fetch.base_url}/fetch`,
+									{
+										method: 'POST',
+										headers: {
+											Authorization: `Bearer ${api_key}`,
+											'Content-Type':
+												'application/json',
+										},
+										body: JSON.stringify({
+											url: single_url,
+											renderJs:
+												extract_depth === 'advanced',
+										}),
+										signal: AbortSignal.timeout(
+											config.processing.linkup_fetch
+												.timeout,
+										),
+									},
+								);
+
+							return {
+								url: single_url,
+								content: data.markdown || '',
+								success: true,
+							};
+						} catch (error) {
+							console.error(
+								`Error fetching ${single_url}:`,
+								error,
+							);
+							return {
+								url: single_url,
+								content: '',
+								success: false,
+								error:
+									error instanceof Error
+										? error.message
+										: 'Unknown error',
+							};
+						}
+					}),
+				);
+
+				return aggregate_url_results(
+					results,
+					this.name,
+					urls,
+					extract_depth,
+				);
+			} catch (error) {
+				handle_provider_error(
+					error,
+					this.name,
+					'fetch webpage content',
+				);
+			}
+		};
+
+		return retry_with_backoff(fetch_request);
+	}
+}

--- a/src/providers/search/linkup/index.ts
+++ b/src/providers/search/linkup/index.ts
@@ -29,7 +29,9 @@ export class LinkupSearchProvider implements SearchProvider {
 	description =
 		'Agentic web search via Linkup. #1 factuality on SimpleQA benchmark. Returns structured search results with source content. Supports domain and date filtering.';
 
-	async search(params: BaseSearchParams): Promise<SearchResult[]> {
+	async search(
+		params: BaseSearchParams & { depth?: 'standard' | 'deep' },
+	): Promise<SearchResult[]> {
 		const api_key = validate_api_key(
 			config.search.linkup.api_key,
 			this.name,
@@ -39,7 +41,7 @@ export class LinkupSearchProvider implements SearchProvider {
 			try {
 				const request_body: Record<string, any> = {
 					q: sanitize_query(params.query),
-					depth: 'standard',
+					depth: params.depth ?? 'standard',
 					outputType: 'searchResults',
 				};
 

--- a/src/providers/search/linkup/index.ts
+++ b/src/providers/search/linkup/index.ts
@@ -1,0 +1,114 @@
+import { http_json } from '../../../common/http.js';
+import {
+	BaseSearchParams,
+	SearchProvider,
+	SearchResult,
+} from '../../../common/types.js';
+import {
+	handle_provider_error,
+	retry_with_backoff,
+	sanitize_query,
+	validate_api_key,
+} from '../../../common/utils.js';
+import { config } from '../../../config/env.js';
+
+interface LinkupSearchResult {
+	type: 'text' | 'image';
+	name: string;
+	url: string;
+	content: string;
+	favicon: string;
+}
+
+interface LinkupSearchResponse {
+	results: LinkupSearchResult[];
+}
+
+export class LinkupSearchProvider implements SearchProvider {
+	name = 'linkup';
+	description =
+		'Agentic web search via Linkup. #1 factuality on SimpleQA benchmark. Returns structured search results with source content. Supports domain and date filtering.';
+
+	async search(params: BaseSearchParams): Promise<SearchResult[]> {
+		const api_key = validate_api_key(
+			config.search.linkup.api_key,
+			this.name,
+		);
+
+		const search_request = async () => {
+			try {
+				const request_body: Record<string, any> = {
+					q: sanitize_query(params.query),
+					depth: 'standard',
+					outputType: 'searchResults',
+				};
+
+				if (params.limit) {
+					request_body.maxResults = params.limit;
+				}
+
+				if (
+					params.include_domains &&
+					params.include_domains.length > 0
+				) {
+					request_body.includeDomains =
+						params.include_domains.slice(0, 50);
+					if (params.include_domains.length > 50) {
+						console.warn(
+							'Linkup: includeDomains truncated to 50 entries',
+						);
+					}
+				}
+
+				if (
+					params.exclude_domains &&
+					params.exclude_domains.length > 0
+				) {
+					request_body.excludeDomains =
+						params.exclude_domains.slice(0, 50);
+					if (params.exclude_domains.length > 50) {
+						console.warn(
+							'Linkup: excludeDomains truncated to 50 entries',
+						);
+					}
+				}
+
+				const data = await http_json<LinkupSearchResponse>(
+					this.name,
+					`${config.search.linkup.base_url}/search`,
+					{
+						method: 'POST',
+						headers: {
+							Authorization: `Bearer ${api_key}`,
+							'Content-Type': 'application/json',
+						},
+						body: JSON.stringify(request_body),
+						signal: AbortSignal.timeout(
+							config.search.linkup.timeout,
+						),
+					},
+				);
+
+				return (data.results || [])
+					.filter((result) => result.type === 'text')
+					.map((result) => ({
+						title: result.name,
+						url: result.url,
+						snippet: result.content,
+						source_provider: this.name,
+						metadata: {
+							favicon: result.favicon,
+						},
+					}));
+			} catch (error) {
+				handle_provider_error(
+					error,
+					this.name,
+					'fetch search results',
+				);
+			}
+		};
+
+		return retry_with_backoff(search_request);
+	}
+}

--- a/src/providers/search/linkup/index.ts
+++ b/src/providers/search/linkup/index.ts
@@ -30,7 +30,7 @@ export class LinkupSearchProvider implements SearchProvider {
 		'Agentic web search via Linkup. #1 factuality on SimpleQA benchmark. Returns structured search results with source content. Supports domain and date filtering.';
 
 	async search(
-		params: BaseSearchParams & { depth?: 'standard' | 'deep' },
+		params: BaseSearchParams & { depth?: 'fast' | 'standard' | 'deep' },
 	): Promise<SearchResult[]> {
 		const api_key = validate_api_key(
 			config.search.linkup.api_key,

--- a/src/providers/unified/ai_search.ts
+++ b/src/providers/unified/ai_search.ts
@@ -7,12 +7,14 @@ import {
 } from '../../common/types.js';
 import { ExaAnswerProvider } from '../ai_response/exa_answer/index.js';
 import { KagiFastGPTProvider } from '../ai_response/kagi_fastgpt/index.js';
+import { LinkupAnswerProvider } from '../ai_response/linkup_answer/index.js';
 import { PerplexityProvider } from '../ai_response/perplexity/index.js';
 
 export type AISearchProvider =
 	| 'perplexity'
 	| 'kagi_fastgpt'
-	| 'exa_answer';
+	| 'exa_answer'
+	| 'linkup_answer';
 
 export interface UnifiedAISearchParams extends BaseSearchParams {
 	provider: AISearchProvider;
@@ -21,7 +23,7 @@ export interface UnifiedAISearchParams extends BaseSearchParams {
 export class UnifiedAISearchProvider implements SearchProvider {
 	name = 'ai_search';
 	description =
-		'AI-powered search with reasoning. Supports perplexity (real-time + reasoning), kagi_fastgpt (quick answers), exa_answer (semantic AI).';
+		'AI-powered search with reasoning. Supports perplexity (real-time + reasoning), kagi_fastgpt (quick answers), exa_answer (semantic AI), linkup_answer (deep sourced answers).';
 
 	private providers: Map<AISearchProvider, SearchProvider> =
 		new Map();
@@ -30,6 +32,7 @@ export class UnifiedAISearchProvider implements SearchProvider {
 		this.providers.set('perplexity', new PerplexityProvider());
 		this.providers.set('kagi_fastgpt', new KagiFastGPTProvider());
 		this.providers.set('exa_answer', new ExaAnswerProvider());
+		this.providers.set('linkup_answer', new LinkupAnswerProvider());
 	}
 
 	async search(

--- a/src/providers/unified/web_search.ts
+++ b/src/providers/unified/web_search.ts
@@ -8,9 +8,10 @@ import {
 import { BraveSearchProvider } from '../search/brave/index.js';
 import { ExaSearchProvider } from '../search/exa/index.js';
 import { KagiSearchProvider } from '../search/kagi/index.js';
+import { LinkupSearchProvider } from '../search/linkup/index.js';
 import { TavilySearchProvider } from '../search/tavily/index.js';
 
-export type WebSearchProvider = 'tavily' | 'brave' | 'kagi' | 'exa';
+export type WebSearchProvider = 'tavily' | 'brave' | 'kagi' | 'exa' | 'linkup';
 
 export interface UnifiedWebSearchParams extends BaseSearchParams {
 	provider: WebSearchProvider;
@@ -19,7 +20,7 @@ export interface UnifiedWebSearchParams extends BaseSearchParams {
 export class UnifiedWebSearchProvider implements SearchProvider {
 	name = 'web_search';
 	description =
-		'Search the web. Providers: tavily (factual/citations), brave (privacy/operators), kagi (quality/operators), exa (AI-semantic). Brave/Kagi support query operators like site:, filetype:, lang:, etc.';
+		'Search the web. Providers: tavily (factual/citations), brave (privacy/operators), kagi (quality/operators), exa (AI-semantic), linkup (agentic/factuality). Brave/Kagi support query operators like site:, filetype:, lang:, etc.';
 
 	private providers: Map<WebSearchProvider, SearchProvider> =
 		new Map();
@@ -29,6 +30,7 @@ export class UnifiedWebSearchProvider implements SearchProvider {
 		this.providers.set('brave', new BraveSearchProvider());
 		this.providers.set('kagi', new KagiSearchProvider());
 		this.providers.set('exa', new ExaSearchProvider());
+		this.providers.set('linkup', new LinkupSearchProvider());
 	}
 
 	async search(

--- a/src/server/tools.ts
+++ b/src/server/tools.ts
@@ -101,9 +101,9 @@ class ToolRegistry {
 						),
 						depth: v.optional(
 							v.pipe(
-								v.picklist(['standard', 'deep']),
+								v.picklist(['fast', 'standard', 'deep']),
 								v.description(
-									'Search depth (linkup only): standard (fast) or deep (thorough, 10x cost)',
+									'Search depth (linkup only): fast (sub-second), standard (default), deep (thorough, 10x cost)',
 								),
 							),
 						),
@@ -243,9 +243,9 @@ class ToolRegistry {
 						),
 						depth: v.optional(
 							v.pipe(
-								v.picklist(['standard', 'deep']),
+								v.picklist(['fast', 'standard', 'deep']),
 								v.description(
-									'Search depth (linkup_answer only): standard (fast) or deep (thorough, default)',
+									'Search depth (linkup_answer only): fast (sub-second), standard (moderate), deep (thorough, default)',
 								),
 							),
 						),

--- a/src/server/tools.ts
+++ b/src/server/tools.ts
@@ -99,6 +99,14 @@ class ToolRegistry {
 								v.description('Domains to exclude'),
 							),
 						),
+						depth: v.optional(
+							v.pipe(
+								v.picklist(['standard', 'deep']),
+								v.description(
+									'Search depth (linkup only): standard (fast) or deep (thorough, 10x cost)',
+								),
+							),
+						),
 					}),
 				},
 				async ({
@@ -107,6 +115,7 @@ class ToolRegistry {
 					limit,
 					include_domains,
 					exclude_domains,
+					depth,
 				}) => {
 					try {
 						const results = await this.web_search_provider!.search({
@@ -115,6 +124,7 @@ class ToolRegistry {
 							limit,
 							include_domains,
 							exclude_domains,
+							depth,
 						} as any);
 						const safe_results = handle_large_result(
 							results,
@@ -231,14 +241,23 @@ class ToolRegistry {
 						limit: v.optional(
 							v.pipe(v.number(), v.description('Result limit')),
 						),
+						depth: v.optional(
+							v.pipe(
+								v.picklist(['standard', 'deep']),
+								v.description(
+									'Search depth (linkup_answer only): standard (fast) or deep (thorough, default)',
+								),
+							),
+						),
 					}),
 				},
-				async ({ query, provider, limit }) => {
+				async ({ query, provider, limit, depth }) => {
 					try {
 						const results = await this.ai_search_provider!.search({
 							query,
 							provider,
 							limit,
+							depth,
 						} as any);
 						const safe_results = handle_large_result(
 							results,

--- a/src/server/tools.ts
+++ b/src/server/tools.ts
@@ -81,7 +81,7 @@ class ToolRegistry {
 					schema: v.object({
 						query: v.pipe(v.string(), v.description('Query')),
 						provider: v.pipe(
-							v.picklist(['tavily', 'brave', 'kagi', 'exa']),
+							v.picklist(['tavily', 'brave', 'kagi', 'exa', 'linkup']),
 							v.description('Search provider'),
 						),
 						limit: v.optional(
@@ -224,6 +224,7 @@ class ToolRegistry {
 								'perplexity',
 								'kagi_fastgpt',
 								'exa_answer',
+								'linkup_answer',
 							]),
 							v.description('AI provider'),
 						),


### PR DESCRIPTION
## Summary

Adds [Linkup.so](https://linkup.so) as a provider across three categories:

- **Web Search** (`web_search` tool, provider `linkup`): Agentic search via `/search` endpoint with `searchResults` output type. Supports domain filtering (`includeDomains`/`excludeDomains`) and result limits.
- **AI Search** (`ai_search` tool, provider `linkup_answer`): Deep sourced answers via `/search` endpoint with `sourcedAnswer` output type. Uses multi-step agentic retrieval for complex queries requiring synthesis across multiple sources.
- **Processing** (`linkup_fetch_process` tool): Webpage-to-markdown conversion via `/fetch` endpoint with optional JavaScript rendering for dynamic pages.

Linkup is [#1 on OpenAI's SimpleQA factuality benchmark](https://docs.linkup.so), making it a strong addition for factual grounding in LLM applications. All three providers share a single `LINKUP_API_KEY` environment variable and are conditionally registered based on key availability.

### Changes

| File | Change |
|------|--------|
| `src/config/env.ts` | Add `LINKUP_API_KEY` + 3 config entries |
| `src/providers/search/linkup/index.ts` | **New** — Web search provider |
| `src/providers/ai_response/linkup_answer/index.ts` | **New** — AI answer provider |
| `src/providers/processing/linkup_fetch/index.ts` | **New** — Fetch/processing provider |
| `src/providers/unified/web_search.ts` | Register `linkup` in unified provider |
| `src/providers/unified/ai_search.ts` | Register `linkup_answer` in unified provider |
| `src/server/tools.ts` | Add to `web_search` and `ai_search` picklists |
| `src/providers/index.ts` | Conditional registration for all 3 providers |

### Configuration

Set the `LINKUP_API_KEY` environment variable to enable Linkup providers. Without it, the server starts normally with Linkup providers simply not registered.

## Test plan

- [ ] `pnpm build` compiles without errors
- [ ] Server starts without `LINKUP_API_KEY` (providers not registered, no crash)
- [ ] `web_search` with `provider: "linkup"` returns search results
- [ ] `ai_search` with `provider: "linkup_answer"` returns sourced answers
- [ ] `linkup_fetch_process` with a URL returns markdown content
- [ ] Domain filtering (`include_domains`/`exclude_domains`) works correctly
- [ ] `provider-status` resource lists all 3 Linkup providers when key is set