### PR TITLE
Add cross-provider failover and cooldown after 429/outage

### DIFF
--- a/.changeset/failover-after-429.md
+++ b/.changeset/failover-after-429.md
@@ -1,0 +1,5 @@
+---
+'mcp-omnisearch': patch
+---
+
+feat: fail over auto-routed search after retryable 429/outage errors

--- a/README.md
+++ b/README.md
@@ -74,7 +74,9 @@ working.
 
 ### `web_search`
 
-Search the web with Tavily, Brave, Kagi, Exa, or Kagi Enrichment.
+Search the web with Tavily, Brave, Kagi, Exa, or Kagi Enrichment. Omit
+`provider` to auto-route with retry-then-failover. An explicit
+`provider` is forced and fails hard if that engine is down.
 
 ```json
 {
@@ -87,6 +89,8 @@ Search the web with Tavily, Brave, Kagi, Exa, or Kagi Enrichment.
 ### `ai_search`
 
 Get sourced AI answers with Kagi FastGPT, Exa Answer, or Linkup.
+`provider` is optional; omitting it auto-routes with the same
+fail-hard rule for an explicit provider.
 
 ```json
 {

--- a/docs/provider-selection.md
+++ b/docs/provider-selection.md
@@ -33,6 +33,26 @@ Use a GitHub personal access token with no scopes selected for public
 search only. See
 [troubleshooting](troubleshooting.md#github-token-setup).
 
+## Auto-route and failover
+
+`web_search` and `ai_search` accept an optional `provider`.
+
+- **Omit `provider`** to auto-route across configured providers in
+  registration order. On transient 429, 503, timeout, or billing
+  suspension, the server retries that provider with
+  `retry_with_backoff`, then fails over to the next eligible provider.
+  Repeated failures cool the failing provider down locally for 1m,
+  then 5m, 25m, and 1h. Auto-route responses use
+  `{ results, metadata }` so skip reasons (`cooldown`, `quota`,
+  `timeout`) are visible. The server never invents results if every
+  provider fails.
+- **Set `provider`** to force that engine. Explicit providers fail
+  hard: no failover to another engine. A forced call still records
+  cooldown so later auto-routed calls can skip the unhealthy provider.
+
+Cooldown is process-local in-memory state. It resets when the MCP
+server restarts.
+
 ## Processing providers
 
 | Provider    | API key             | Modes                                          | Best for                                                                   |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -17,13 +17,13 @@ and configured providers remain available.
 
 ## Common failure modes
 
-| Symptom                                   | Likely cause                                              | Fix                                                                                                                              |
-| ----------------------------------------- | --------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| Provider is unavailable                   | Missing API key                                           | Set the provider key and restart the MCP server. Check `omnisearch://providers/status`.                                          |
-| Request fails with unauthorized/forbidden | Invalid key or plan mismatch                              | Verify the key belongs to the provider and has access to the endpoint or plan tier.                                              |
-| Query rejected before provider call       | Invalid input                                             | Check for empty queries, unsupported modes, malformed domains, or unsupported URL protocols.                                     |
-| Repeated transient errors                 | Rate limits, timeout, network failure, or provider 5xx    | Retry later or lower request volume. Retryable failures are handled separately from invalid credentials and validation failures. |
-| Returned file path cannot be read         | Server wrote a temp file on a remote/container filesystem | Retry with `large_result_mode: "inline"` or set `OMNISEARCH_LARGE_RESULT_MODE=inline`.                                           |
+| Symptom                                   | Likely cause                                              | Fix                                                                                                                                                                           |
+| ----------------------------------------- | --------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Provider is unavailable                   | Missing API key                                           | Set the provider key and restart the MCP server. Check `omnisearch://providers/status`.                                                                                       |
+| Request fails with unauthorized/forbidden | Invalid key or plan mismatch                              | Verify the key belongs to the provider and has access to the endpoint or plan tier.                                                                                           |
+| Query rejected before provider call       | Invalid input                                             | Check for empty queries, unsupported modes, malformed domains, or unsupported URL protocols.                                                                                  |
+| Repeated transient errors                 | Rate limits, timeout, network failure, or provider 5xx    | Omit `provider` so auto-route can fail over after `retry_with_backoff`. A dead provider is cooled down locally (1m / 5m / 25m / 1h). An explicit `provider` still fails hard. |
+| Returned file path cannot be read         | Server wrote a temp file on a remote/container filesystem | Retry with `large_result_mode: "inline"` or set `OMNISEARCH_LARGE_RESULT_MODE=inline`.                                                                                        |
 
 ## GitHub token setup
 
@@ -54,6 +54,13 @@ Each provider has its own limits. MCP Omnisearch formats provider
 rate-limit errors and retries only retryable classes such as 429,
 timeouts, network failures, and 5xx responses. Invalid credentials and
 validation failures are not retried.
+
+When `provider` is omitted, a provider that still fails after
+`retry_with_backoff` is skipped and the next configured search
+provider is tried. Skip reasons appear in response metadata as
+`cooldown`, `quota`, or `timeout`. If every provider fails, the tool
+returns an error and does not invent results. An explicit `provider`
+does not fail over.
 
 ## Large result paths
 

--- a/src/common/errors.test.ts
+++ b/src/common/errors.test.ts
@@ -78,6 +78,26 @@ describe('create_error_response', () => {
 		});
 	});
 
