### PR TITLE
feat: add in-process search result cache with TTL

### DIFF
--- a/.changeset/search-result-cache.md
+++ b/.changeset/search-result-cache.md
@@ -1,0 +1,5 @@
+---
+'mcp-omnisearch': patch
+---
+
+feat: add in-process web_search result cache with configurable TTL

--- a/README.md
+++ b/README.md
@@ -84,6 +84,13 @@ Search the web with Tavily, Brave, Kagi, Exa, or Kagi Enrichment.
 }
 ```
 
+Identical `web_search` calls reuse an in-process cache keyed by
+normalized query, provider, limit, and domain filters. The default TTL
+is one hour. Pass `no_cache: true` (or set `OMNISEARCH_NO_CACHE=true`)
+to force a fresh vendor request. Cache write failures are ignored so
+search still returns. Partial multi-provider responses are never
+stored as complete answers.
+
 ### `ai_search`
 
 Get sourced AI answers with Kagi FastGPT, Exa Answer, or Linkup.
@@ -144,6 +151,10 @@ Tavily, Kagi, Firecrawl, or Exa.
 - `FIRECRAWL_API_KEY`
 - `FIRECRAWL_BASE_URL` optional, for self-hosted Firecrawl
 - `OMNISEARCH_LARGE_RESULT_MODE` optional, `file` default or `inline`
+- `OMNISEARCH_SEARCH_CACHE_TTL_MS` optional, default `3600000` (1
+  hour)
+- `OMNISEARCH_NO_CACHE` optional, `true`/`1`/`yes`/`on` bypasses the
+  search cache for every request
 
 ## Development
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -127,6 +127,8 @@ Container variables:
 - `LINKUP_API_KEY`
 - `FIRECRAWL_API_KEY`
 - `FIRECRAWL_BASE_URL`
+- `OMNISEARCH_SEARCH_CACHE_TTL_MS` optional, default `3600000`
+- `OMNISEARCH_NO_CACHE` optional, bypasses the in-process search cache
 - `PORT`, defaults to `8000`
 
 ## OpenAPI access

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -23,6 +23,7 @@ and configured providers remain available.
 | Request fails with unauthorized/forbidden | Invalid key or plan mismatch                              | Verify the key belongs to the provider and has access to the endpoint or plan tier.                                              |
 | Query rejected before provider call       | Invalid input                                             | Check for empty queries, unsupported modes, malformed domains, or unsupported URL protocols.                                     |
 | Repeated transient errors                 | Rate limits, timeout, network failure, or provider 5xx    | Retry later or lower request volume. Retryable failures are handled separately from invalid credentials and validation failures. |
+| Search results look stale                 | In-process cache hit within TTL                           | Pass `no_cache: true` or set `OMNISEARCH_NO_CACHE=true`. Restarting the server also clears the cache.                            |
 | Returned file path cannot be read         | Server wrote a temp file on a remote/container filesystem | Retry with `large_result_mode: "inline"` or set `OMNISEARCH_LARGE_RESULT_MODE=inline`.                                           |
 
 ## GitHub token setup

--- a/src/common/search-cache.test.ts
+++ b/src/common/search-cache.test.ts
@@ -1,0 +1,253 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+	build_search_cache_key,
+	cached_search,
+	is_complete_search_outcome,
+	is_search_cache_bypassed,
+	reset_default_search_cache,
+	SearchCache,
+} from './search-cache.js';
+import {
+	DEFAULT_SEARCH_CACHE_TTL_MS,
+	parse_search_cache_ttl_ms,
+} from '../config/env.js';
+
+afterEach(() => {
+	reset_default_search_cache();
+});
+
+describe('build_search_cache_key', () => {
+	it('normalizes query, provider, default limit, and domain order', () => {
+		expect(
+			build_search_cache_key({
+				query: '  Foo   Bar ',
+				provider: 'Brave',
+			}),
+		).toBe(
+			build_search_cache_key({
+				query: 'foo bar',
+				provider: 'brave',
+				limit: 10,
+				include_domains: [],
+				exclude_domains: [],
+			}),
+		);
+
+		expect(
+			build_search_cache_key({
+				query: 'q',
+				provider: 'brave',
+				include_domains: ['B.com', 'a.com'],
+				exclude_domains: ['Ads.example', 'spam.test'],
+			}),
+		).toBe(
+			build_search_cache_key({
+				query: 'q',
+				provider: 'brave',
+				include_domains: ['a.com', 'b.com'],
+				exclude_domains: ['spam.test', 'ads.example'],
+			}),
+		);
+	});
+
+	it('changes the key when provider, limit, or filters differ', () => {
+		const base = {
+			query: 'sveltekit',
+			provider: 'brave',
+			limit: 5,
+		};
+
+		expect(build_search_cache_key(base)).not.toBe(
+			build_search_cache_key({ ...base, provider: 'tavily' }),
+		);
+		expect(build_search_cache_key(base)).not.toBe(
+			build_search_cache_key({ ...base, limit: 10 }),
+		);
+		expect(build_search_cache_key(base)).not.toBe(
+			build_search_cache_key({
+				...base,
+				include_domains: ['svelte.dev'],
+			}),
+		);
+		expect(build_search_cache_key(base)).not.toBe(
+			build_search_cache_key({
+				...base,
+				filters: { freshness: 'week' },
+			}),
+		);
+	});
+});
+
+describe('SearchCache', () => {
+	it('returns a cloned hit within TTL and misses after expiry', () => {
+		let now = 1_000;
+		const cache = new SearchCache<{ title: string }[]>({
+			ttl_ms: 1_000,
+			now: () => now,
+		});
+		const stored = [{ title: 'Example' }];
+
+		expect(cache.set('k', stored)).toBe(true);
+		stored[0].title = 'mutated';
+
+		const hit = cache.get('k');
+		expect(hit).toEqual([{ title: 'Example' }]);
+		if (hit) hit[0].title = 'caller-mutated';
+		expect(cache.get('k')).toEqual([{ title: 'Example' }]);
+
+		now = 2_001;
+		expect(cache.get('k')).toBeUndefined();
+	});
+
+	it('does not store incomplete multi-provider results as complete', () => {
+		const cache = new SearchCache();
+		const partial = [{ title: 'partial', url: 'https://x.test' }];
+
+		expect(
+			is_complete_search_outcome({
+				failed_providers: ['exa'],
+			}),
+		).toBe(false);
+		expect(
+			is_complete_search_outcome({
+				selected_providers: ['brave', 'exa'],
+				succeeded_providers: ['brave'],
+			}),
+		).toBe(false);
+		expect(
+			is_complete_search_outcome({
+				failed_providers: [],
+				complete: true,
+			}),
+		).toBe(true);
+		expect(is_complete_search_outcome()).toBe(true);
+
+		expect(cache.set('partial', partial, { complete: false })).toBe(
+			false,
+		);
+		expect(cache.get('partial')).toBeUndefined();
+	});
+
+	it('treats cache write failures as non-fatal', () => {
+		const cache = new SearchCache({
+			store: {
+				get: () => {
+					throw new Error('read failed');
+				},
+				set: () => {
+					throw new Error('disk full');
+				},
+			},
+		});
+
+		expect(cache.set('k', [{ title: 'x' }])).toBe(false);
+		expect(cache.get('k')).toBeUndefined();
+	});
+});
+
+describe('cached_search', () => {
+	it('reuses complete results and honors no_cache plus env bypass', async () => {
+		const cache = new SearchCache<string>();
+		let calls = 0;
+		const load = async () => {
+			calls += 1;
+			return `result-${calls}`;
+		};
+		const key = { query: 'Example Query', provider: 'Brave' };
+
+		expect(await cached_search(key, load, { cache })).toBe(
+			'result-1',
+		);
+		expect(
+			await cached_search(
+				{ query: 'example query', provider: 'brave' },
+				load,
+				{ cache },
+			),
+		).toBe('result-1');
+		expect(calls).toBe(1);
+
+		expect(
+			await cached_search(key, load, { cache, no_cache: true }),
+		).toBe('result-2');
+		expect(calls).toBe(2);
+
+		expect(
+			is_search_cache_bypassed(false, {
+				OMNISEARCH_NO_CACHE: 'true',
+			}),
+		).toBe(true);
+		expect(
+			await cached_search(key, load, {
+				cache,
+				env: { OMNISEARCH_NO_CACHE: '1' },
+			}),
+		).toBe('result-3');
+		expect(calls).toBe(3);
+	});
+
+	it('does not cache a partial multi-provider load as a complete hit', async () => {
+		const cache = new SearchCache<{
+			results: string[];
+			failed_providers: string[];
+		}>();
+		let calls = 0;
+		const load = async () => {
+			calls += 1;
+			return {
+				results: ['brave-hit'],
+				failed_providers: ['exa'],
+			};
+		};
+
+		const first = await cached_search(
+			{ query: 'q', provider: 'multi' },
+			load,
+			{
+				cache,
+				complete: (value) => is_complete_search_outcome(value),
+			},
+		);
+		const second = await cached_search(
+			{ query: 'q', provider: 'multi' },
+			load,
+			{
+				cache,
+				complete: (value) => is_complete_search_outcome(value),
+			},
+		);
+
+		expect(first.results).toEqual(['brave-hit']);
+		expect(second.results).toEqual(['brave-hit']);
+		expect(calls).toBe(2);
+	});
+});
+
+describe('search cache env', () => {
+	it('defaults TTL to one hour and accepts a valid override', () => {
+		expect(parse_search_cache_ttl_ms({})).toBe(
+			DEFAULT_SEARCH_CACHE_TTL_MS,
+		);
+		expect(DEFAULT_SEARCH_CACHE_TTL_MS).toBe(60 * 60 * 1000);
+		expect(
+			parse_search_cache_ttl_ms({
+				OMNISEARCH_SEARCH_CACHE_TTL_MS: '120000',
+			}),
+		).toBe(120000);
+		expect(
+			parse_search_cache_ttl_ms({
+				OMNISEARCH_SEARCH_CACHE_TTL_MS: 'nope',
+			}),
+		).toBe(DEFAULT_SEARCH_CACHE_TTL_MS);
+		expect(
+			parse_search_cache_ttl_ms({
+				OMNISEARCH_SEARCH_CACHE_TTL_MS: '-1',
+			}),
+		).toBe(DEFAULT_SEARCH_CACHE_TTL_MS);
+		expect(
+			is_search_cache_bypassed(false, {
+				OMNISEARCH_NO_CACHE: 'off',
+			}),
+		).toBe(false);
+	});
+});

--- a/src/common/search-cache.ts
+++ b/src/common/search-cache.ts
@@ -1,0 +1,228 @@
+import {
+	is_search_cache_disabled,
+	parse_search_cache_ttl_ms,
+} from '../config/env.js';
+
+export const DEFAULT_SEARCH_LIMIT = 10;
+
+export interface SearchCacheKeyParts {
+	query: string;
+	provider: string;
+	limit?: number;
+	include_domains?: string[];
+	exclude_domains?: string[];
+	filters?: Record<string, unknown>;
+}
+
+export interface SearchCacheRecord<T> {
+	value: T;
+	expires_at: number;
+}
+
+export interface SearchCacheStore<T> {
+	get(key: string): SearchCacheRecord<T> | undefined;
+	set(key: string, record: SearchCacheRecord<T>): void;
+	delete?(key: string): void;
+}
+
+export interface SearchCacheOptions<T> {
+	ttl_ms?: number;
+	now?: () => number;
+	store?: SearchCacheStore<T>;
+	clone?: (value: T) => T;
+}
+
+export interface SearchCacheSetOptions {
+	// Incomplete multi-provider responses must not be stored
+	// as if they were a full answer.
+	complete?: boolean;
+}
+
+export interface MultiProviderSearchOutcome {
+	complete?: boolean;
+	failed_providers?: string[];
+	succeeded_providers?: string[];
+	selected_providers?: string[];
+}
+
+export interface CachedSearchOptions<T> {
+	no_cache?: boolean;
+	env?: NodeJS.ProcessEnv;
+	cache?: SearchCache<T>;
+	complete?: boolean | ((value: T) => boolean);
+}
+
+const clone_value = <T>(value: T): T => {
+	if (typeof structuredClone === 'function') {
+		return structuredClone(value);
+	}
+
+	return JSON.parse(JSON.stringify(value)) as T;
+};
+
+const normalize_query = (query: string): string =>
+	query.trim().replace(/\s+/g, ' ').toLowerCase();
+
+const normalize_domain_list = (domains?: string[]): string[] => {
+	if (!domains?.length) return [];
+
+	return [
+		...new Set(
+			domains
+				.map((domain) => domain.trim().toLowerCase())
+				.filter(Boolean),
+		),
+	].sort();
+};
+
+const normalize_filters = (
+	filters?: Record<string, unknown>,
+): Record<string, unknown> | undefined => {
+	if (!filters) return undefined;
+
+	const entries = Object.entries(filters)
+		.filter(([, value]) => value !== undefined)
+		.sort(([left], [right]) => left.localeCompare(right));
+
+	if (entries.length === 0) return undefined;
+
+	return Object.fromEntries(entries);
+};
+
+export const build_search_cache_key = (
+	parts: SearchCacheKeyParts,
+): string =>
+	JSON.stringify({
+		query: normalize_query(parts.query),
+		provider: parts.provider.trim().toLowerCase(),
+		limit: parts.limit ?? DEFAULT_SEARCH_LIMIT,
+		include_domains: normalize_domain_list(parts.include_domains),
+		exclude_domains: normalize_domain_list(parts.exclude_domains),
+		filters: normalize_filters(parts.filters),
+	});
+
+export const is_complete_search_outcome = (
+	outcome?: MultiProviderSearchOutcome,
+): boolean => {
+	if (!outcome) return true;
+	if (outcome.complete === false) return false;
+	if ((outcome.failed_providers?.length ?? 0) > 0) return false;
+
+	const selected = outcome.selected_providers;
+	const succeeded = outcome.succeeded_providers;
+	if (selected && succeeded && selected.length !== succeeded.length) {
+		return false;
+	}
+
+	return true;
+};
+
+export const is_search_cache_bypassed = (
+	no_cache = false,
+	env: NodeJS.ProcessEnv = process.env,
+): boolean => no_cache === true || is_search_cache_disabled(env);
+
+class MemorySearchCacheStore<T> implements SearchCacheStore<T> {
+	private readonly records = new Map<string, SearchCacheRecord<T>>();
+
+	get(key: string) {
+		return this.records.get(key);
+	}
+
+	set(key: string, record: SearchCacheRecord<T>) {
+		this.records.set(key, record);
+	}
+
+	delete(key: string) {
+		this.records.delete(key);
+	}
+}
+
+export class SearchCache<T = unknown> {
+	private readonly ttl_ms: number;
+	private readonly now: () => number;
+	private readonly store: SearchCacheStore<T>;
+	private readonly clone: (value: T) => T;
+
+	constructor(options: SearchCacheOptions<T> = {}) {
+		this.ttl_ms = options.ttl_ms ?? parse_search_cache_ttl_ms();
+		this.now = options.now ?? Date.now;
+		this.store = options.store ?? new MemorySearchCacheStore<T>();
+		this.clone = options.clone ?? clone_value;
+	}
+
+	get(key: string): T | undefined {
+		try {
+			const record = this.store.get(key);
+			if (!record) return undefined;
+
+			if (record.expires_at <= this.now()) {
+				this.store.delete?.(key);
+				return undefined;
+			}
+
+			return this.clone(record.value);
+		} catch {
+			return undefined;
+		}
+	}
+
+	set(
+		key: string,
+		value: T,
+		options: SearchCacheSetOptions = {},
+	): boolean {
+		if (options.complete === false) return false;
+
+		try {
+			this.store.set(key, {
+				value: this.clone(value),
+				expires_at: this.now() + this.ttl_ms,
+			});
+			return true;
+		} catch {
+			return false;
+		}
+	}
+}
+
+let default_search_cache: SearchCache<unknown> | undefined;
+
+export const get_default_search_cache = <T>(
+	env: NodeJS.ProcessEnv = process.env,
+): SearchCache<T> => {
+	default_search_cache ??= new SearchCache({
+		ttl_ms: parse_search_cache_ttl_ms(env),
+	});
+	return default_search_cache as SearchCache<T>;
+};
+
+export const reset_default_search_cache = () => {
+	default_search_cache = undefined;
+};
+
+export const cached_search = async <T>(
+	key_parts: SearchCacheKeyParts,
+	load: () => Promise<T>,
+	options: CachedSearchOptions<T> = {},
+): Promise<T> => {
+	const env = options.env ?? process.env;
+	const cache = options.cache ?? get_default_search_cache<T>(env);
+
+	if (is_search_cache_bypassed(options.no_cache, env)) {
+		return load();
+	}
+
+	const key = build_search_cache_key(key_parts);
+	const hit = cache.get(key);
+	if (hit !== undefined) return hit;
+
+	const value = await load();
+	const complete =
+		typeof options.complete === 'function'
+			? options.complete(value)
+			: (options.complete ?? true);
+
+	cache.set(key, value, { complete });
+	return value;
+};

--- a/src/config/env.test.ts
+++ b/src/config/env.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
+	DEFAULT_SEARCH_CACHE_TTL_MS,
+	is_search_cache_disabled,
+	parse_search_cache_ttl_ms,
 	should_warn_for_local_file_offload,
 	warn_for_local_file_offload,
 } from './env.js';
@@ -35,6 +38,25 @@ describe('large-result local file offload warnings', () => {
 			should_warn_for_local_file_offload({
 				OMNISEARCH_LARGE_RESULT_MODE: 'file',
 			}),
+		).toBe(false);
+	});
+});
+
+describe('search cache environment', () => {
+	it('parses TTL overrides and no_cache bypass flags', () => {
+		expect(parse_search_cache_ttl_ms({})).toBe(
+			DEFAULT_SEARCH_CACHE_TTL_MS,
+		);
+		expect(
+			parse_search_cache_ttl_ms({
+				OMNISEARCH_SEARCH_CACHE_TTL_MS: '0',
+			}),
+		).toBe(0);
+		expect(
+			is_search_cache_disabled({ OMNISEARCH_NO_CACHE: 'yes' }),
+		).toBe(true);
+		expect(
+			is_search_cache_disabled({ OMNISEARCH_NO_CACHE: 'false' }),
 		).toBe(false);
 	});
 });

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -198,3 +198,30 @@ export const validate_config = () => {
 
 	warn_for_local_file_offload();
 };
+
+export const DEFAULT_SEARCH_CACHE_TTL_MS = 60 * 60 * 1000;
+
+const truthy_env_values = new Set(['1', 'true', 'yes', 'on']);
+
+export const parse_search_cache_ttl_ms = (
+	env: NodeJS.ProcessEnv = process.env,
+): number => {
+	const raw = env.OMNISEARCH_SEARCH_CACHE_TTL_MS;
+	if (raw === undefined || raw.trim() === '') {
+		return DEFAULT_SEARCH_CACHE_TTL_MS;
+	}
+
+	const parsed = Number(raw);
+	if (!Number.isFinite(parsed) || parsed < 0) {
+		return DEFAULT_SEARCH_CACHE_TTL_MS;
+	}
+
+	return parsed;
+};
+
+export const is_search_cache_disabled = (
+	env: NodeJS.ProcessEnv = process.env,
+): boolean => {
+	const raw = env.OMNISEARCH_NO_CACHE?.trim().toLowerCase();
+	return raw !== undefined && truthy_env_values.has(raw);
+};

--- a/src/server/tools/contract.test.ts
+++ b/src/server/tools/contract.test.ts
@@ -152,6 +152,20 @@ describe('MCP tool contract', () => {
 			v.safeParse(schema, { query: 'test', provider: 'kagi' })
 				.success,
 		).toBe(false);
+		expect(
+			v.safeParse(schema, {
+				query: 'test',
+				provider: 'brave',
+				no_cache: true,
+			}).success,
+		).toBe(true);
+		expect(
+			v.safeParse(schema, {
+				query: 'test',
+				provider: 'brave',
+				no_cache: 'yes',
+			}).success,
+		).toBe(false);
 	});
 
 	it('validates public web_extract payloads and unavailable modes at the MCP layer', async () => {
@@ -250,7 +264,7 @@ describe('MCP tool contract', () => {
 				.mockResolvedValue(new Response('nope', { status: 401 })),
 		);
 		const failure = await tool.handler({
-			query: 'example',
+			query: 'unauthorized example',
 			provider: 'brave',
 		});
 
@@ -261,6 +275,57 @@ describe('MCP tool contract', () => {
 			provider: 'brave',
 			retryable: false,
 		});
+	});
+
+	it('reuses cached web_search results and honors no_cache', async () => {
+		const { tools } = await load_contract({
+			BRAVE_API_KEY: 'brave-key',
+		});
+		const tool = tools.find(
+			(entry) => entry.definition.name === 'web_search',
+		)!;
+		const brave_body = {
+			web: {
+				results: [
+					{
+						title: 'Cached',
+						url: 'https://example.com',
+						description: 'Cached result',
+					},
+				],
+			},
+		};
+		const fetch_mock = vi
+			.fn()
+			.mockResolvedValue(
+				new Response(JSON.stringify(brave_body), { status: 200 }),
+			);
+		vi.stubGlobal('fetch', fetch_mock);
+
+		const first = await tool.handler({
+			query: 'Example Query',
+			provider: 'brave',
+			limit: 5,
+			large_result_mode: 'inline',
+		});
+		const second = await tool.handler({
+			query: 'example query',
+			provider: 'brave',
+			limit: 5,
+			large_result_mode: 'inline',
+		});
+
+		expect(parse_tool_body(first)).toEqual(parse_tool_body(second));
+		expect(fetch_mock).toHaveBeenCalledTimes(1);
+
+		await tool.handler({
+			query: 'example query',
+			provider: 'brave',
+			limit: 5,
+			no_cache: true,
+			large_result_mode: 'inline',
+		});
+		expect(fetch_mock).toHaveBeenCalledTimes(2);
 	});
 
 	it('covers large-result inline/file modes and compact extraction at the MCP layer', async () => {

--- a/src/server/tools/schemas.test.ts
+++ b/src/server/tools/schemas.test.ts
@@ -6,6 +6,7 @@ import {
 	include_raw_contents_schema,
 	large_result_mode_schema,
 	limit_schema,
+	no_cache_schema,
 	query_schema,
 	url_or_urls_schema,
 } from './schemas.js';
@@ -45,6 +46,11 @@ describe('tool schemas', () => {
 		expect(
 			v.safeParse(include_raw_contents_schema, 'false').success,
 		).toBe(false);
+		expect(v.safeParse(no_cache_schema, undefined).success).toBe(
+			true,
+		);
+		expect(v.safeParse(no_cache_schema, true).success).toBe(true);
+		expect(v.safeParse(no_cache_schema, 'true').success).toBe(false);
 	});
 
 	it('accepts hostnames but rejects URLs as domain filters', () => {

--- a/src/server/tools/schemas.ts
+++ b/src/server/tools/schemas.ts
@@ -59,6 +59,15 @@ export const exclude_domains_schema = v.optional(
 	),
 );
 
+export const no_cache_schema = v.optional(
+	v.pipe(
+		v.boolean(),
+		v.description(
+			'Bypass the search result cache and fetch fresh results from the provider',
+		),
+	),
+);
+
 export const http_url_schema = v.pipe(
 	v.string(),
 	v.url('URL must be valid'),

--- a/src/server/tools/web-search.ts
+++ b/src/server/tools/web-search.ts
@@ -1,6 +1,7 @@
 import { McpServer } from 'tmcp';
 import type { GenericSchema } from 'valibot';
 import * as v from 'valibot';
+import { cached_search } from '../../common/search-cache.js';
 import { SearchProvider } from '../../common/types.js';
 import {
 	web_search_provider_definitions,
@@ -13,6 +14,7 @@ import {
 	include_domains_schema,
 	large_result_mode_schema,
 	limit_schema,
+	no_cache_schema,
 	query_schema,
 } from './schemas.js';
 
@@ -58,6 +60,7 @@ export const register_web_search = (
 				include_domains: include_domains_schema,
 				exclude_domains: exclude_domains_schema,
 				large_result_mode: large_result_mode_schema,
+				no_cache: no_cache_schema,
 			}),
 		},
 		async ({
@@ -67,18 +70,30 @@ export const register_web_search = (
 			include_domains,
 			exclude_domains,
 			large_result_mode,
+			no_cache,
 		}) =>
 			handle_tool_result(
 				'web_search',
 				async () => {
 					const selected = providers.require(provider, 'web_search');
 
-					return selected.search({
-						query,
-						limit,
-						include_domains,
-						exclude_domains,
-					});
+					return cached_search(
+						{
+							query,
+							provider,
+							limit,
+							include_domains,
+							exclude_domains,
+						},
+						() =>
+							selected.search({
+								query,
+								limit,
+								include_domains,
+								exclude_domains,
+							}),
+						{ no_cache },
+					);
 				},
 				{ large_result_mode },
 			),


### PR DESCRIPTION
## Summary

Adds an in-process `web_search` cache so identical agent retries do not re-bill the vendor. Results are keyed by normalized query, provider, limit, and domain filters, with a one-hour default TTL.

Fixes #193.

## Scope

- `src/common/search-cache.ts` — TTL cache, key normalization, non-fatal writes, and a `complete` guard so partial multi-provider outcomes are not stored as full answers
- `web_search` `no_cache` flag plus `OMNISEARCH_NO_CACHE` / `OMNISEARCH_SEARCH_CACHE_TTL_MS`
- Docs, changeset, and unit/contract tests only for this path

## Verification

```bash
pnpm test
pnpm run check
pnpm run build
```

- 118 tests passed
- format / lint / typecheck / advisory check passed
- build succeeded

Example: two identical `web_search` calls (`query` + `provider` + `limit` + filters) hit the vendor once; `no_cache: true` forces a second live call.

## Impact

- Non-breaking. Cache is enabled by default for complete single-provider `web_search` results.
- In-process only (cleared on process restart). Write failures never fail the search.
- Partial multi-provider responses are not cached as complete. Current `web_search` is still single-provider; the guard is in place for later fan-out work.
- No new API keys.