### PR TITLE
feat: adaptive routing from recent provider health

### DIFF
--- a/.changeset/adaptive-routing-health.md
+++ b/.changeset/adaptive-routing-health.md
@@ -1,0 +1,5 @@
+---
+'mcp-omnisearch': minor
+---
+
+feat: add process-local adaptive routing from recent provider health

--- a/README.md
+++ b/README.md
@@ -144,6 +144,9 @@ Tavily, Kagi, Firecrawl, or Exa.
 - `FIRECRAWL_API_KEY`
 - `FIRECRAWL_BASE_URL` optional, for self-hosted Firecrawl
 - `OMNISEARCH_LARGE_RESULT_MODE` optional, `file` default or `inline`
+- `OMNISEARCH_ADAPTIVE_ROUTING` optional, `on` by default. Set `off`
+  to disable bounded score adjustments from recent provider health.
+  Outcome state is process-local and is never sent to vendors.
 
 ## Development
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -127,6 +127,9 @@ Container variables:
 - `LINKUP_API_KEY`
 - `FIRECRAWL_API_KEY`
 - `FIRECRAWL_BASE_URL`
+- `OMNISEARCH_ADAPTIVE_ROUTING` optional, `on` by default. Set `off`
+  to disable adaptive score adjustments. Health samples stay
+  process-local and are never sent to vendors.
 - `PORT`, defaults to `8000`
 
 ## OpenAPI access

--- a/docs/provider-selection.md
+++ b/docs/provider-selection.md
@@ -53,3 +53,27 @@ search only. See
   `kagi_fastgpt`, `exa_answer`, or `linkup`.
 - Need to crawl/scrape/map a site? Use `web_extract` with `firecrawl`.
 - Need public code/repository/user discovery? Use `github_search`.
+
+## Adaptive routing from recent provider health
+
+Omnisearch keeps a process-local rolling window of recent provider
+outcomes (latency, empty results, and errors). When auto-routing
+supplies query-class scores, those outcomes become a bounded
+adjustment of at most ±1.0 so a currently healthy provider can win a
+close call.
+
+This does **not** override:
+
+- an explicit `provider` argument
+- a strong query-class lead (margin ≥ 1.0)
+
+State is in-memory only. It is never written to disk, never includes
+API keys, queries, or vendor error bodies, and is never sent to
+providers.
+
+Adaptive scoring is **on by default**. Disable it with
+`OMNISEARCH_ADAPTIVE_ROUTING=off`.
+
+Pass `quality_report: true` on `web_search`, `ai_search`,
+`github_search`, or `web_extract` to see the current adjustments and
+sample counts. Default tool payloads stay unchanged.

