### PR TITLE
fix: update provider APIs to match current specs

### DIFF
--- a/.changeset/few-poets-return.md
+++ b/.changeset/few-poets-return.md
@@ -1,0 +1,5 @@
+---
+'mcp-omnisearch': patch
+---
+
+fix: update Exa, Firecrawl v2, and Tavily APIs to match current specs

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -72,36 +72,36 @@ export const config = {
 		firecrawl_scrape: {
 			api_key: FIRECRAWL_API_KEY,
 			base_url: FIRECRAWL_BASE_URL
-				? `${FIRECRAWL_BASE_URL}/v1/scrape`
-				: 'https://api.firecrawl.dev/v1/scrape',
+				? `${FIRECRAWL_BASE_URL}/v2/scrape`
+				: 'https://api.firecrawl.dev/v2/scrape',
 			timeout: 60000, // 60 seconds - web scraping can take longer
 		},
 		firecrawl_crawl: {
 			api_key: FIRECRAWL_API_KEY,
 			base_url: FIRECRAWL_BASE_URL
-				? `${FIRECRAWL_BASE_URL}/v1/crawl`
-				: 'https://api.firecrawl.dev/v1/crawl',
+				? `${FIRECRAWL_BASE_URL}/v2/crawl`
+				: 'https://api.firecrawl.dev/v2/crawl',
 			timeout: 120000, // 120 seconds - crawling can take even longer
 		},
 		firecrawl_map: {
 			api_key: FIRECRAWL_API_KEY,
 			base_url: FIRECRAWL_BASE_URL
-				? `${FIRECRAWL_BASE_URL}/v1/map`
-				: 'https://api.firecrawl.dev/v1/map',
+				? `${FIRECRAWL_BASE_URL}/v2/map`
+				: 'https://api.firecrawl.dev/v2/map',
 			timeout: 60000, // 60 seconds
 		},
 		firecrawl_extract: {
 			api_key: FIRECRAWL_API_KEY,
 			base_url: FIRECRAWL_BASE_URL
-				? `${FIRECRAWL_BASE_URL}/v1/extract`
-				: 'https://api.firecrawl.dev/v1/extract',
+				? `${FIRECRAWL_BASE_URL}/v2/extract`
+				: 'https://api.firecrawl.dev/v2/extract',
 			timeout: 60000, // 60 seconds
 		},
 		firecrawl_actions: {
 			api_key: FIRECRAWL_API_KEY,
 			base_url: FIRECRAWL_BASE_URL
-				? `${FIRECRAWL_BASE_URL}/v1/scrape`
-				: 'https://api.firecrawl.dev/v1/scrape',
+				? `${FIRECRAWL_BASE_URL}/v2/scrape`
+				: 'https://api.firecrawl.dev/v2/scrape',
 			timeout: 90000, // 90 seconds - actions can take longer
 		},
 		exa_contents: {

--- a/src/providers/ai_response/exa_answer/index.ts
+++ b/src/providers/ai_response/exa_answer/index.ts
@@ -12,26 +12,19 @@ import {
 import { validate_api_key } from '../../../common/validation.js';
 import { config } from '../../../config/env.js';
 
-interface ExaAnswerRequest {
-	query: string;
-	type?: string;
-	livecrawl?: 'always' | 'fallback' | 'preferred';
-	includeDomains?: string[];
-	excludeDomains?: string[];
-	useAutoprompt?: boolean;
-}
-
 interface ExaAnswerResponse {
 	answer: string;
-	sources?: Array<{
+	citations?: Array<{
 		id: string;
 		title: string;
 		url: string;
-		text?: string;
 		publishedDate?: string;
-		author?: string;
+		text?: string;
+		image?: string;
+		favicon?: string;
 	}>;
 	requestId: string;
+	costDollars?: number;
 }
 
 export class ExaAnswerProvider implements SearchProvider {
@@ -47,27 +40,6 @@ export class ExaAnswerProvider implements SearchProvider {
 
 		const search_request = async () => {
 			try {
-				const request_body: ExaAnswerRequest = {
-					query: sanitize_query(params.query),
-					type: 'auto',
-					livecrawl: 'fallback',
-					useAutoprompt: true,
-				};
-
-				// Add domain filtering if provided
-				if (
-					params.include_domains &&
-					params.include_domains.length > 0
-				) {
-					request_body.includeDomains = params.include_domains;
-				}
-				if (
-					params.exclude_domains &&
-					params.exclude_domains.length > 0
-				) {
-					request_body.excludeDomains = params.exclude_domains;
-				}
-
 				const data = await http_json<ExaAnswerResponse>(
 					this.name,
 					`${config.ai_response.exa_answer.base_url}/answer`,
@@ -75,48 +47,49 @@ export class ExaAnswerProvider implements SearchProvider {
 						method: 'POST',
 						headers: {
 							'x-api-key': api_key,
-							Authorization: `Bearer ${api_key}`,
 							'Content-Type': 'application/json',
 						},
-						body: JSON.stringify(request_body),
+						body: JSON.stringify({
+							query: sanitize_query(params.query),
+						}),
+						signal: AbortSignal.timeout(
+							config.ai_response.exa_answer.timeout,
+						),
 					},
 				);
 
-				// Create a result with the AI answer and sources
 				const results: SearchResult[] = [
 					{
 						title: 'AI Answer',
-						url: '', // No specific URL for AI-generated answers
+						url: '',
 						snippet: data.answer,
 						score: 1.0,
 						source_provider: this.name,
 						metadata: {
 							requestId: data.requestId,
 							type: 'ai_answer',
-							sources_count: data.sources?.length || 0,
+							citations_count: data.citations?.length || 0,
 						},
 					},
 				];
 
-				// Add sources as additional results if they exist
-				if (data.sources && data.sources.length > 0) {
-					const source_results = data.sources.map(
-						(source, index) => ({
-							title: source.title,
-							url: source.url,
-							snippet: source.text || 'Source reference',
-							score: 0.9 - index * 0.1,
+				if (data.citations && data.citations.length > 0) {
+					const limit = params.limit ?? data.citations.length;
+					const citation_results = data.citations
+						.slice(0, limit)
+						.map((citation, index) => ({
+							title: citation.title,
+							url: citation.url,
+							snippet: citation.text || 'Source reference',
+							score: 0.9 - index * 0.01,
 							source_provider: this.name,
 							metadata: {
-								id: source.id,
-								author: source.author,
-								publishedDate: source.publishedDate,
-								type: 'source',
-								requestId: data.requestId,
+								id: citation.id,
+								publishedDate: citation.publishedDate,
+								type: 'citation',
 							},
-						}),
-					);
-					results.push(...source_results);
+						}));
+					results.push(...citation_results);
 				}
 
 				return results;

--- a/src/providers/processing/exa_contents/index.ts
+++ b/src/providers/processing/exa_contents/index.ts
@@ -17,7 +17,6 @@ interface ExaContentsRequest {
 	text?: boolean;
 	highlights?: boolean;
 	summary?: boolean;
-	livecrawl?: 'always' | 'fallback' | 'preferred';
 }
 
 interface ExaContentResult {
@@ -77,8 +76,6 @@ export class ExaContentsProvider implements ProcessingProvider {
 					text: true,
 					highlights: extract_depth === 'advanced',
 					summary: extract_depth === 'advanced',
-					livecrawl:
-						extract_depth === 'advanced' ? 'preferred' : 'fallback',
 				};
 
 				const data = await http_json<ExaContentsResponse>(

--- a/src/providers/processing/exa_similar/index.ts
+++ b/src/providers/processing/exa_similar/index.ts
@@ -20,7 +20,6 @@ interface ExaSimilarRequest {
 		text?: { maxCharacters?: number };
 		highlights?: boolean;
 		summary?: boolean;
-		livecrawl?: 'always' | 'fallback' | 'preferred';
 	};
 	includeDomains?: string[];
 	excludeDomains?: string[];
@@ -83,8 +82,6 @@ export class ExaSimilarProvider implements ProcessingProvider {
 						},
 						highlights: extract_depth === 'advanced',
 						summary: extract_depth === 'advanced',
-						livecrawl:
-							extract_depth === 'advanced' ? 'preferred' : 'fallback',
 					},
 				};
 

--- a/src/providers/processing/firecrawl_actions/index.ts
+++ b/src/providers/processing/firecrawl_actions/index.ts
@@ -40,7 +40,13 @@ interface FirecrawlActionsResponse {
 }
 
 // Define the action types
-type ActionType = 'click' | 'type' | 'scroll' | 'wait' | 'select';
+type ActionType =
+	| 'click'
+	| 'write'
+	| 'scroll'
+	| 'wait'
+	| 'executeJavascript'
+	| 'screenshot';
 
 interface Action {
 	type: ActionType;
@@ -48,8 +54,9 @@ interface Action {
 	text?: string;
 	x?: number;
 	y?: number;
-	duration?: number;
-	value?: string;
+	milliseconds?: number;
+	direction?: 'up' | 'down';
+	script?: string;
 }
 
 export class FirecrawlActionsProvider implements ProcessingProvider {
@@ -78,23 +85,22 @@ export class FirecrawlActionsProvider implements ProcessingProvider {
 				const actions: Action[] =
 					extract_depth === 'advanced'
 						? [
-								{ type: 'wait', duration: 2000 }, // Wait for initial page load
-								{ type: 'scroll', duration: 1000 }, // Scroll down
-								{ type: 'wait', duration: 1000 }, // Wait for content to load
-								{ type: 'scroll', duration: 1000 }, // Scroll down more
-								{ type: 'wait', duration: 1000 }, // Wait for content to load
-								// Click on "Read more" or "Show more" buttons if they exist
+								{ type: 'wait', milliseconds: 2000 },
+								{ type: 'scroll', direction: 'down' },
+								{ type: 'wait', milliseconds: 1000 },
+								{ type: 'scroll', direction: 'down' },
+								{ type: 'wait', milliseconds: 1000 },
 								{
 									type: 'click',
 									selector:
 										'button:contains("Read more"), button:contains("Show more"), a:contains("Read more"), a:contains("Show more")',
 								},
-								{ type: 'wait', duration: 2000 }, // Wait for content to expand
+								{ type: 'wait', milliseconds: 2000 },
 							]
 						: [
-								{ type: 'wait', duration: 2000 }, // Wait for initial page load
-								{ type: 'scroll', duration: 1000 }, // Scroll down once
-								{ type: 'wait', duration: 1000 }, // Wait for content to load
+								{ type: 'wait', milliseconds: 2000 },
+								{ type: 'scroll', direction: 'down' },
+								{ type: 'wait', milliseconds: 1000 },
 							];
 
 				// Start the actions
@@ -106,44 +112,7 @@ export class FirecrawlActionsProvider implements ProcessingProvider {
 						{
 							url: actions_url,
 							formats: ['markdown', 'screenshot'],
-							actions: actions.map((action) => {
-								// Convert our action format to Firecrawl's action format
-								switch (action.type) {
-									case 'wait':
-										return {
-											type: 'wait',
-											milliseconds: action.duration || 1000,
-											selector: action.selector,
-										};
-									case 'scroll':
-										return {
-											type: 'scroll',
-											// Firecrawl might use different parameters for scroll
-											// Adjust as needed based on their documentation
-										};
-									case 'click':
-										return {
-											type: 'click',
-											selector: action.selector,
-											x: action.x,
-											y: action.y,
-										};
-									case 'type':
-										return {
-											type: 'type',
-											selector: action.selector,
-											text: action.text || '',
-										};
-									case 'select':
-										return {
-											type: 'select',
-											selector: action.selector,
-											value: action.value || '',
-										};
-									default:
-										return action;
-								}
-							}),
+							actions: actions,
 						},
 						config.processing.firecrawl_actions.timeout,
 					);
@@ -192,14 +161,16 @@ export class FirecrawlActionsProvider implements ProcessingProvider {
 							switch (action.type) {
 								case 'click':
 									return `${index + 1}. Click on ${action.selector || `coordinates (${action.x}, ${action.y})`}`;
-								case 'type':
-									return `${index + 1}. Type "${action.text}" ${action.selector ? `into ${action.selector}` : ''}`;
+								case 'write':
+									return `${index + 1}. Write "${action.text}" ${action.selector ? `into ${action.selector}` : ''}`;
 								case 'scroll':
-									return `${index + 1}. Scroll ${action.duration ? `for ${action.duration}ms` : ''}`;
+									return `${index + 1}. Scroll ${action.direction || 'down'}`;
 								case 'wait':
-									return `${index + 1}. Wait ${action.duration ? `for ${action.duration}ms` : ''}`;
-								case 'select':
-									return `${index + 1}. Select "${action.value}" from ${action.selector}`;
+									return `${index + 1}. Wait ${action.milliseconds ? `for ${action.milliseconds}ms` : ''}`;
+								case 'executeJavascript':
+									return `${index + 1}. Execute JavaScript`;
+								case 'screenshot':
+									return `${index + 1}. Take screenshot`;
 								default:
 									return `${index + 1}. Perform ${action.type} action`;
 							}

--- a/src/providers/processing/firecrawl_map/index.ts
+++ b/src/providers/processing/firecrawl_map/index.ts
@@ -16,9 +16,14 @@ import {
 } from '../../../common/validation.js';
 import { config } from '../../../config/env.js';
 
+interface FirecrawlMapLink {
+	url: string;
+	title?: string;
+}
+
 interface FirecrawlMapResponse {
 	success: boolean;
-	links?: string[];
+	links?: FirecrawlMapLink[];
 	error?: string;
 }
 
@@ -51,7 +56,6 @@ export class FirecrawlMapProvider implements ProcessingProvider {
 						{
 							url: map_url,
 							limit: extract_depth === 'advanced' ? 200 : 50,
-							ignoreSitemap: false,
 							includeSubdomains: false,
 						},
 						config.processing.firecrawl_map.timeout,
@@ -76,7 +80,13 @@ export class FirecrawlMapProvider implements ProcessingProvider {
 				const formatted_content =
 					`# Site Map for ${map_url}\n\n` +
 					`Found ${map_data.links.length} URLs:\n\n` +
-					map_data.links.map((url) => `- ${url}`).join('\n');
+					map_data.links
+						.map((link) =>
+							link.title
+								? `- ${link.url} — ${link.title}`
+								: `- ${link.url}`,
+						)
+						.join('\n');
 
 				// Create a single raw_content entry with all URLs
 				const raw_contents = [

--- a/src/providers/processing/tavily_extract/index.ts
+++ b/src/providers/processing/tavily_extract/index.ts
@@ -17,12 +17,12 @@ interface TavilyExtractResponse {
 	results: {
 		url: string;
 		raw_content: string;
-		images?: {
-			url: string;
-			alt_text?: string;
-		}[];
+		images?: string[];
 	}[];
-	failed_results: string[];
+	failed_results: {
+		url: string;
+		error: string;
+	}[];
 	response_time: number;
 }
 
@@ -92,7 +92,7 @@ export class TavilyExtractProvider implements ProcessingProvider {
 				// Include any failed URLs in metadata
 				const failed_urls =
 					data.failed_results.length > 0
-						? data.failed_results
+						? data.failed_results.map((f) => f.url)
 						: undefined;
 
 				return {

--- a/src/providers/search/exa/index.ts
+++ b/src/providers/search/exa/index.ts
@@ -20,10 +20,8 @@ interface ExaSearchRequest {
 	excludeDomains?: string[];
 	contents?: {
 		text?: { maxCharacters?: number };
-		livecrawl?: 'always' | 'fallback' | 'preferred';
 	};
 	category?: string;
-	useAutoprompt?: boolean;
 }
 
 interface ExaSearchResult {
@@ -62,10 +60,8 @@ export class ExaSearchProvider implements SearchProvider {
 					query: sanitize_query(params.query),
 					type: 'auto', // Let Exa choose between neural and keyword search
 					numResults: params.limit ?? 10,
-					useAutoprompt: true,
 					contents: {
 						text: { maxCharacters: 3000 },
-						livecrawl: 'fallback',
 					},
 				};
 


### PR DESCRIPTION
## Summary

- **Exa Answer**: read `citations` instead of `sources` (was returning 0 sources, now returns 8 citations)
- **Tavily Extract**: fix `failed_results` type from `string[]` to `{url, error}[]`, fix `images` type
- **Firecrawl**: migrate all 5 endpoints from v1 to v2
- **Firecrawl Map**: update response from `string[]` to `{url, title}[]`, remove deprecated `ignoreSitemap`
- **Firecrawl Actions**: rename `type` action to `write`, add `executeJavascript`/`screenshot` types
- **Exa (all)**: remove deprecated `livecrawl` and `useAutoprompt` params

## Test plan

- [x] Exa Answer: confirmed `citations_count: 8` (was 0)
- [x] Tavily Extract: `failed_urls` correctly extracts URL strings from `{url, error}` objects
- [x] Firecrawl v2 scrape: returns markdown via `/v2/scrape`
- [x] Firecrawl v2 map: returns `{url, title}[]` objects with titles displayed
- [x] All tested via both curl and mcp-omnisearch-dev MCP tool calls
- [x] `pnpm run build` clean