### PR TITLE
fix Tavily response_time schema

### DIFF
--- a/.changeset/dark-coats-cheer.md
+++ b/.changeset/dark-coats-cheer.md
@@ -1,0 +1,6 @@
+---
+'mcp-omnisearch': patch
+---
+
+Fix Tavily search response parsing by ignoring unused response_time
+metadata and adding regression coverage tests.

--- a/src/providers/search/search-operators.test.ts
+++ b/src/providers/search/search-operators.test.ts
@@ -109,7 +109,7 @@ describe('search provider operator handling', () => {
 						score: 0.9,
 					},
 				],
-				response_time: '0.1',
+				response_time: 0.1,
 			}),
 		);
 

--- a/src/providers/search/tavily/index.test.ts
+++ b/src/providers/search/tavily/index.test.ts
@@ -1,0 +1,64 @@
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	vi,
+} from 'vitest';
+
+const json_response = (body: unknown) =>
+	new Response(JSON.stringify(body), {
+		status: 200,
+		headers: { 'content-type': 'application/json' },
+	});
+
+describe('TavilySearchProvider', () => {
+	beforeEach(() => {
+		vi.resetModules();
+		vi.stubEnv('TAVILY_API_KEY', 'test-tavily-key');
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		vi.unstubAllEnvs();
+		vi.restoreAllMocks();
+	});
+
+	it('maps results when Tavily returns numeric response_time metadata', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(async () =>
+				json_response({
+					query: 'example domain',
+					results: [
+						{
+							title: 'Example Domains',
+							url: 'https://www.iana.org/help/example-domains',
+							content: 'Reserved example domains.',
+							score: 0.99986553,
+						},
+					],
+					response_time: 0.57,
+					request_id: '77d06e01-a9a1-4968-8fc3-5889dd2b61e9',
+				}),
+			),
+		);
+		const { TavilySearchProvider } = await import('./index.js');
+
+		await expect(
+			new TavilySearchProvider().search({
+				query: 'example domain',
+				limit: 1,
+			}),
+		).resolves.toEqual([
+			{
+				title: 'Example Domains',
+				url: 'https://www.iana.org/help/example-domains',
+				snippet: 'Reserved example domains.',
+				score: 0.99986553,
+				source_provider: 'tavily',
+			},
+		]);
+	});
+});

--- a/src/providers/search/tavily/index.ts
+++ b/src/providers/search/tavily/index.ts
@@ -40,7 +40,7 @@ const tavily_search_response_schema = v.object({
 			score: v.number(),
 		}),
 	),
-	response_time: v.optional(v.string()),
+	response_time: v.optional(v.number()),
 });
 
 export class TavilySearchProvider implements SearchProvider {

--- a/src/providers/search/tavily/index.ts
+++ b/src/providers/search/tavily/index.ts
@@ -40,7 +40,6 @@ const tavily_search_response_schema = v.object({
 			score: v.number(),
 		}),
 	),
-	response_time: v.optional(v.number()),
 });
 
 export class TavilySearchProvider implements SearchProvider {


### PR DESCRIPTION
## Summary
- ignore unused Tavily `response_time` metadata when validating search responses
- keep the operator fixture aligned with Tavily's numeric `response_time` shape
- add a Tavily search regression test using the reported upstream response shape

## Why
Tavily search can return valid responses with numeric `response_time` metadata. Since the provider does not use that metadata, validating it can reject otherwise valid results. The response schema now validates only the fields the adapter actually consumes.

## Test plan
- `pnpm check`
- `pnpm test`
- `pnpm build`

Closes #140.