--- a/src/common/adaptive-routing.test.ts
+++ b/src/common/adaptive-routing.test.ts
@@ -1,0 +1,383 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { ErrorType, ProviderError } from './types.js';
+import {
+	MAX_SAMPLES_PER_PROVIDER,
+	MAX_SCORE_ADJUSTMENT,
+	MIN_SAMPLES_FOR_ADJUSTMENT,
+	SAMPLE_MAX_AGE_SECONDS,
+	STRONG_QUERY_CLASS_MARGIN,
+	apply_adaptive_routing,
+	build_adaptive_quality_report,
+	count_adaptive_results,
+	get_provider_performance,
+	is_non_health_error,
+	provider_performance_adjustment,
+	provider_performance_adjustments,
+	record_provider_outcome,
+	record_tool_outcome,
+	reset_adaptive_routing_for_tests,
+} from './adaptive-routing.js';
+
+const NOW = 1_700_000_000;
+
+const record_many = (
+	provider: string,
+	count: number,
+	sample: {
+		lat: number;
+		n: number;
+		err: boolean;
+	},
+	start = NOW,
+) => {
+	for (let index = 0; index < count; index += 1) {
+		record_provider_outcome(
+			provider,
+			sample.lat,
+			sample.n,
+			sample.err,
+			start + index,
+		);
+	}
+};
+
+afterEach(() => {
+	reset_adaptive_routing_for_tests();
+	delete process.env.OMNISEARCH_ADAPTIVE_ROUTING;
+});
+
+describe('count_adaptive_results', () => {
+	it('uses array length and empty extract content', () => {
+		expect(count_adaptive_results([{ url: 'https://a' }])).toBe(1);
+		expect(count_adaptive_results([])).toBe(0);
+		expect(count_adaptive_results({ content: '  ' })).toBe(0);
+		expect(count_adaptive_results({ content: 'ok' })).toBe(1);
+		expect(count_adaptive_results({ ok: true })).toBe(1);
+	});
+});
+
+describe('provider outcome window', () => {
+	it('keeps only the last 50 samples per provider', () => {
+		record_many('brave', MAX_SAMPLES_PER_PROVIDER + 10, {
+			lat: 0.4,
+			n: 5,
+			err: false,
+		});
+
+		expect(get_provider_performance('brave', NOW + 60).samples).toBe(
+			MAX_SAMPLES_PER_PROVIDER,
+		);
+	});
+
+	it('ignores samples older than seven days', () => {
+		record_provider_outcome('tavily', 0.3, 4, false, NOW);
+		record_many(
+			'tavily',
+			MIN_SAMPLES_FOR_ADJUSTMENT,
+			{ lat: 0.3, n: 4, err: false },
+			NOW + SAMPLE_MAX_AGE_SECONDS + 10,
+		);
+
+		expect(
+			get_provider_performance(
+				'tavily',
+				NOW + SAMPLE_MAX_AGE_SECONDS + 20,
+			).samples,
+		).toBe(MIN_SAMPLES_FOR_ADJUSTMENT);
+	});
+
+	it('stores only timestamp, latency, count, and error flag', () => {
+		record_provider_outcome('exa', 1.25, 3, false, NOW);
+		const performance = get_provider_performance('exa', NOW);
+		const serialized = JSON.stringify(performance);
+
+		expect(serialized).not.toMatch(/api[_-]?key/i);
+		expect(serialized).not.toContain('sk-');
+		expect(serialized).not.toContain('Bearer');
+		expect(performance).toEqual(
+			expect.objectContaining({
+				samples: 1,
+				success_rate: 1,
+				empty_rate: 0,
+			}),
+		);
+	});
+});
+
+describe('bounded performance adjustments', () => {
+	it('returns 0 until the minimum sample count exists', () => {
+		record_many('kagi', MIN_SAMPLES_FOR_ADJUSTMENT - 1, {
+			lat: 0.2,
+			n: 8,
+			err: false,
+		});
+
+		expect(provider_performance_adjustment('kagi', NOW + 20)).toBe(0);
+	});
+
+	it('stays within ±1.0 and rewards healthy providers', () => {
+		record_many('healthy', MIN_SAMPLES_FOR_ADJUSTMENT, {
+			lat: 0.2,
+			n: 8,
+			err: false,
+		});
+		record_many('failing', MIN_SAMPLES_FOR_ADJUSTMENT, {
+			lat: 7.5,
+			n: 0,
+			err: true,
+		});
+		record_many('empty', MIN_SAMPLES_FOR_ADJUSTMENT, {
+			lat: 0.4,
+			n: 0,
+			err: false,
+		});
+
+		const healthy = provider_performance_adjustment(
+			'healthy',
+			NOW + 20,
+		);
+		const failing = provider_performance_adjustment(
+			'failing',
+			NOW + 20,
+		);
+		const empty = provider_performance_adjustment('empty', NOW + 20);
+
+		expect(healthy).toBeGreaterThan(0);
+		expect(failing).toBeLessThan(0);
+		expect(empty).toBeLessThan(healthy);
+		expect(Math.abs(healthy)).toBeLessThanOrEqual(
+			MAX_SCORE_ADJUSTMENT,
+		);
+		expect(Math.abs(failing)).toBeLessThanOrEqual(
+			MAX_SCORE_ADJUSTMENT,
+		);
+		expect(failing).toBe(-MAX_SCORE_ADJUSTMENT);
+	});
+
+	it('omits zero adjustments from the map', () => {
+		expect(
+			provider_performance_adjustments(['unknown'], NOW),
+		).toEqual({});
+	});
+});
+
+describe('apply_adaptive_routing', () => {
+	it('never overrides an explicit provider', () => {
+		record_many('brave', MIN_SAMPLES_FOR_ADJUSTMENT, {
+			lat: 7,
+			n: 0,
+			err: true,
+		});
+		record_many('tavily', MIN_SAMPLES_FOR_ADJUSTMENT, {
+			lat: 0.2,
+			n: 8,
+			err: false,
+		});
+
+		const decision = apply_adaptive_routing({
+			candidates: ['brave', 'tavily'],
+			base_scores: { brave: 0, tavily: 3 },
+			explicit_provider: 'brave',
+			now: NOW + 20,
+		});
+
+		expect(decision).toEqual(
+			expect.objectContaining({
+				selected: 'brave',
+				reason: 'explicit_provider',
+				applied: false,
+			}),
+		);
+		expect(decision.adjustments.tavily).toBeGreaterThan(0);
+	});
+
+	it('does not let health flip a strong query-class lead', () => {
+		record_many('exa', MIN_SAMPLES_FOR_ADJUSTMENT, {
+			lat: 7,
+			n: 0,
+			err: true,
+		});
+		record_many('brave', MIN_SAMPLES_FOR_ADJUSTMENT, {
+			lat: 0.2,
+			n: 8,
+			err: false,
+		});
+
+		const decision = apply_adaptive_routing({
+			candidates: ['exa', 'brave'],
+			base_scores: {
+				exa: STRONG_QUERY_CLASS_MARGIN,
+				brave: 0,
+			},
+			now: NOW + 20,
+		});
+
+		expect(decision.selected).toBe('exa');
+		expect(decision.reason).toBe('strong_query_class');
+		expect(decision.applied).toBe(false);
+		expect(decision.adjustments.brave).toBeGreaterThan(0);
+		expect(decision.adjustments.exa).toBeLessThan(0);
+	});
+
+	it('lets currently healthy providers win close calls', () => {
+		record_many('kagi', MIN_SAMPLES_FOR_ADJUSTMENT, {
+			lat: 7,
+			n: 0,
+			err: true,
+		});
+		record_many('tavily', MIN_SAMPLES_FOR_ADJUSTMENT, {
+			lat: 0.2,
+			n: 8,
+			err: false,
+		});
+
+		const decision = apply_adaptive_routing({
+			candidates: ['kagi', 'tavily'],
+			base_scores: { kagi: 0.2, tavily: 0 },
+			now: NOW + 20,
+		});
+
+		expect(decision.selected).toBe('tavily');
+		expect(decision.reason).toBe('adaptive');
+		expect(decision.applied).toBe(true);
+	});
+
+	it('honors OMNISEARCH_ADAPTIVE_ROUTING=off', () => {
+		process.env.OMNISEARCH_ADAPTIVE_ROUTING = 'off';
+		record_many('tavily', MIN_SAMPLES_FOR_ADJUSTMENT, {
+			lat: 0.2,
+			n: 8,
+			err: false,
+		});
+
+		const decision = apply_adaptive_routing({
+			candidates: ['kagi', 'tavily'],
+			base_scores: { kagi: 0.2, tavily: 0 },
+			now: NOW + 20,
+		});
+
+		expect(decision.selected).toBe('kagi');
+		expect(decision.reason).toBe('disabled');
+		expect(decision.adjustments).toEqual({});
+	});
+
+	it('uses base scores only when adaptive routing is disabled', () => {
+		record_many('kagi', MIN_SAMPLES_FOR_ADJUSTMENT, {
+			lat: 7,
+			n: 0,
+			err: true,
+		});
+		record_many('tavily', MIN_SAMPLES_FOR_ADJUSTMENT, {
+			lat: 0.2,
+			n: 8,
+			err: false,
+		});
+
+		const decision = apply_adaptive_routing({
+			candidates: ['kagi', 'tavily'],
+			base_scores: { kagi: 0.2, tavily: 0 },
+			enabled: false,
+			now: NOW + 20,
+		});
+
+		expect(decision).toEqual(
+			expect.objectContaining({
+				selected: 'kagi',
+				reason: 'disabled',
+				applied: false,
+				enabled: false,
+				adjustments: {},
+			}),
+		);
+	});
+
+	it('returns no_candidates when the pool is empty', () => {
+		expect(
+			apply_adaptive_routing({
+				candidates: [],
+				now: NOW,
+			}),
+		).toEqual(
+			expect.objectContaining({
+				selected: undefined,
+				reason: 'no_candidates',
+				applied: false,
+			}),
+		);
+	});
+});
+
+describe('quality report and tool recording', () => {
+	it('exposes adjustments without secrets or vendor errors', () => {
+		record_many('brave', MIN_SAMPLES_FOR_ADJUSTMENT, {
+			lat: 0.3,
+			n: 4,
+			err: false,
+		});
+
+		const report = build_adaptive_quality_report({
+			candidates: ['brave', 'tavily'],
+			explicit_provider: 'brave',
+			now: NOW + 20,
+		});
+		const serialized = JSON.stringify(report);
+
+		expect(report.scope).toBe('process_local');
+		expect(report.reason).toBe('explicit_provider');
+		expect(report.selected).toBe('brave');
+		expect(report.providers.brave.samples).toBe(
+			MIN_SAMPLES_FOR_ADJUSTMENT,
+		);
+		expect(serialized).not.toMatch(/api[_-]?key/i);
+		expect(serialized).not.toContain('Authorization');
+		expect(serialized).not.toMatch(/rate limit|401|403/i);
+	});
+
+	it('records tool success, empty, and error outcomes', () => {
+		record_tool_outcome({
+			provider: 'brave',
+			started_at_ms: Date.now() - 200,
+			result: [{ url: 'https://example.com' }],
+		});
+		record_tool_outcome({
+			provider: 'brave',
+			started_at_ms: Date.now() - 200,
+			result: [],
+		});
+		record_tool_outcome({
+			provider: 'brave',
+			started_at_ms: Date.now() - 200,
+			error: new Error('vendor boom with key sk-secret'),
+		});
+
+		const performance = get_provider_performance('brave');
+		expect(performance.samples).toBe(3);
+		expect(performance.success_rate).toBeCloseTo(2 / 3, 3);
+		expect(JSON.stringify(performance)).not.toContain('sk-secret');
+		expect(JSON.stringify(performance)).not.toContain('vendor boom');
+	});
+
+	it('does not treat invalid input as provider health', () => {
+		expect(
+			is_non_health_error(
+				new ProviderError(
+					ErrorType.INVALID_INPUT,
+					'bad mode',
+					'web_extract',
+				),
+			),
+		).toBe(true);
+
+		record_tool_outcome({
+			provider: 'tavily',
+			started_at_ms: Date.now(),
+			error: new ProviderError(
+				ErrorType.INVALID_INPUT,
+				'bad mode',
+				'web_extract',
+			),
+		});
+
+		expect(get_provider_performance('tavily').samples).toBe(0);
+	});
+});

