### PR TITLE
fix: migrate Firecrawl endpoints from v1 to v2

### DIFF
--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -80,36 +80,36 @@ export const config = {
 		firecrawl_scrape: {
 			api_key: FIRECRAWL_API_KEY,
 			base_url: FIRECRAWL_BASE_URL
-				? `${FIRECRAWL_BASE_URL}/v1/scrape`
-				: 'https://api.firecrawl.dev/v1/scrape',
+				? `${FIRECRAWL_BASE_URL}/v2/scrape`
+				: 'https://api.firecrawl.dev/v2/scrape',
 			timeout: 60000, // 60 seconds - web scraping can take longer
 		},
 		firecrawl_crawl: {
 			api_key: FIRECRAWL_API_KEY,
 			base_url: FIRECRAWL_BASE_URL
-				? `${FIRECRAWL_BASE_URL}/v1/crawl`
-				: 'https://api.firecrawl.dev/v1/crawl',
+				? `${FIRECRAWL_BASE_URL}/v2/crawl`
+				: 'https://api.firecrawl.dev/v2/crawl',
 			timeout: 120000, // 120 seconds - crawling can take even longer
 		},
 		firecrawl_map: {
 			api_key: FIRECRAWL_API_KEY,
 			base_url: FIRECRAWL_BASE_URL
-				? `${FIRECRAWL_BASE_URL}/v1/map`
-				: 'https://api.firecrawl.dev/v1/map',
+				? `${FIRECRAWL_BASE_URL}/v2/map`
+				: 'https://api.firecrawl.dev/v2/map',
 			timeout: 60000, // 60 seconds
 		},
 		firecrawl_extract: {
 			api_key: FIRECRAWL_API_KEY,
 			base_url: FIRECRAWL_BASE_URL
-				? `${FIRECRAWL_BASE_URL}/v1/extract`
-				: 'https://api.firecrawl.dev/v1/extract',
+				? `${FIRECRAWL_BASE_URL}/v2/extract`
+				: 'https://api.firecrawl.dev/v2/extract',
 			timeout: 60000, // 60 seconds
 		},
 		firecrawl_actions: {
 			api_key: FIRECRAWL_API_KEY,
 			base_url: FIRECRAWL_BASE_URL
-				? `${FIRECRAWL_BASE_URL}/v1/scrape`
-				: 'https://api.firecrawl.dev/v1/scrape',
+				? `${FIRECRAWL_BASE_URL}/v2/scrape`
+				: 'https://api.firecrawl.dev/v2/scrape',
 			timeout: 90000, // 90 seconds - actions can take longer
 		},
 		exa_contents: {


### PR DESCRIPTION
## Summary

- Update all Firecrawl API endpoints from `/v1/` to `/v2/` to match the current default API version
- Covers all 5 Firecrawl config entries: scrape, crawl, map, extract, actions
- Both `FIRECRAWL_BASE_URL` conditional paths and hardcoded defaults updated

No breaking changes in request/response format — v2 is backwards compatible for these endpoints.

## Test plan

- [ ] `pnpm build` compiles without errors
- [ ] Firecrawl scrape/crawl/map/extract/actions work with v2 endpoints
- [ ] Custom `FIRECRAWL_BASE_URL` still works correctly