### PR TITLE
fix: remove deprecated useAutoprompt from Exa providers

### DIFF
--- a/src/providers/ai_response/exa_answer/index.ts
+++ b/src/providers/ai_response/exa_answer/index.ts
@@ -18,7 +18,6 @@ interface ExaAnswerRequest {
 	livecrawl?: 'always' | 'fallback' | 'preferred';
 	includeDomains?: string[];
 	excludeDomains?: string[];
-	useAutoprompt?: boolean;
 }
 
 interface ExaAnswerResponse {
@@ -51,7 +50,6 @@ export class ExaAnswerProvider implements SearchProvider {
 					query: sanitize_query(params.query),
 					type: 'auto',
 					livecrawl: 'fallback',
-					useAutoprompt: true,
 				};
 
 				// Add domain filtering if provided

--- a/src/providers/search/exa/index.ts
+++ b/src/providers/search/exa/index.ts
@@ -23,7 +23,6 @@ interface ExaSearchRequest {
 		livecrawl?: 'always' | 'fallback' | 'preferred';
 	};
 	category?: string;
-	useAutoprompt?: boolean;
 }
 
 interface ExaSearchResult {
@@ -40,7 +39,6 @@ interface ExaSearchResult {
 
 interface ExaSearchResponse {
 	requestId: string;
-	autopromptString?: string;
 	resolvedSearchType: string;
 	results: ExaSearchResult[];
 }
@@ -62,7 +60,6 @@ export class ExaSearchProvider implements SearchProvider {
 					query: sanitize_query(params.query),
 					type: 'auto', // Let Exa choose between neural and keyword search
 					numResults: params.limit ?? 10,
-					useAutoprompt: true,
 					contents: {
 						text: { maxCharacters: 3000 },
 						livecrawl: 'fallback',
@@ -110,7 +107,6 @@ export class ExaSearchProvider implements SearchProvider {
 						author: result.author,
 						publishedDate: result.publishedDate,
 						highlights: result.highlights,
-						autopromptString: data.autopromptString,
 						resolvedSearchType: data.resolvedSearchType,
 					},
 				}));


### PR DESCRIPTION
## Summary

- Remove deprecated `useAutoprompt` parameter from Exa search and answer providers
- Remove `autopromptString` from response metadata mapping
- Per current Exa API docs, this parameter is no longer supported

## Test plan

- [ ] `pnpm build` compiles without errors
- [ ] Exa search still returns results without autoprompt
- [ ] Exa answer still works correctly