--- a/src/common/adaptive-routing.ts
+++ b/src/common/adaptive-routing.ts
@@ -1,0 +1,422 @@
+// Process-local adaptive routing from recent provider health.
+//
+// Records latency / empty / error outcomes in a small rolling window
+// and turns them into a bounded score adjustment. Adjustments can
+// break ties and win close calls; they must not override an explicit
+// provider or a strong query-class lead. State never includes queries,
+// API keys, or vendor error bodies, and is never sent to providers.
+
+import { is_adaptive_routing_enabled } from '../config/env.js';
+import { ErrorType, ProviderError } from './types.js';
+
+export const MAX_SAMPLES_PER_PROVIDER = 50;
+export const SAMPLE_MAX_AGE_SECONDS = 7 * 24 * 3600;
+export const MIN_SAMPLES_FOR_ADJUSTMENT = 5;
+export const MAX_SCORE_ADJUSTMENT = 1.0;
+export const STRONG_QUERY_CLASS_MARGIN = 1.0;
+export const LATENCY_CEILING_SECONDS = 8.0;
+export const PERFORMANCE_BASELINE = 0.75;
+
+export type AdaptiveRoutingReason =
+	| 'explicit_provider'
+	| 'strong_query_class'
+	| 'adaptive'
+	| 'disabled'
+	| 'no_candidates';
+
+export interface ProviderSample {
+	t: number;
+	lat: number;
+	n: number;
+	err: boolean;
+}
+
+export interface ProviderPerformance {
+	samples: number;
+	success_rate: number;
+	empty_rate: number;
+	median_latency_seconds: number | null;
+	score_adjustment: number;
+}
+
+export interface AdaptiveRoutingDecision {
+	selected: string | undefined;
+	reason: AdaptiveRoutingReason;
+	applied: boolean;
+	enabled: boolean;
+	base_scores: Record<string, number>;
+	adjustments: Record<string, number>;
+	adjusted_scores: Record<string, number>;
+}
+
+export interface AdaptiveQualityReport {
+	enabled: boolean;
+	scope: 'process_local';
+	applied: boolean;
+	reason: AdaptiveRoutingReason;
+	selected?: string;
+	adjustments: Record<string, number>;
+	providers: Record<string, ProviderPerformance>;
+}
+
+export interface ApplyAdaptiveRoutingInput {
+	candidates: readonly string[];
+	base_scores?: Record<string, number>;
+	explicit_provider?: string;
+	now?: number;
+	enabled?: boolean;
+}
+
+const provider_samples = new Map<string, ProviderSample[]>();
+
+const now_seconds = () => Date.now() / 1000;
+
+const round3 = (value: number) => Number(value.toFixed(3));
+
+const median = (values: number[]): number => {
+	const sorted = [...values].sort((a, b) => a - b);
+	const mid = Math.floor(sorted.length / 2);
+	return sorted.length % 2
+		? sorted[mid]
+		: (sorted[mid - 1] + sorted[mid]) / 2;
+};
+
+const clamp_adjustment = (value: number) =>
+	Math.max(
+		-MAX_SCORE_ADJUSTMENT,
+		Math.min(MAX_SCORE_ADJUSTMENT, value),
+	);
+
+const fresh_samples = (
+	provider: string,
+	now: number,
+): ProviderSample[] => {
+	const cutoff = now - SAMPLE_MAX_AGE_SECONDS;
+	return (provider_samples.get(provider) ?? []).filter(
+		(sample) => sample.t >= cutoff,
+	);
+};
+
+/**
+ * Count results for an outcome sample. Arrays use length; extract
+ * payloads with empty `content` count as empty.
+ */
+export const count_adaptive_results = (result: unknown): number => {
+	if (Array.isArray(result)) return result.length;
+
+	if (result && typeof result === 'object') {
+		const content = (result as { content?: unknown }).content;
+		if (typeof content === 'string') {
+			return content.trim() === '' ? 0 : 1;
+		}
+	}
+
+	return 1;
+};
+
+/**
+ * True when an error is a caller/validation problem, not provider
+ * health. Those must not move adaptive scores.
+ */
+export const is_non_health_error = (error: unknown): boolean =>
+	error instanceof ProviderError &&
+	error.type === ErrorType.INVALID_INPUT;
+
+/**
+ * Record one local outcome. Stores only timestamp, latency, result
+ * count, and an error flag — never queries, keys, or error text.
+ */
+export const record_provider_outcome = (
+	provider: string,
+	latency_seconds: number,
+	result_count: number,
+	error: boolean,
+	now?: number,
+): void => {
+	const sample: ProviderSample = {
+		t: Math.floor(now ?? now_seconds()),
+		lat: round3(Math.max(0, Number(latency_seconds) || 0)),
+		n: Math.max(0, Math.floor(Number(result_count) || 0)),
+		err: Boolean(error),
+	};
+	const samples = provider_samples.get(provider) ?? [];
+	samples.push(sample);
+	provider_samples.set(
+		provider,
+		samples.slice(-MAX_SAMPLES_PER_PROVIDER),
+	);
+};
+
+/**
+ * Summarize fresh samples for one provider. Returns zeros when the
+ * window is empty.
+ */
+export const get_provider_performance = (
+	provider: string,
+	now?: number,
+): ProviderPerformance => {
+	const now_ts = now ?? now_seconds();
+	const samples = fresh_samples(provider, now_ts);
+	if (samples.length === 0) {
+		return {
+			samples: 0,
+			success_rate: 0,
+			empty_rate: 0,
+			median_latency_seconds: null,
+			score_adjustment: 0,
+		};
+	}
+
+	const successes = samples.filter((sample) => !sample.err);
+	const empty = successes.filter((sample) => sample.n === 0);
+	const latencies = successes.map((sample) => sample.lat);
+
+	return {
+		samples: samples.length,
+		success_rate: round3(successes.length / samples.length),
+		empty_rate: successes.length
+			? round3(empty.length / successes.length)
+			: 0,
+		median_latency_seconds: latencies.length
+			? round3(median(latencies))
+			: null,
+		score_adjustment: provider_performance_adjustment(
+			provider,
+			now_ts,
+		),
+	};
+};
+
+/**
+ * Bounded routing-score adjustment from recent performance.
+ * Reliability (success, discounted by empties) plus speed vs an 8s
+ * ceiling, then mapped around a 0.75 baseline into ±1.0.
+ */
+export const provider_performance_adjustment = (
+	provider: string,
+	now?: number,
+): number => {
+	const now_ts = now ?? now_seconds();
+	const samples = fresh_samples(provider, now_ts);
+	if (samples.length < MIN_SAMPLES_FOR_ADJUSTMENT) return 0;
+
+	const successes = samples.filter((sample) => !sample.err);
+	const empty = successes.filter((sample) => sample.n === 0);
+	const latencies = successes.map((sample) => sample.lat);
+	const success_rate = successes.length / samples.length;
+	const empty_rate = successes.length
+		? empty.length / successes.length
+		: 0;
+	const reliability = success_rate * (1 - 0.5 * empty_rate);
+	const median_latency = latencies.length ? median(latencies) : null;
+	const speed =
+		median_latency == null
+			? 0
+			: Math.max(
+					0,
+					Math.min(1, 1 - median_latency / LATENCY_CEILING_SECONDS),
+				);
+	const combined = 0.6 * reliability + 0.4 * speed;
+	const adjustment =
+		(combined - PERFORMANCE_BASELINE) * 2 * MAX_SCORE_ADJUSTMENT;
+
+	return round3(clamp_adjustment(adjustment));
+};
+
+/**
+ * Non-zero adjustments for the given providers.
+ */
+export const provider_performance_adjustments = (
+	providers: readonly string[],
+	now?: number,
+): Record<string, number> => {
+	const adjustments: Record<string, number> = {};
+	for (const provider of providers) {
+		const value = provider_performance_adjustment(provider, now);
+		if (value !== 0) adjustments[provider] = value;
+	}
+	return adjustments;
+};
+
+const pick_winner = (
+	candidates: readonly string[],
+	scores: Record<string, number>,
+): string => {
+	let winner = candidates[0];
+	let best = scores[winner] ?? 0;
+	for (const candidate of candidates.slice(1)) {
+		const score = scores[candidate] ?? 0;
+		if (score > best) {
+			winner = candidate;
+			best = score;
+		}
+	}
+	return winner;
+};
+
+const query_class_margin = (
+	candidates: readonly string[],
+	base_scores: Record<string, number>,
+): number => {
+	if (candidates.length < 2) return Number.POSITIVE_INFINITY;
+
+	const ranked = [...candidates].sort(
+		(left, right) =>
+			(base_scores[right] ?? 0) - (base_scores[left] ?? 0),
+	);
+	return (
+		(base_scores[ranked[0]] ?? 0) - (base_scores[ranked[1]] ?? 0)
+	);
+};
+
+/**
+ * Choose a provider from query-class scores plus bounded health
+ * adjustments. Explicit provider and a strong query-class lead always
+ * win; adaptive scoring only decides close calls.
+ */
+export const apply_adaptive_routing = (
+	input: ApplyAdaptiveRoutingInput,
+): AdaptiveRoutingDecision => {
+	const enabled = input.enabled ?? is_adaptive_routing_enabled();
+	const candidates = input.candidates;
+	const base_scores = Object.fromEntries(
+		candidates.map((provider) => [
+			provider,
+			input.base_scores?.[provider] ?? 0,
+		]),
+	);
+	const now = input.now ?? now_seconds();
+	const adjustments = enabled
+		? provider_performance_adjustments(candidates, now)
+		: {};
+	const adjusted_scores = Object.fromEntries(
+		candidates.map((provider) => [
+			provider,
+			round3(
+				(base_scores[provider] ?? 0) + (adjustments[provider] ?? 0),
+			),
+		]),
+	);
+
+	if (input.explicit_provider) {
+		return {
+			selected: input.explicit_provider,
+			reason: 'explicit_provider',
+			applied: false,
+			enabled,
+			base_scores,
+			adjustments,
+			adjusted_scores,
+		};
+	}
+
+	if (candidates.length === 0) {
+		return {
+			selected: undefined,
+			reason: 'no_candidates',
+			applied: false,
+			enabled,
+			base_scores,
+			adjustments,
+			adjusted_scores,
+		};
+	}
+
+	if (!enabled) {
+		return {
+			selected: pick_winner(candidates, base_scores),
+			reason: 'disabled',
+			applied: false,
+			enabled,
+			base_scores,
+			adjustments: {},
+			adjusted_scores: { ...base_scores },
+		};
+	}
+
+	const margin = query_class_margin(candidates, base_scores);
+	if (margin >= STRONG_QUERY_CLASS_MARGIN) {
+		return {
+			selected: pick_winner(candidates, base_scores),
+			reason: 'strong_query_class',
+			applied: false,
+			enabled,
+			base_scores,
+			adjustments,
+			adjusted_scores,
+		};
+	}
+
+	return {
+		selected: pick_winner(candidates, adjusted_scores),
+		reason: 'adaptive',
+		applied: true,
+		enabled,
+		base_scores,
+		adjustments,
+		adjusted_scores,
+	};
+};
+
+/**
+ * Opt-in quality report. Contains only local aggregates — no keys,
+ * queries, or raw vendor errors.
+ */
+export const build_adaptive_quality_report = (
+	input: ApplyAdaptiveRoutingInput,
+): AdaptiveQualityReport => {
+	const decision = apply_adaptive_routing(input);
+	const now = input.now ?? now_seconds();
+	const providers = Object.fromEntries(
+		input.candidates.map((provider) => [
+			provider,
+			get_provider_performance(provider, now),
+		]),
+	);
+
+	return {
+		enabled: decision.enabled,
+		scope: 'process_local',
+		applied: decision.applied,
+		reason: decision.reason,
+		selected: decision.selected,
+		adjustments: decision.adjustments,
+		providers,
+	};
+};
+
+/**
+ * Record a finished tool call when it reflects provider health.
+ */
+export const record_tool_outcome = (input: {
+	provider?: string;
+	started_at_ms: number;
+	result?: unknown;
+	error?: unknown;
+	result_count?: (result: unknown) => number;
+	now?: number;
+}): void => {
+	if (!input.provider) return;
+	if (input.error && is_non_health_error(input.error)) return;
+
+	const latency_seconds = Math.max(
+		0,
+		(Date.now() - input.started_at_ms) / 1000,
+	);
+	const result_count = input.error
+		? 0
+		: (input.result_count ?? count_adaptive_results)(input.result);
+
+	record_provider_outcome(
+		input.provider,
+		latency_seconds,
+		result_count,
+		Boolean(input.error),
+		input.now,
+	);
+};
+
+/** Test-only: drop the in-memory window. */
+export const reset_adaptive_routing_for_tests = (): void => {
+	provider_samples.clear();
+};