+	it('includes skipped provider metadata when present', () => {
+		const error = new ProviderError(
+			ErrorType.RATE_LIMIT,
+			'All search providers failed. Skipped: tavily (quota). No results invented.',
+			'web_search',
+			{
+				retryable: false,
+				skipped_providers: [{ provider: 'tavily', reason: 'quota' }],
+			},
+		);
+
+		expect(create_error_response(error)).toEqual({
+			error: error.message,
+			type: ErrorType.RATE_LIMIT,
+			provider: 'web_search',
+			retryable: false,
+			skipped_providers: [{ provider: 'tavily', reason: 'quota' }],
+		});
+	});
+
 	it('formats generic errors as unexpected errors', () => {
 		expect(create_error_response(new Error('unexpected'))).toEqual({
 			error: 'Unexpected error: unexpected',

--- a/src/common/errors.ts
+++ b/src/common/errors.ts
@@ -104,11 +104,15 @@ export const sanitize_query = (query: string): string => {
 
 export const create_error_response = (error: Error) => {
 	if (error instanceof ProviderError) {
+		const skipped_providers = error.details?.skipped_providers;
 		return {
 			error: error.message,
 			type: error.type,
 			provider: error.provider,
 			retryable: error.details?.retryable ?? false,
+			...(Array.isArray(skipped_providers)
+				? { skipped_providers }
+				: {}),
 		};
 	}
 	return {

--- a/src/common/provider-failover.test.ts
+++ b/src/common/provider-failover.test.ts
@@ -1,0 +1,196 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { run_with_provider_failover } from './provider-failover.js';
+import { ProviderHealthTracker } from './provider-health.js';
+import { ErrorType, ProviderError } from './types.js';
+
+afterEach(() => {
+	vi.useRealTimers();
+	vi.restoreAllMocks();
+});
+
+const rate_limit = (provider: string) =>
+	new ProviderError(ErrorType.RATE_LIMIT, 'slow down', provider, {
+		status: 429,
+		retryable: true,
+	});
+
+describe('run_with_provider_failover', () => {
+	it('retries a transient failure then returns that provider', async () => {
+		vi.useFakeTimers();
+		const first = vi
+			.fn<() => Promise<string>>()
+			.mockRejectedValueOnce(rate_limit('tavily'))
+			.mockResolvedValueOnce('tavily-ok');
+
+		const promise = run_with_provider_failover(
+			[
+				{ id: 'tavily', run: first },
+				{ id: 'exa', run: vi.fn() },
+			],
+			{
+				retry: {
+					max_retries: 2,
+					initial_delay: 50,
+					jitter_ratio: 0,
+				},
+			},
+		);
+
+		await vi.advanceTimersByTimeAsync(50);
+		await expect(promise).resolves.toEqual({
+			value: 'tavily-ok',
+			provider: 'tavily',
+			skipped: [],
+		});
+		expect(first).toHaveBeenCalledTimes(2);
+	});
+
+	it('fails over after retries and records skip metadata', async () => {
+		vi.useFakeTimers();
+		vi.spyOn(console, 'error').mockImplementation(() => {});
+		const tavily = vi
+			.fn<() => Promise<string>>()
+			.mockRejectedValue(rate_limit('tavily'));
+		const exa = vi
+			.fn<() => Promise<string>>()
+			.mockResolvedValue('exa-ok');
+
+		const promise = run_with_provider_failover(
+			[
+				{ id: 'tavily', run: tavily },
+				{ id: 'exa', run: exa },
+			],
+			{
+				retry: {
+					max_retries: 1,
+					initial_delay: 25,
+					jitter_ratio: 0,
+				},
+			},
+		);
+
+		await vi.advanceTimersByTimeAsync(25);
+		await expect(promise).resolves.toEqual({
+			value: 'exa-ok',
+			provider: 'exa',
+			skipped: [{ provider: 'tavily', reason: 'quota' }],
+		});
+		expect(tavily).toHaveBeenCalledTimes(2);
+		expect(exa).toHaveBeenCalledTimes(1);
+	});
+
+	it('skips providers already in cooldown', async () => {
+		const health = new ProviderHealthTracker({ now: () => 0 });
+		health.record_failure('tavily', rate_limit('tavily'));
+		const tavily = vi.fn<() => Promise<string>>();
+		const exa = vi
+			.fn<() => Promise<string>>()
+			.mockResolvedValue('exa-ok');
+
+		await expect(
+			run_with_provider_failover(
+				[
+					{ id: 'tavily', run: tavily },
+					{ id: 'exa', run: exa },
+				],
+				{ health, retry: { max_retries: 0 } },
+			),
+		).resolves.toEqual({
+			value: 'exa-ok',
+			provider: 'exa',
+			skipped: [{ provider: 'tavily', reason: 'cooldown' }],
+		});
+		expect(tavily).not.toHaveBeenCalled();
+	});
+
+	it('does not invent results when every provider fails', async () => {
+		vi.spyOn(console, 'error').mockImplementation(() => {});
+		const health = new ProviderHealthTracker({ now: () => 0 });
+
+		await expect(
+			run_with_provider_failover(
+				[
+					{
+						id: 'tavily',
+						run: async () => {
+							throw rate_limit('tavily');
+						},
+					},
+					{
+						id: 'exa',
+						run: async () => {
+							throw new ProviderError(
+								ErrorType.TIMEOUT,
+								'timed out',
+								'exa',
+							);
+						},
+					},
+				],
+				{
+					health,
+					tool_name: 'web_search',
+					retry: { max_retries: 0 },
+				},
+			),
+		).rejects.toMatchObject({
+			name: 'ProviderError',
+			provider: 'web_search',
+			message: expect.stringContaining('No results invented'),
+			details: {
+				retryable: false,
+				skipped_providers: [
+					{ provider: 'tavily', reason: 'quota' },
+					{ provider: 'exa', reason: 'timeout' },
+				],
+				cause: 'timed out',
+			},
+		});
+		expect(health.is_cooling_down('tavily')).toBe(true);
+		expect(health.is_cooling_down('exa')).toBe(true);
+	});
+
+	it('does not fail over invalid input errors', async () => {
+		const error = new ProviderError(
+			ErrorType.INVALID_INPUT,
+			'bad query',
+			'tavily',
+		);
+		const exa = vi.fn<() => Promise<string>>();
+
+		await expect(
+			run_with_provider_failover(
+				[
+					{
+						id: 'tavily',
+						run: async () => {
+							throw error;
+						},
+					},
+					{ id: 'exa', run: exa },
+				],
+				{ retry: { max_retries: 0 } },
+			),
+		).rejects.toBe(error);
+		expect(exa).not.toHaveBeenCalled();
+	});
+
+	it('treats empty provider results as success', async () => {
+		const exa = vi.fn<() => Promise<string[]>>();
+
+		await expect(
+			run_with_provider_failover(
+				[
+					{ id: 'tavily', run: async () => [] },
+					{ id: 'exa', run: exa },
+				],
+				{ retry: { max_retries: 0 } },
+			),
+		).resolves.toEqual({
+			value: [],
+			provider: 'tavily',
+			skipped: [],
+		});
+		expect(exa).not.toHaveBeenCalled();
+	});
+});

--- a/src/common/provider-failover.ts
+++ b/src/common/provider-failover.ts
@@ -1,0 +1,141 @@
+import {
+	ProviderHealthTracker,
+	skip_reason_from_error,
+	type ProviderSkipReason,
+} from './provider-health.js';
+import {
+	is_retryable_error,
+	retry_with_backoff,
+	type RetryOptions,
+} from './retry.js';
+import { ErrorType, ProviderError } from './types.js';
+
+export interface ProviderAttempt<T> {
+	id: string;
+	run: () => Promise<T>;
+}
+
+export interface SkippedProvider {
+	provider: string;
+	reason: ProviderSkipReason;
+}
+
+export interface FailoverSuccess<T> {
+	value: T;
+	provider: string;
+	skipped: SkippedProvider[];
+}
+
+export interface AutoRouteResult<T> {
+	results: T;
+	metadata: {
+		used_provider: string;
+		skipped_providers: SkippedProvider[];
+	};
+}
+
+export interface FailoverOptions {
+	health?: ProviderHealthTracker;
+	retry?: RetryOptions;
+	tool_name?: string;
+}
+
+export const is_failover_eligible = (error: unknown): boolean => {
+	if (
+		error instanceof ProviderError &&
+		error.type === ErrorType.INVALID_INPUT
+	) {
+		return false;
+	}
+
+	return (
+		is_retryable_error(error) ||
+		(error instanceof ProviderError &&
+			error.type === ErrorType.AUTH_ERROR)
+	);
+};
+
+export const to_auto_route_result = <T>(
+	outcome: FailoverSuccess<T>,
+): AutoRouteResult<T> => ({
+	results: outcome.value,
+	metadata: {
+		used_provider: outcome.provider,
+		skipped_providers: outcome.skipped,
+	},
+});
+
+export const run_with_provider_failover = async <T>(
+	attempts: readonly ProviderAttempt<T>[],
+	options: FailoverOptions = {},
+): Promise<FailoverSuccess<T>> => {
+	const health = options.health ?? new ProviderHealthTracker();
+	const tool_name = options.tool_name ?? 'search';
+	const skipped: SkippedProvider[] = [];
+	let last_error: unknown;
+
+	if (attempts.length === 0) {
+		throw new ProviderError(
+			ErrorType.INVALID_INPUT,
+			'No search providers are configured',
+			tool_name,
+		);
+	}
+
+	for (const attempt of attempts) {
+		if (health.is_cooling_down(attempt.id)) {
+			skipped.push({
+				provider: attempt.id,
+				reason: 'cooldown',
+			});
+			continue;
+		}
+
+		try {
+			const value = await retry_with_backoff(
+				attempt.run,
+				options.retry,
+			);
+			health.record_success(attempt.id);
+			return {
+				value,
+				provider: attempt.id,
+				skipped,
+			};
+		} catch (error) {
+			last_error = error;
+			if (!is_failover_eligible(error)) {
+				throw error;
+			}
+
+			const reason = skip_reason_from_error(error);
+			health.record_failure(attempt.id, error);
+			skipped.push({
+				provider: attempt.id,
+				reason,
+			});
+			console.error(
+				`${tool_name}: ${attempt.id} failed (${reason}); trying next provider`,
+			);
+		}
+	}
+
+	const skipped_summary =
+		skipped
+			.map((entry) => `${entry.provider} (${entry.reason})`)
+			.join(', ') || 'none';
+
+	throw new ProviderError(
+		last_error instanceof ProviderError
+			? last_error.type
+			: ErrorType.PROVIDER_ERROR,
+		`All search providers failed. Skipped: ${skipped_summary}. No results invented.`,
+		tool_name,
+		{
+			retryable: false,
+			skipped_providers: skipped,
+			cause:
+				last_error instanceof Error ? last_error.message : undefined,
+		},
+	);
+};

--- a/src/common/provider-health.test.ts
+++ b/src/common/provider-health.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from 'vitest';
+import {
+	COOLDOWN_STEPS_MS,
+	ProviderHealthTracker,
+	decorate_status_with_health,
+	skip_reason_from_error,
+} from './provider-health.js';
+import { ErrorType, ProviderError } from './types.js';
+
+describe('skip_reason_from_error', () => {
+	it('maps 429 and auth failures to quota', () => {
+		expect(
+			skip_reason_from_error(
+				new ProviderError(
+					ErrorType.RATE_LIMIT,
+					'rate limited',
+					'tavily',
+					{ status: 429 },
+				),
+			),
+		).toBe('quota');
+		expect(
+			skip_reason_from_error(
+				new ProviderError(
+					ErrorType.AUTH_ERROR,
+					'suspended',
+					'tavily',
+					{ status: 403 },
+				),
+			),
+		).toBe('quota');
+	});
+
+	it('maps timeouts to timeout and other outages to cooldown', () => {
+		expect(
+			skip_reason_from_error(
+				new ProviderError(ErrorType.TIMEOUT, 'slow', 'brave'),
+			),
+		).toBe('timeout');
+		expect(
+			skip_reason_from_error(
+				new DOMException('aborted', 'AbortError'),
+			),
+		).toBe('timeout');
+		expect(
+			skip_reason_from_error(
+				new ProviderError(
+					ErrorType.TRANSIENT_PROVIDER_ERROR,
+					'unavailable',
+					'exa',
+					{ status: 503 },
+				),
+			),
+		).toBe('cooldown');
+	});
+});
+
+describe('ProviderHealthTracker', () => {
+	it('applies stepped cooldowns and resets after success', () => {
+		let now = 1_000_000;
+		const health = new ProviderHealthTracker({
+			now: () => now,
+		});
+		const error = new ProviderError(
+			ErrorType.RATE_LIMIT,
+			'429',
+			'tavily',
+			{ status: 429 },
+		);
+
+		health.record_failure('tavily', error);
+		expect(health.is_cooling_down('tavily')).toBe(true);
+		expect(health.get_skip_reason('tavily')).toBe('quota');
+		expect(health.get_cooldown_until('tavily')).toBe(
+			new Date(now + COOLDOWN_STEPS_MS[0]).toISOString(),
+		);
+
+		now += COOLDOWN_STEPS_MS[0];
+		expect(health.is_cooling_down('tavily')).toBe(false);
+
+		health.record_failure('tavily', error);
+		expect(health.get_cooldown_until('tavily')).toBe(
+			new Date(now + COOLDOWN_STEPS_MS[1]).toISOString(),
+		);
+
+		now += COOLDOWN_STEPS_MS[1];
+		health.record_failure('tavily', error);
+		expect(health.get_cooldown_until('tavily')).toBe(
+			new Date(now + COOLDOWN_STEPS_MS[2]).toISOString(),
+		);
+
+		now += COOLDOWN_STEPS_MS[2];
+		health.record_failure('tavily', error);
+		expect(health.get_cooldown_until('tavily')).toBe(
+			new Date(now + COOLDOWN_STEPS_MS[3]).toISOString(),
+		);
+
+		now += COOLDOWN_STEPS_MS[3];
+		health.record_failure('tavily', error);
+		expect(health.get_cooldown_until('tavily')).toBe(
+			new Date(now + COOLDOWN_STEPS_MS[3]).toISOString(),
+		);
+
+		health.record_success('tavily');
+		expect(health.is_cooling_down('tavily')).toBe(false);
+		expect(health.get_skip_reason('tavily')).toBeUndefined();
+	});
+
+	it('decorates available provider status while cooling down', () => {
+		const health = new ProviderHealthTracker({
+			now: () => 0,
+		});
+		health.record_failure(
+			'exa',
+			new ProviderError(ErrorType.TIMEOUT, 'timeout', 'exa'),
+		);
+
+		expect(
+			decorate_status_with_health(
+				{
+					id: 'exa',
+					status: 'available',
+				},
+				health,
+			),
+		).toEqual({
+			id: 'exa',
+			status: 'available',
+			skip_reason: 'cooldown',
+			cooldown_until: new Date(COOLDOWN_STEPS_MS[0]).toISOString(),
+		});
+	});
+});

--- a/src/common/provider-health.ts
+++ b/src/common/provider-health.ts
@@ -1,0 +1,136 @@
+import { ErrorType, ProviderError } from './types.js';
+
+export type ProviderSkipReason = 'cooldown' | 'quota' | 'timeout';
+
+export const COOLDOWN_STEPS_MS = [
+	60_000, // 1 minute
+	5 * 60_000, // 5 minutes
+	25 * 60_000, // 25 minutes
+	60 * 60_000, // 1 hour
+] as const;
+
+export interface ProviderHealthOptions {
+	now?: () => number;
+	steps?: readonly number[];
+}
+
+interface HealthEntry {
+	consecutive_failures: number;
+	cooldown_until: number;
+	last_reason: ProviderSkipReason;
+}
+
+const is_object_with_name = (
+	error: unknown,
+): error is { name: string } =>
+	typeof error === 'object' &&
+	error !== null &&
+	'name' in error &&
+	typeof error.name === 'string';
+
+export const skip_reason_from_error = (
+	error: unknown,
+): ProviderSkipReason => {
+	if (error instanceof ProviderError) {
+		if (
+			error.type === ErrorType.RATE_LIMIT ||
+			error.type === ErrorType.AUTH_ERROR ||
+			error.details?.status === 429
+		) {
+			return 'quota';
+		}
+
+		if (
+			error.type === ErrorType.TIMEOUT ||
+			error.details?.status === 408
+		) {
+			return 'timeout';
+		}
+	}
+
+	if (is_object_with_name(error)) {
+		if (
+			error.name === 'TimeoutError' ||
+			error.name === 'AbortError'
+		) {
+			return 'timeout';
+		}
+	}
+
+	return 'cooldown';
+};
+
+export class ProviderHealthTracker {
+	private readonly entries = new Map<string, HealthEntry>();
+	private readonly now: () => number;
+	private readonly steps: readonly number[];
+
+	constructor(options: ProviderHealthOptions = {}) {
+		this.now = options.now ?? Date.now;
+		this.steps = options.steps ?? COOLDOWN_STEPS_MS;
+	}
+
+	clear() {
+		this.entries.clear();
+	}
+
+	is_cooling_down(provider_id: string): boolean {
+		const entry = this.entries.get(provider_id);
+		if (!entry) return false;
+		return this.now() < entry.cooldown_until;
+	}
+
+	get_skip_reason(
+		provider_id: string,
+	): ProviderSkipReason | undefined {
+		if (!this.is_cooling_down(provider_id)) return undefined;
+		return this.entries.get(provider_id)?.last_reason;
+	}
+
+	get_cooldown_until(provider_id: string): string | undefined {
+		const entry = this.entries.get(provider_id);
+		if (!entry || this.now() >= entry.cooldown_until) {
+			return undefined;
+		}
+		return new Date(entry.cooldown_until).toISOString();
+	}
+
+	record_success(provider_id: string) {
+		this.entries.delete(provider_id);
+	}
+
+	record_failure(provider_id: string, error: unknown) {
+		const existing = this.entries.get(provider_id);
+		const consecutive_failures =
+			(existing?.consecutive_failures ?? 0) + 1;
+		const step_index = Math.min(
+			consecutive_failures - 1,
+			this.steps.length - 1,
+		);
+
+		this.entries.set(provider_id, {
+			consecutive_failures,
+			cooldown_until: this.now() + this.steps[step_index],
+			last_reason: skip_reason_from_error(error),
+		});
+	}
+}
+
+export const decorate_status_with_health = <
+	T extends { id: string; status: string },
+>(
+	status: T,
+	health: ProviderHealthTracker,
+): T & {
+	skip_reason?: ProviderSkipReason;
+	cooldown_until?: string;
+} => {
+	if (status.status !== 'available') return status;
+	if (!health.is_cooling_down(status.id)) return status;
+
+	return {
+		...status,
+		skip_reason: 'cooldown',
+		cooldown_until: health.get_cooldown_until(status.id),
+	};
+};

--- a/src/server/provider-registry.ts
+++ b/src/server/provider-registry.ts
@@ -1,3 +1,4 @@
+import type { ProviderSkipReason } from '../common/provider-health.js';
 import { ErrorType, ProviderError } from '../common/types.js';
 import { is_api_key_valid } from '../common/validation.js';
 
@@ -30,6 +31,8 @@ export interface ProviderStatus {
 	modes: readonly string[];
 	capabilities: readonly string[];
 	unavailable_reason?: 'missing_api_key';
+	skip_reason?: ProviderSkipReason;
+	cooldown_until?: string;
 }
 
 export interface RegisteredProvider<T> {

--- a/src/server/tools/ai-search.ts
+++ b/src/server/tools/ai-search.ts
@@ -1,7 +1,19 @@
 import { McpServer } from 'tmcp';
 import type { GenericSchema } from 'valibot';
 import * as v from 'valibot';
-import { SearchProvider } from '../../common/types.js';
+import {
+	is_failover_eligible,
+	run_with_provider_failover,
+	to_auto_route_result,
+} from '../../common/provider-failover.js';
+import {
+	decorate_status_with_health,
+	ProviderHealthTracker,
+} from '../../common/provider-health.js';
+import {
+	BaseSearchParams,
+	SearchProvider,
+} from '../../common/types.js';
 import {
 	ai_search_provider_definitions,
 	type AISearchProviderName,
@@ -15,9 +27,15 @@ import {
 } from './schemas.js';
 
 const providers = new ProviderRegistry<SearchProvider>();
+const health = new ProviderHealthTracker();
+
+const provider_retry = {
+	max_retries: 0,
+} as const;
 
 export const initialize_ai_search = (): boolean => {
 	providers.clear();
+	health.clear();
 	providers.register_all(ai_search_provider_definitions);
 
 	return providers.size > 0;
@@ -26,7 +44,43 @@ export const initialize_ai_search = (): boolean => {
 export const get_available_providers = () => providers.names();
 
 export const get_provider_status_entries = () =>
-	providers.status_entries();
+	providers
+		.status_entries()
+		.map((status) => decorate_status_with_health(status, health));
+
+const search_explicit = async (
+	provider: string,
+	params: BaseSearchParams,
+) => {
+	const selected = providers.require(provider, 'ai_search');
+
+	try {
+		const results = await selected.search(params);
+		health.record_success(provider);
+		return results;
+	} catch (error) {
+		if (is_failover_eligible(error)) {
+			health.record_failure(provider, error);
+		}
+		throw error;
+	}
+};
+
+const search_auto = async (params: BaseSearchParams) => {
+	const outcome = await run_with_provider_failover(
+		providers.entries().map((entry) => ({
+			id: entry.id,
+			run: () => entry.instance.search(params),
+		})),
+		{
+			health,
+			retry: provider_retry,
+			tool_name: 'ai_search',
+		},
+	);
+
+	return to_auto_route_result(outcome);
+};
 
 export const register_ai_search = (
 	server: McpServer<GenericSchema>,
@@ -39,7 +93,7 @@ export const register_ai_search = (
 		{
 			name: 'ai_search',
 			description:
-				'Get AI-powered answers with citations and reasoning. Use when you need synthesized answers rather than raw search results. Providers: kagi_fastgpt (fast ~900ms answers), exa_answer (semantic AI), linkup (deep agentic search with sources).',
+				'Get AI-powered answers with citations and reasoning. Use when you need synthesized answers rather than raw search results. Providers: kagi_fastgpt (fast ~900ms answers), exa_answer (semantic AI), linkup (deep agentic search with sources). Omit provider to auto-route with failover; an explicit provider fails hard.',
 			annotations: {
 				readOnlyHint: true,
 				destructiveHint: false,
@@ -48,9 +102,13 @@ export const register_ai_search = (
 			},
 			schema: v.object({
 				query: query_schema,
-				provider: v.pipe(
-					v.picklist(provider_names),
-					v.description('AI search provider to use'),
+				provider: v.optional(
+					v.pipe(
+						v.picklist(provider_names),
+						v.description(
+							'AI search provider to use. Omit to auto-route across configured providers with retry-then-failover. An explicit provider is forced and fails hard if that provider is down.',
+						),
+					),
 				),
 				limit: limit_schema,
 				large_result_mode: large_result_mode_schema,
@@ -60,12 +118,13 @@ export const register_ai_search = (
 			handle_tool_result(
 				'ai_search',
 				async () => {
-					const selected = providers.require(provider, 'ai_search');
+					const params = { query, limit };
 
-					return selected.search({
-						query,
-						limit,
-					});
+					if (provider) {
+						return search_explicit(provider, params);
+					}
+
+					return search_auto(params);
 				},
 				{ large_result_mode },
 			),

--- a/src/server/tools/contract.test.ts
+++ b/src/server/tools/contract.test.ts
@@ -78,11 +78,12 @@ const mock_tavily_extract_response = (content: string) => {
 
 afterEach(() => {
 	for (const key of API_KEY_NAMES) delete process.env[key];
+	vi.useRealTimers();
 	vi.unstubAllGlobals();
 	vi.restoreAllMocks();
 });
 
-describe('MCP tool contract', () => {
+describe('MCP tool contract', { timeout: 15_000 }, () => {
 	it('registers no public tools when no providers are configured', async () => {
 		const { tools, tools_module } = await load_contract({});
 
@@ -152,6 +153,7 @@ describe('MCP tool contract', () => {
 			v.safeParse(schema, { query: 'test', provider: 'kagi' })
 				.success,
 		).toBe(false);
+		expect(v.safeParse(schema, { query: 'test' }).success).toBe(true);
 	});
 
 	it('validates public web_extract payloads and unavailable modes at the MCP layer', async () => {
@@ -261,6 +263,119 @@ describe('MCP tool contract', () => {
 			provider: 'brave',
 			retryable: false,
 		});
+	});
+
+	it('auto-routes web_search after a 429 and keeps explicit providers fail-hard', async () => {
+		vi.useFakeTimers();
+		vi.spyOn(console, 'error').mockImplementation(() => {});
+		const { tools } = await load_contract({
+			TAVILY_API_KEY: 'tavily-key',
+			EXA_API_KEY: 'exa-key',
+		});
+		const tool = tools.find(
+			(entry) => entry.definition.name === 'web_search',
+		)!;
+		const exa_body = {
+			requestId: 'req-1',
+			results: [
+				{
+					id: 'id-1',
+					title: 'Exa result',
+					url: 'https://example.com',
+					text: 'Body text',
+					score: 0.7,
+				},
+			],
+		};
+
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(async (input: RequestInfo | URL) => {
+				const url =
+					typeof input === 'string'
+						? input
+						: input instanceof URL
+							? input.href
+							: input.url;
+				if (url.includes('api.tavily.com')) {
+					return new Response('rate limited', { status: 429 });
+				}
+				return new Response(JSON.stringify(exa_body), {
+					status: 200,
+				});
+			}),
+		);
+
+		const auto_route = tool.handler({
+			query: 'example',
+			large_result_mode: 'inline',
+		});
+		await vi.runAllTimersAsync();
+		const auto_body = parse_tool_body(await auto_route);
+
+		expect(auto_body).toEqual({
+			results: [
+				expect.objectContaining({
+					title: 'Exa result',
+					source_provider: 'exa',
+				}),
+			],
+			metadata: {
+				used_provider: 'exa',
+				skipped_providers: [{ provider: 'tavily', reason: 'quota' }],
+			},
+		});
+
+		const explicit = tool.handler({
+			query: 'example',
+			provider: 'tavily',
+			large_result_mode: 'inline',
+		});
+		await vi.runAllTimersAsync();
+		const explicit_response = await explicit;
+		const explicit_body = parse_tool_body(explicit_response);
+
+		expect(explicit_response.isError).toBe(true);
+		expect(explicit_body).toEqual(
+			expect.objectContaining({
+				type: 'RATE_LIMIT',
+				provider: 'tavily',
+				retryable: true,
+			}),
+		);
+		expect(explicit_body.results).toBeUndefined();
+	});
+
+	it('returns a typed error instead of invented results when every auto-routed provider fails', async () => {
+		vi.useFakeTimers();
+		vi.spyOn(console, 'error').mockImplementation(() => {});
+		const { tools } = await load_contract({
+			TAVILY_API_KEY: 'tavily-key',
+			EXA_API_KEY: 'exa-key',
+		});
+		const tool = tools.find(
+			(entry) => entry.definition.name === 'web_search',
+		)!;
+
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(async () => new Response('down', { status: 503 })),
+		);
+
+		const pending = tool.handler({
+			query: 'example',
+			large_result_mode: 'inline',
+		});
+		await vi.runAllTimersAsync();
+		const response = await pending;
+		const body = parse_tool_body(response);
+
+		expect(response.isError).toBe(true);
+		expect(body.error).toContain('No results invented');
+		expect(body.skipped_providers).toEqual([
+			{ provider: 'tavily', reason: 'cooldown' },
+			{ provider: 'exa', reason: 'cooldown' },
+		]);
 	});
 
 	it('covers large-result inline/file modes and compact extraction at the MCP layer', async () => {

--- a/src/server/tools/web-search.ts
+++ b/src/server/tools/web-search.ts
@@ -1,7 +1,19 @@
 import { McpServer } from 'tmcp';
 import type { GenericSchema } from 'valibot';
 import * as v from 'valibot';
-import { SearchProvider } from '../../common/types.js';
+import {
+	is_failover_eligible,
+	run_with_provider_failover,
+	to_auto_route_result,
+} from '../../common/provider-failover.js';
+import {
+	decorate_status_with_health,
+	ProviderHealthTracker,
+} from '../../common/provider-health.js';
+import {
+	BaseSearchParams,
+	SearchProvider,
+} from '../../common/types.js';
 import {
 	web_search_provider_definitions,
 	type WebSearchProviderName,
@@ -17,9 +29,15 @@ import {
 } from './schemas.js';
 
 const providers = new ProviderRegistry<SearchProvider>();
+const health = new ProviderHealthTracker();
+
+const provider_retry = {
+	max_retries: 0,
+} as const;
 
 export const initialize_web_search = (): boolean => {
 	providers.clear();
+	health.clear();
 	providers.register_all(web_search_provider_definitions);
 
 	return providers.size > 0;
@@ -28,7 +46,43 @@ export const initialize_web_search = (): boolean => {
 export const get_available_providers = () => providers.names();
 
 export const get_provider_status_entries = () =>
-	providers.status_entries();
+	providers
+		.status_entries()
+		.map((status) => decorate_status_with_health(status, health));
+
+const search_explicit = async (
+	provider: string,
+	params: BaseSearchParams,
+) => {
+	const selected = providers.require(provider, 'web_search');
+
+	try {
+		const results = await selected.search(params);
+		health.record_success(provider);
+		return results;
+	} catch (error) {
+		if (is_failover_eligible(error)) {
+			health.record_failure(provider, error);
+		}
+		throw error;
+	}
+};
+
+const search_auto = async (params: BaseSearchParams) => {
+	const outcome = await run_with_provider_failover(
+		providers.entries().map((entry) => ({
+			id: entry.id,
+			run: () => entry.instance.search(params),
+		})),
+		{
+			health,
+			retry: provider_retry,
+			tool_name: 'web_search',
+		},
+	);
+
+	return to_auto_route_result(outcome);
+};
 
 export const register_web_search = (
 	server: McpServer<GenericSchema>,
@@ -41,7 +95,7 @@ export const register_web_search = (
 		{
 			name: 'web_search',
 			description:
-				'Search the web for information. Use when you need to find web pages, articles, or data. Providers: tavily (factual/citations), brave (privacy/operators), kagi (quality/operators), exa (AI-semantic), kagi_enrichment (specialized indexes). Brave/Kagi support query operators like site:, filetype:, lang:, before:, after:.',
+				'Search the web for information. Use when you need to find web pages, articles, or data. Providers: tavily (factual/citations), brave (privacy/operators), kagi (quality/operators), exa (AI-semantic), kagi_enrichment (specialized indexes). Brave/Kagi support query operators like site:, filetype:, lang:, before:, after:. Omit provider to auto-route with failover; an explicit provider fails hard.',
 			annotations: {
 				readOnlyHint: true,
 				destructiveHint: false,
@@ -50,9 +104,13 @@ export const register_web_search = (
 			},
 			schema: v.object({
 				query: query_schema,
-				provider: v.pipe(
-					v.picklist(provider_names),
-					v.description('Search provider to use'),
+				provider: v.optional(
+					v.pipe(
+						v.picklist(provider_names),
+						v.description(
+							'Search provider to use. Omit to auto-route across configured providers with retry-then-failover. An explicit provider is forced and fails hard if that provider is down.',
+						),
+					),
 				),
 				limit: limit_schema,
 				include_domains: include_domains_schema,
@@ -71,14 +129,18 @@ export const register_web_search = (
 			handle_tool_result(
 				'web_search',
 				async () => {
-					const selected = providers.require(provider, 'web_search');
-
-					return selected.search({
+					const params = {
 						query,
 						limit,
 						include_domains,
 						exclude_domains,
-					});
+					};
+
+					if (provider) {
+						return search_explicit(provider, params);
+					}
+
+					return search_auto(params);
 				},
 				{ large_result_mode },
 			),


### PR DESCRIPTION
## Summary

Auto-routed `web_search` and `ai_search` calls now retry transient 429/503/timeout failures with the existing `retry_with_backoff` helper, then fail over to the next eligible provider. Repeated failures cool that provider down locally (1m / 5m / 25m / 1h) so later auto-routed calls skip it. The server never invents results if every provider fails.

Fixes #191.

## Scope

- New in-memory provider health tracker and failover helper.
- Optional `provider` on `web_search` and `ai_search` for auto-route.
- Skip reasons (`cooldown`, `quota`, `timeout`) in auto-route metadata and all-failed errors.
- Docs for the fail-hard vs failover rule.
- Changeset.

No provider HTTP adapters or unrelated refactors.

## Behavior

- **Omit `provider`:** auto-route in registration order. Retry the current provider, then fail over. Auto-route responses use `{ results, metadata.used_provider, metadata.skipped_providers }`.
- **Set `provider`:** forced. That call **fails hard** and does not fail over. A forced failure still records cooldown so later auto-routed calls can skip the unhealthy provider.
- Empty results from a working provider are success (not a failover trigger).
- Invalid input does not fail over.
- Cooldown is process-local and resets on server restart.

## Verification

- `pnpm run check`
- `pnpm run test` (121 tests)
- `pnpm run build`

## Impact

- Non-breaking for existing explicit-`provider` clients (still return `SearchResult[]`).
- New optional auto-route path changes the response envelope to include skip metadata.
- No new API keys or env vars.