### PR TITLE
fix: update Perplexity model options, remove deprecated models

### DIFF
--- a/src/providers/ai_response/perplexity/index.ts
+++ b/src/providers/ai_response/perplexity/index.ts
@@ -25,7 +25,7 @@ export interface PerplexityResponse {
 }
 
 export interface PerplexityOptions {
-	model?: 'sonar-pro' | 'sonar' | 'sonar-reasoning' | 'r1-1776';
+	model?: 'sonar-pro' | 'sonar' | 'sonar-reasoning-pro' | 'sonar-deep-research';
 	max_tokens?: number;
 	temperature?: number;
 	include_sources?: boolean;


### PR DESCRIPTION
## Summary

- Replace deprecated `sonar-reasoning` (Dec 2025) and `r1-1776` (Aug 2025) models
- Add current models: `sonar-reasoning-pro` and `sonar-deep-research`
- Default model `sonar-pro` remains unchanged and valid

## Test plan

- [ ] `pnpm build` compiles without errors
- [ ] Perplexity AI search still works with `sonar-pro` default