--- a/src/config/env.test.ts
+++ b/src/config/env.test.ts
@@ -1,8 +1,35 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
+	is_adaptive_routing_enabled,
 	should_warn_for_local_file_offload,
 	warn_for_local_file_offload,
 } from './env.js';
+
+describe('adaptive routing config', () => {
+	it('defaults to on and can be disabled', () => {
+		expect(is_adaptive_routing_enabled({})).toBe(true);
+		expect(
+			is_adaptive_routing_enabled({
+				OMNISEARCH_ADAPTIVE_ROUTING: 'on',
+			}),
+		).toBe(true);
+		expect(
+			is_adaptive_routing_enabled({
+				OMNISEARCH_ADAPTIVE_ROUTING: 'off',
+			}),
+		).toBe(false);
+		expect(
+			is_adaptive_routing_enabled({
+				OMNISEARCH_ADAPTIVE_ROUTING: 'false',
+			}),
+		).toBe(false);
+		expect(
+			is_adaptive_routing_enabled({
+				OMNISEARCH_ADAPTIVE_ROUTING: '0',
+			}),
+		).toBe(false);
+	});
+});
 
 describe('large-result local file offload warnings', () => {
 	it('warns when file mode is configured in likely remote deployments', () => {

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -134,6 +134,21 @@ const remote_deployment_markers = [
 	'VERCEL',
 ];
 
+const adaptive_routing_disabled = new Set([
+	'0',
+	'false',
+	'off',
+	'no',
+]);
+
+export const is_adaptive_routing_enabled = (
+	env: NodeJS.ProcessEnv = process.env,
+) => {
+	const raw = env.OMNISEARCH_ADAPTIVE_ROUTING?.trim().toLowerCase();
+	if (!raw) return true;
+	return !adaptive_routing_disabled.has(raw);
+};
+
 export const should_warn_for_local_file_offload = (
 	env: NodeJS.ProcessEnv = process.env,
 ) =>

--- a/src/server/tools/ai-search.ts
+++ b/src/server/tools/ai-search.ts
@@ -11,6 +11,7 @@ import { handle_tool_result } from './responses.js';
 import {
 	large_result_mode_schema,
 	limit_schema,
+	quality_report_schema,
 	query_schema,
 } from './schemas.js';
 
@@ -54,9 +55,16 @@ export const register_ai_search = (
 				),
 				limit: limit_schema,
 				large_result_mode: large_result_mode_schema,
+				quality_report: quality_report_schema,
 			}),
 		},
-		async ({ query, provider, limit, large_result_mode }) =>
+		async ({
+			query,
+			provider,
+			limit,
+			large_result_mode,
+			quality_report,
+		}) =>
 			handle_tool_result(
 				'ai_search',
 				async () => {
@@ -67,7 +75,14 @@ export const register_ai_search = (
 						limit,
 					});
 				},
-				{ large_result_mode },
+				{
+					large_result_mode,
+					quality_report,
+					adaptive: {
+						provider,
+						candidates: providers.ids(),
+					},
+				},
 			),
 	);
 };

--- a/src/server/tools/contract.test.ts
+++ b/src/server/tools/contract.test.ts
@@ -152,6 +152,13 @@ describe('MCP tool contract', () => {
 			v.safeParse(schema, { query: 'test', provider: 'kagi' })
 				.success,
 		).toBe(false);
+		expect(
+			v.safeParse(schema, {
+				query: 'sveltekit docs',
+				provider: 'brave',
+				quality_report: true,
+			}).success,
+		).toBe(true);
 	});
 
 	it('validates public web_extract payloads and unavailable modes at the MCP layer', async () => {
@@ -242,6 +249,50 @@ describe('MCP tool contract', () => {
 				source_provider: 'brave',
 			},
 		]);
+
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValueOnce(
+				new Response(
+					JSON.stringify({
+						web: {
+							results: [
+								{
+									title: 'Example',
+									url: 'https://example.com',
+									description: 'Example result',
+								},
+							],
+						},
+					}),
+					{ status: 200 },
+				),
+			),
+		);
+		const reported = parse_tool_body(
+			await tool.handler({
+				query: 'example',
+				provider: 'brave',
+				large_result_mode: 'inline',
+				quality_report: true,
+			}),
+		);
+		expect(reported.result).toEqual([
+			{
+				title: 'Example',
+				url: 'https://example.com',
+				snippet: 'Example result',
+				source_provider: 'brave',
+			},
+		]);
+		expect(reported.quality_report.adaptive_routing).toEqual(
+			expect.objectContaining({
+				scope: 'process_local',
+				reason: 'explicit_provider',
+				selected: 'brave',
+			}),
+		);
+		expect(JSON.stringify(reported)).not.toMatch(/api[_-]?key/i);
 
 		vi.stubGlobal(
 			'fetch',

--- a/src/server/tools/github-search.ts
+++ b/src/server/tools/github-search.ts
@@ -8,6 +8,7 @@ import { handle_tool_result } from './responses.js';
 import {
 	large_result_mode_schema,
 	limit_schema,
+	quality_report_schema,
 	query_schema,
 } from './schemas.js';
 
@@ -57,6 +58,7 @@ export const register_github_search = (
 						v.description('Sort order (repositories only)'),
 					),
 				),
+				quality_report: quality_report_schema,
 			}),
 		},
 		async ({
@@ -65,6 +67,7 @@ export const register_github_search = (
 			limit,
 			large_result_mode,
 			sort,
+			quality_report,
 		}) =>
 			handle_tool_result(
 				'github_search',
@@ -93,7 +96,14 @@ export const register_github_search = (
 							});
 					}
 				},
-				{ large_result_mode },
+				{
+					large_result_mode,
+					quality_report,
+					adaptive: {
+						provider: 'github',
+						candidates: ['github'],
+					},
+				},
 			),
 	);
 };

--- a/src/server/tools/responses.test.ts
+++ b/src/server/tools/responses.test.ts
@@ -1,4 +1,8 @@
 import { afterEach, describe, expect, it } from 'vitest';
+import {
+	get_provider_performance,
+	reset_adaptive_routing_for_tests,
+} from '../../common/adaptive-routing.js';
 import { ErrorType, ProviderError } from '../../common/types.js';
 import {
 	create_error_tool_response,
@@ -10,6 +14,7 @@ const original_large_result_mode =
 	process.env.OMNISEARCH_LARGE_RESULT_MODE;
 
 afterEach(() => {
+	reset_adaptive_routing_for_tests();
 	if (original_large_result_mode === undefined) {
 		delete process.env.OMNISEARCH_LARGE_RESULT_MODE;
 	} else {
@@ -93,6 +98,72 @@ describe('tool responses', () => {
 				},
 			],
 		});
+	});
+
+	it('keeps default payloads unchanged and records health locally', async () => {
+		const response = await handle_tool_result(
+			'web_search',
+			async () => [{ title: 'ok' }],
+			{
+				adaptive: {
+					provider: 'brave',
+					candidates: ['brave', 'tavily'],
+				},
+			},
+		);
+
+		expect(response).toEqual({
+			content: [
+				{
+					type: 'text',
+					text: JSON.stringify([{ title: 'ok' }], null, 2),
+				},
+			],
+		});
+		expect(get_provider_performance('brave').samples).toBe(1);
+	});
+
+	it('attaches a secret-free adaptive quality report when requested', async () => {
+		const response = await handle_tool_result(
+			'web_search',
+			async () => [{ title: 'ok' }],
+			{
+				quality_report: true,
+				adaptive: {
+					provider: 'brave',
+					candidates: ['brave', 'tavily'],
+				},
+			},
+		);
+		const body = JSON.parse(response.content[0].text);
+
+		expect(body.result).toEqual([{ title: 'ok' }]);
+		expect(body.quality_report.adaptive_routing).toEqual(
+			expect.objectContaining({
+				enabled: true,
+				scope: 'process_local',
+				applied: false,
+				reason: 'explicit_provider',
+				selected: 'brave',
+			}),
+		);
+		expect(JSON.stringify(body)).not.toMatch(/api[_-]?key/i);
+	});
+
+	it('does not record invalid input as provider health', async () => {
+		await handle_tool_result(
+			'web_extract',
+			async () => {
+				throw new ProviderError(
+					ErrorType.INVALID_INPUT,
+					'bad mode',
+					'web_extract',
+				);
+			},
+			{ adaptive: { provider: 'tavily' } },
+		);
+
+		expect(get_provider_performance('tavily').samples).toBe(0);
 	});
 
 	it('wraps thrown errors as MCP error responses', async () => {

--- a/src/server/tools/responses.ts
+++ b/src/server/tools/responses.ts
@@ -1,3 +1,7 @@
+import {
+	build_adaptive_quality_report,
+	record_tool_outcome,
+} from '../../common/adaptive-routing.js';
 import { create_error_response } from '../../common/errors.js';
 import {
 	handle_large_result,
@@ -18,22 +22,67 @@ export const create_error_tool_response = (error: Error) => ({
 	isError: true,
 });
 
+export interface AdaptiveToolOptions {
+	provider: string;
+	candidates?: readonly string[];
+	result_count?: (result: unknown) => number;
+}
+
 export interface ToolResultOptions {
 	large_result_mode?: LargeResultMode;
+	quality_report?: boolean;
+	adaptive?: AdaptiveToolOptions;
 }
+
+const attach_quality_report = (
+	payload: unknown,
+	options: ToolResultOptions,
+) => {
+	if (!options.quality_report) return payload;
+
+	const provider = options.adaptive?.provider;
+	const candidates =
+		options.adaptive?.candidates ?? (provider ? [provider] : []);
+
+	return {
+		result: payload,
+		quality_report: {
+			adaptive_routing: build_adaptive_quality_report({
+				candidates,
+				explicit_provider: provider,
+			}),
+		},
+	};
+};
 
 export const handle_tool_result = async <T>(
 	tool_name: string,
 	result: () => Promise<T>,
 	options: ToolResultOptions = {},
 ) => {
+	const started_at_ms = Date.now();
 	try {
+		const payload = await result();
+		record_tool_outcome({
+			provider: options.adaptive?.provider,
+			started_at_ms,
+			result: payload,
+			result_count: options.adaptive?.result_count,
+		});
 		return create_json_tool_response(
-			handle_large_result(await result(), tool_name, {
-				mode: options.large_result_mode,
-			}),
+			attach_quality_report(
+				handle_large_result(payload, tool_name, {
+					mode: options.large_result_mode,
+				}),
+				options,
+			),
 		);
 	} catch (error) {
+		record_tool_outcome({
+			provider: options.adaptive?.provider,
+			started_at_ms,
+			error,
+		});
 		return create_error_tool_response(error as Error);
 	}
 };

--- a/src/server/tools/schemas.test.ts
+++ b/src/server/tools/schemas.test.ts
@@ -6,6 +6,7 @@ import {
 	include_raw_contents_schema,
 	large_result_mode_schema,
 	limit_schema,
+	quality_report_schema,
 	query_schema,
 	url_or_urls_schema,
 } from './schemas.js';
@@ -45,6 +46,15 @@ describe('tool schemas', () => {
 		expect(
 			v.safeParse(include_raw_contents_schema, 'false').success,
 		).toBe(false);
+		expect(
+			v.safeParse(quality_report_schema, undefined).success,
+		).toBe(true);
+		expect(v.safeParse(quality_report_schema, true).success).toBe(
+			true,
+		);
+		expect(v.safeParse(quality_report_schema, 'true').success).toBe(
+			false,
+		);
 	});
 
 	it('accepts hostnames but rejects URLs as domain filters', () => {

--- a/src/server/tools/schemas.ts
+++ b/src/server/tools/schemas.ts
@@ -20,6 +20,15 @@ export const limit_schema = v.optional(
 	),
 );
 
+export const quality_report_schema = v.optional(
+	v.pipe(
+		v.boolean(),
+		v.description(
+			'When true, include a structured quality report with process-local adaptive routing adjustments. Default false. Never includes API keys or vendor error bodies.',
+		),
+	),
+);
+
 export const large_result_mode_schema = v.optional(
 	v.pipe(
 		v.picklist(['inline', 'file']),

--- a/src/server/tools/web-extract.ts
+++ b/src/server/tools/web-extract.ts
@@ -19,6 +19,7 @@ import { handle_tool_result } from './responses.js';
 import {
 	include_raw_contents_schema,
 	large_result_mode_schema,
+	quality_report_schema,
 	url_or_urls_schema,
 } from './schemas.js';
 
@@ -84,6 +85,7 @@ export const register_web_extract = (
 				),
 				large_result_mode: large_result_mode_schema,
 				include_raw_contents: include_raw_contents_schema,
+				quality_report: quality_report_schema,
 			}),
 		},
 		async ({
@@ -93,6 +95,7 @@ export const register_web_extract = (
 			extract_depth,
 			large_result_mode,
 			include_raw_contents = true,
+			quality_report,
 		}) =>
 			handle_tool_result(
 				'web_extract',
@@ -129,7 +132,14 @@ export const register_web_extract = (
 						? result
 						: omit_raw_contents(result);
 				},
-				{ large_result_mode },
+				{
+					large_result_mode,
+					quality_report,
+					adaptive: {
+						provider,
+						candidates: providers.names(),
+					},
+				},
 			),
 	);
 };

--- a/src/server/tools/web-search.ts
+++ b/src/server/tools/web-search.ts
@@ -13,6 +13,7 @@ import {
 	include_domains_schema,
 	large_result_mode_schema,
 	limit_schema,
+	quality_report_schema,
 	query_schema,
 } from './schemas.js';
 
@@ -58,6 +59,7 @@ export const register_web_search = (
 				include_domains: include_domains_schema,
 				exclude_domains: exclude_domains_schema,
 				large_result_mode: large_result_mode_schema,
+				quality_report: quality_report_schema,
 			}),
 		},
 		async ({
@@ -67,6 +69,7 @@ export const register_web_search = (
 			include_domains,
 			exclude_domains,
 			large_result_mode,
+			quality_report,
 		}) =>
 			handle_tool_result(
 				'web_search',
@@ -80,7 +83,14 @@ export const register_web_search = (
 						exclude_domains,
 					});
 				},
-				{ large_result_mode },
+				{
+					large_result_mode,
+					quality_report,
+					adaptive: {
+						provider,
+						candidates: providers.ids(),
+					},
+				},
 			),
 	);
 };


### PR DESCRIPTION
## Summary

Adds process-local adaptive routing from recent provider health so auto-routing can prefer engines that are working *today* without changing the explicit-provider default.

- Record latency / empty / error outcomes in a rolling window (last 50 calls, 7 days).
- Apply a bounded ±1.0 score adjustment so currently healthy providers win close calls.
- Never override an explicit `provider` or a strong query-class lead (margin ≥ 1.0).
- Disable with `OMNISEARCH_ADAPTIVE_ROUTING=off` (default on).
- Opt-in `quality_report: true` exposes adjustments; default payloads are unchanged.
- State is in-memory only. No API keys, queries, or vendor error bodies are stored or sent to vendors.

Fixes #201.

## Scope

- `src/common/adaptive-routing.ts` — window, scoring, apply/guard API
- Tool handlers record outcomes and attach the opt-in report
- Docs + `OMNISEARCH_ADAPTIVE_ROUTING` in README / provider-selection / deployment

No provider HTTP changes and no new vendor requests.

## Verification

```bash
pnpm test
pnpm run check
pnpm run build
```

All 128 tests passed, including guards for explicit provider, strong query-class, close-call flips, disable, and secret-free reports.

## Impact

- Non-breaking: `provider` remains required; default responses are unchanged.
- New optional `quality_report` flag on search/extract tools.
- New optional env var; unset keeps adaptive scoring enabled.