### PR TITLE
Add locale defaults for country and language

### DIFF
--- a/.changeset/locale-defaults.md
+++ b/.changeset/locale-defaults.md
@@ -1,0 +1,6 @@
+---
+'mcp-omnisearch': patch
+---
+
+Add optional country and language locale defaults for Brave, Tavily,
+and Kagi

--- a/README.md
+++ b/README.md
@@ -53,9 +53,17 @@ Search the web with Tavily, Brave, Kagi, Exa, or Kagi Enrichment.
 {
 	"query": "sveltekit remote functions site:docs.svelte.dev",
 	"provider": "brave",
-	"limit": 10
+	"limit": 10,
+	"country": "at",
+	"language": "de"
 }
 ```
+
+Optional `country` (ISO 3166-1 alpha-2) and `language` (ISO 639-1 or
+`auto`) override server defaults. They apply only to locale-aware
+providers (`brave`, `tavily`, `kagi`). Query language never changes
+country. Resolved locale and source (`config`, `param`, or `inferred`)
+are returned in result metadata.
 
 ### `ai_search`
 
@@ -117,6 +125,8 @@ Tavily, Kagi, Firecrawl, or Exa.
 - `FIRECRAWL_API_KEY`
 - `FIRECRAWL_BASE_URL` optional, for self-hosted Firecrawl
 - `OMNISEARCH_LARGE_RESULT_MODE` optional, `file` default or `inline`
+- `OMNISEARCH_COUNTRY` optional, ISO 3166-1 alpha-2 (e.g. `at`)
+- `OMNISEARCH_LANGUAGE` optional, ISO 639-1 or `auto` (e.g. `de`)
 
 ## Development
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -79,6 +79,8 @@ Container variables:
 - `LINKUP_API_KEY`
 - `FIRECRAWL_API_KEY`
 - `FIRECRAWL_BASE_URL`
+- `OMNISEARCH_COUNTRY` optional, ISO 3166-1 alpha-2
+- `OMNISEARCH_LANGUAGE` optional, ISO 639-1 or `auto`
 - `PORT`, defaults to `8000`
 
 ## OpenAPI access

--- a/docs/provider-selection.md
+++ b/docs/provider-selection.md
@@ -47,6 +47,9 @@ search only. See
 - Need native operators like `filetype:pdf`, `intitle:`, or `before:`?
   Start with `brave` or `kagi`.
 - Need API-level domain/date/country filtering? Use `tavily`.
+- Need non-US country/language defaults? Set `OMNISEARCH_COUNTRY` /
+  `OMNISEARCH_LANGUAGE` or pass `country` / `language` on `web_search`
+  for `brave`, `tavily`, and `kagi`.
 - Need semantic discovery, similar pages, or meaning-based results?
   Use `exa`.
 - Need source-grounded narrative answers? Use `ai_search` with

--- a/docs/search-operators.md
+++ b/docs/search-operators.md
@@ -27,6 +27,23 @@ and GitHub uses GitHub search qualifiers.
 Unsupported provider-specific operators remain in the sanitized query
 where possible rather than being flattened globally.
 
+## Locale defaults
+
+Set `OMNISEARCH_COUNTRY` and/or `OMNISEARCH_LANGUAGE` for server-wide
+defaults. Per-call `country` / `language` on `web_search` win.
+`language=auto` enables conservative query-language inference. `lang:`
+/ `loc:` operators and unambiguous place names can infer values, but
+query language never changes country.
+
+Locale is applied only to providers with region/language parameters:
+
+- `brave`: `country` and `search_lang` request fields
+- `tavily`: `country` request field
+- `kagi`: `loc:` and `lang:` query operators
+
+`exa` and `kagi_enrichment` are unchanged. Without config or per-call
+overrides, current provider defaults stay in place.
+
 ## Tested examples
 
 ### Brave: native operator passthrough

--- a/src/common/locale.test.ts
+++ b/src/common/locale.test.ts
@@ -1,0 +1,318 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+	detect_location_country,
+	infer_query_language,
+	locale_metadata_for_provider,
+	parse_country,
+	parse_language,
+	resolve_search_locale,
+	to_tavily_country,
+	warn_invalid_locale_config,
+	with_locale_metadata,
+} from './locale.js';
+
+describe('parse_country', () => {
+	it('accepts ISO 3166-1 alpha-2 codes case-insensitively', () => {
+		expect(parse_country('AT')).toBe('at');
+		expect(parse_country('ch')).toBe('ch');
+	});
+
+	it('maps common country aliases and location names', () => {
+		expect(parse_country('USA')).toBe('us');
+		expect(parse_country('United-Kingdom')).toBe('gb');
+		expect(parse_country('austria')).toBe('at');
+		expect(parse_country('vienna')).toBe('at');
+	});
+
+	it('rejects empty or invalid values', () => {
+		expect(parse_country(undefined)).toBeUndefined();
+		expect(parse_country('')).toBeUndefined();
+		expect(parse_country('usa!')).toBeUndefined();
+		expect(parse_country('eng')).toBeUndefined();
+	});
+});
+
+describe('parse_language', () => {
+	it('accepts ISO 639-1 codes and auto', () => {
+		expect(parse_language('DE')).toBe('de');
+		expect(parse_language('auto')).toBe('auto');
+	});
+
+	it('rejects empty or invalid values', () => {
+		expect(parse_language(undefined)).toBeUndefined();
+		expect(parse_language('eng')).toBeUndefined();
+		expect(parse_language('de-AT')).toBeUndefined();
+	});
+});
+
+describe('resolve_search_locale', () => {
+	it('leaves current behavior unchanged without config or params', () => {
+		expect(
+			resolve_search_locale({
+				query: 'beste Kaffeehäuser Wien Öffnungszeiten',
+			}),
+		).toEqual({ active: false });
+	});
+
+	it('uses config country and language when set', () => {
+		expect(
+			resolve_search_locale({
+				query: 'weather',
+				config_country: 'AT',
+				config_language: 'de',
+			}),
+		).toEqual({
+			active: true,
+			country: 'at',
+			country_source: 'config',
+			language: 'de',
+			language_source: 'config',
+		});
+	});
+
+	it('lets per-call params win over config', () => {
+		expect(
+			resolve_search_locale({
+				query: 'weather',
+				config_country: 'at',
+				config_language: 'de',
+				param_country: 'ch',
+				param_language: 'fr',
+			}),
+		).toEqual({
+			active: true,
+			country: 'ch',
+			country_source: 'param',
+			language: 'fr',
+			language_source: 'param',
+		});
+	});
+
+	it('does not change country when query language is inferred', () => {
+		expect(
+			resolve_search_locale({
+				query: 'beste Kaffeehäuser Öffnungszeiten heute',
+				config_country: 'ch',
+				config_language: 'auto',
+			}),
+		).toEqual({
+			active: true,
+			country: 'ch',
+			country_source: 'config',
+			language: 'de',
+			language_source: 'inferred',
+		});
+	});
+
+	it('uses loc: and lang: operators as inferred per-call overrides', () => {
+		expect(
+			resolve_search_locale({
+				query: 'news loc:us lang:en',
+				config_country: 'at',
+				config_language: 'de',
+			}),
+		).toEqual({
+			active: true,
+			country: 'us',
+			country_source: 'inferred',
+			language: 'en',
+			language_source: 'inferred',
+		});
+	});
+
+	it('uses an unambiguous location hint without changing language', () => {
+		expect(
+			resolve_search_locale({
+				query: 'cafes in Vienna',
+				config_country: 'us',
+				config_language: 'en',
+			}),
+		).toEqual({
+			active: true,
+			country: 'at',
+			country_source: 'inferred',
+			language: 'en',
+			language_source: 'config',
+		});
+	});
+
+	it('ignores conflicting location hints so config keeps country', () => {
+		expect(
+			resolve_search_locale({
+				query: 'Paris vs Madrid',
+				config_country: 'us',
+			}),
+		).toEqual({
+			active: true,
+			country: 'us',
+			country_source: 'config',
+		});
+	});
+
+	it('does not infer language for terse technical queries', () => {
+		expect(
+			resolve_search_locale({
+				query: 'DAC R2R NOS',
+				config_language: 'auto',
+			}),
+		).toEqual({ active: true });
+	});
+
+	it('lets an explicit language param win over lang: operators', () => {
+		expect(
+			resolve_search_locale({
+				query: 'news lang:en',
+				param_language: 'de',
+			}),
+		).toEqual({
+			active: true,
+			language: 'de',
+			language_source: 'param',
+		});
+	});
+});
+
+describe('detect_location_country and infer_query_language', () => {
+	it('requires a single agreed location hint', () => {
+		expect(detect_location_country('cafes in Vienna')).toBe('at');
+		expect(
+			detect_location_country('Paris vs Madrid'),
+		).toBeUndefined();
+	});
+
+	it('requires a clear language winner', () => {
+		expect(
+			infer_query_language('beste Kaffeehäuser Öffnungszeiten heute'),
+		).toBe('de');
+		expect(infer_query_language('DAC R2R NOS')).toBeUndefined();
+	});
+});
+
+describe('to_tavily_country', () => {
+	it('maps ISO codes to English country names', () => {
+		expect(to_tavily_country('at')).toBe('austria');
+		expect(to_tavily_country('gb')).toBe('united kingdom');
+		expect(to_tavily_country('United-Kingdom')).toBe(
+			'united kingdom',
+		);
+	});
+});
+
+describe('locale metadata', () => {
+	it('omits metadata for providers without locale params', () => {
+		expect(
+			locale_metadata_for_provider('exa', {
+				active: true,
+				country: 'at',
+				country_source: 'config',
+			}),
+		).toBeUndefined();
+	});
+
+	it('reports only country for Tavily', () => {
+		expect(
+			locale_metadata_for_provider('tavily', {
+				active: true,
+				country: 'at',
+				country_source: 'config',
+				language: 'de',
+				language_source: 'param',
+			}),
+		).toEqual({
+			locale: {
+				country: 'at',
+				source: { country: 'config' },
+			},
+		});
+	});
+
+	it('reports country and language for Brave and Kagi', () => {
+		expect(
+			locale_metadata_for_provider('brave', {
+				active: true,
+				country: 'ch',
+				country_source: 'param',
+				language: 'de',
+				language_source: 'inferred',
+			}),
+		).toEqual({
+			locale: {
+				country: 'ch',
+				language: 'de',
+				source: {
+					country: 'param',
+					language: 'inferred',
+				},
+			},
+		});
+	});
+
+	it('merges locale metadata onto search results', () => {
+		expect(
+			with_locale_metadata(
+				[
+					{
+						title: 'Result',
+						url: 'https://example.com',
+						snippet: 'Summary',
+						source_provider: 'kagi',
+						metadata: { rank: 1 },
+					},
+				],
+				'kagi',
+				{
+					active: true,
+					country: 'at',
+					country_source: 'config',
+				},
+			),
+		).toEqual([
+			{
+				title: 'Result',
+				url: 'https://example.com',
+				snippet: 'Summary',
+				source_provider: 'kagi',
+				metadata: {
+					rank: 1,
+					locale: {
+						country: 'at',
+						source: { country: 'config' },
+					},
+				},
+			},
+		]);
+	});
+});
+
+describe('warn_invalid_locale_config', () => {
+	it('warns for invalid country and language values', () => {
+		const warn = vi.fn();
+
+		warn_invalid_locale_config(
+			{
+				OMNISEARCH_COUNTRY: 'austria-at',
+				OMNISEARCH_LANGUAGE: 'german',
+			},
+			warn,
+		);
+
+		expect(warn).toHaveBeenCalledTimes(2);
+		expect(warn.mock.calls[0]?.[0]).toContain('OMNISEARCH_COUNTRY');
+		expect(warn.mock.calls[1]?.[0]).toContain('OMNISEARCH_LANGUAGE');
+	});
+
+	it('does not warn for valid or empty locale config', () => {
+		const warn = vi.fn();
+
+		warn_invalid_locale_config(
+			{
+				OMNISEARCH_COUNTRY: 'at',
+				OMNISEARCH_LANGUAGE: 'auto',
+			},
+			warn,
+		);
+		warn_invalid_locale_config({}, warn);
+
+		expect(warn).not.toHaveBeenCalled();
+	});
+});

--- a/src/common/locale.ts
+++ b/src/common/locale.ts
@@ -1,0 +1,585 @@
+import {
+	apply_search_operators,
+	parse_search_operators,
+} from './search-operators.js';
+import type { ProviderMetadata, SearchResult } from './types.js';
+
+export const AUTO_LANGUAGE = 'auto';
+
+export type LocaleSource = 'config' | 'param' | 'inferred';
+
+export const LOCALE_AWARE_PROVIDERS = new Set([
+	'brave',
+	'tavily',
+	'kagi',
+]);
+
+export const LANGUAGE_INFERENCE_MIN_MATCHES = 2;
+
+const COUNTRY_ALIASES: Record<string, string> = {
+	usa: 'us',
+	'united states': 'us',
+	uk: 'gb',
+	'united kingdom': 'gb',
+	'great britain': 'gb',
+	austria: 'at',
+	osterreich: 'at',
+	österreich: 'at',
+	germany: 'de',
+	deutschland: 'de',
+	switzerland: 'ch',
+	schweiz: 'ch',
+	france: 'fr',
+	spain: 'es',
+	españa: 'es',
+	italy: 'it',
+	italia: 'it',
+	portugal: 'pt',
+	netherlands: 'nl',
+};
+
+export const LOCATION_COUNTRY_HINTS: Record<string, string> = {
+	wien: 'at',
+	vienna: 'at',
+	graz: 'at',
+	salzburg: 'at',
+	innsbruck: 'at',
+	österreich: 'at',
+	austria: 'at',
+	berlin: 'de',
+	münchen: 'de',
+	munich: 'de',
+	hamburg: 'de',
+	frankfurt: 'de',
+	deutschland: 'de',
+	germany: 'de',
+	zürich: 'ch',
+	zurich: 'ch',
+	schweiz: 'ch',
+	switzerland: 'ch',
+	paris: 'fr',
+	lyon: 'fr',
+	marseille: 'fr',
+	france: 'fr',
+	madrid: 'es',
+	barcelona: 'es',
+	españa: 'es',
+	spain: 'es',
+	rome: 'it',
+	roma: 'it',
+	milano: 'it',
+	milan: 'it',
+	italia: 'it',
+	italy: 'it',
+	lisbon: 'pt',
+	lisboa: 'pt',
+	portugal: 'pt',
+	amsterdam: 'nl',
+	rotterdam: 'nl',
+	netherlands: 'nl',
+	london: 'gb',
+	manchester: 'gb',
+	'united kingdom': 'gb',
+	'new york': 'us',
+	chicago: 'us',
+	'san francisco': 'us',
+	usa: 'us',
+};
+
+const LANGUAGE_INFERENCE_STOPWORDS: Record<string, Set<string>> = {
+	en: new Set([
+		'the',
+		'and',
+		'what',
+		'how',
+		'where',
+		'when',
+		'which',
+		'who',
+		'best',
+		'near',
+		'hours',
+		'open',
+		'with',
+		'from',
+		'for',
+		'are',
+		'is',
+		'was',
+		'does',
+		'latest',
+		'today',
+		'new',
+	]),
+	de: new Set([
+		'der',
+		'die',
+		'das',
+		'und',
+		'oder',
+		'nicht',
+		'ist',
+		'sind',
+		'ein',
+		'eine',
+		'einen',
+		'mit',
+		'für',
+		'von',
+		'wie',
+		'wo',
+		'was',
+		'warum',
+		'welche',
+		'beste',
+		'besten',
+		'gibt',
+		'öffnungszeiten',
+		'heute',
+		'morgen',
+		'preis',
+		'kaufen',
+		'günstig',
+		'nähe',
+	]),
+	es: new Set([
+		'el',
+		'los',
+		'las',
+		'una',
+		'unos',
+		'que',
+		'qué',
+		'cómo',
+		'dónde',
+		'cuál',
+		'por',
+		'para',
+		'con',
+		'mejores',
+		'mejor',
+		'cerca',
+		'hoy',
+		'horario',
+		'horarios',
+		'abierto',
+		'abiertos',
+		'tiendas',
+		'restaurantes',
+		'precio',
+		'precios',
+		'donde',
+		'como',
+	]),
+	fr: new Set([
+		'le',
+		'les',
+		'des',
+		'une',
+		'du',
+		'où',
+		'quel',
+		'quelle',
+		'quels',
+		'quelles',
+		'meilleur',
+		'meilleure',
+		'meilleurs',
+		'meilleures',
+		'horaires',
+		'ouvert',
+		'ouverts',
+		'ouverture',
+		'aujourd',
+		'hui',
+		'près',
+		'proche',
+		'avec',
+		'pour',
+		'prix',
+		'cher',
+		'que',
+	]),
+	it: new Set([
+		'il',
+		'lo',
+		'gli',
+		'che',
+		'come',
+		'dove',
+		'quale',
+		'quali',
+		'migliori',
+		'migliore',
+		'orari',
+		'orario',
+		'aperto',
+		'aperti',
+		'vicino',
+		'con',
+		'oggi',
+		'prezzo',
+		'prezzi',
+		'negozi',
+		'ristoranti',
+		'della',
+		'delle',
+	]),
+	pt: new Set([
+		'os',
+		'do',
+		'dos',
+		'das',
+		'um',
+		'uma',
+		'que',
+		'como',
+		'onde',
+		'qual',
+		'quais',
+		'melhores',
+		'melhor',
+		'horários',
+		'aberto',
+		'perto',
+		'hoje',
+		'preço',
+		'lojas',
+		'com',
+		'você',
+		'para',
+		'restaurantes',
+	]),
+	nl: new Set([
+		'het',
+		'een',
+		'waar',
+		'hoe',
+		'welke',
+		'beste',
+		'goedkoop',
+		'goedkoopste',
+		'vandaag',
+		'morgen',
+		'openingstijden',
+		'winkel',
+		'winkels',
+		'dichtbij',
+		'buurt',
+		'naar',
+		'zijn',
+		'niet',
+		'voor',
+	]),
+};
+
+const LANGUAGE_INFERENCE_CHAR_HINTS: Record<string, string> = {
+	de: 'äöüß',
+	es: 'ñ¿¡',
+	pt: 'ãõ',
+	fr: 'œ',
+};
+
+export interface LocaleEnv {
+	country?: string;
+	language?: string;
+}
+
+export interface LocaleInputs {
+	query: string;
+	param_country?: string;
+	param_language?: string;
+	config_country?: string;
+	config_language?: string;
+}
+
+export interface ResolvedLocale {
+	country?: string;
+	language?: string;
+	country_source?: LocaleSource;
+	language_source?: LocaleSource;
+	active: boolean;
+}
+
+const normalize_alias_key = (value: string) =>
+	value
+		.trim()
+		.toLowerCase()
+		.replace(/[-_]+/g, ' ')
+		.replace(/\s+/g, ' ');
+
+export const parse_country = (value?: string): string | undefined => {
+	if (!value) return undefined;
+	const normalized = normalize_alias_key(value);
+	if (!normalized) return undefined;
+
+	const aliased =
+		COUNTRY_ALIASES[normalized] ?? LOCATION_COUNTRY_HINTS[normalized];
+	if (aliased) return aliased;
+
+	if (/^[a-z]{2}$/.test(normalized)) return normalized;
+	return undefined;
+};
+
+export const parse_language = (
+	value?: string,
+): string | undefined => {
+	if (!value) return undefined;
+	const normalized = value.trim().toLowerCase();
+	if (!normalized) return undefined;
+	if (normalized === AUTO_LANGUAGE) return AUTO_LANGUAGE;
+	if (/^[a-z]{2}$/.test(normalized)) return normalized;
+	return undefined;
+};
+
+export const read_locale_env = (
+	env: NodeJS.ProcessEnv = process.env,
+): LocaleEnv => ({
+	country: env.OMNISEARCH_COUNTRY,
+	language: env.OMNISEARCH_LANGUAGE,
+});
+
+export const warn_invalid_locale_config = (
+	env: NodeJS.ProcessEnv = process.env,
+	warn: (message: string) => void = console.warn,
+) => {
+	const country = env.OMNISEARCH_COUNTRY?.trim();
+	if (country && !parse_country(country)) {
+		warn(
+			`Warning: OMNISEARCH_COUNTRY="${country}" is not a valid ISO 3166-1 alpha-2 country code and will be ignored.`,
+		);
+	}
+
+	const language = env.OMNISEARCH_LANGUAGE?.trim();
+	if (language && !parse_language(language)) {
+		warn(
+			`Warning: OMNISEARCH_LANGUAGE="${language}" is not a valid ISO 639-1 language code or "auto" and will be ignored.`,
+		);
+	}
+};
+
+export const provider_supports_locale = (provider: string) =>
+	LOCALE_AWARE_PROVIDERS.has(provider);
+
+export const provider_applies_language = (provider: string) =>
+	provider === 'brave' || provider === 'kagi';
+
+export const detect_location_country = (
+	query?: string,
+): string | undefined => {
+	if (!query) return undefined;
+	const lowered = query.toLowerCase();
+	const countries = new Set<string>();
+
+	for (const [place, country] of Object.entries(
+		LOCATION_COUNTRY_HINTS,
+	)) {
+		const escaped = place.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+		const pattern = new RegExp(
+			`(^|[^\\p{L}\\p{N}_])${escaped}($|[^\\p{L}\\p{N}_])`,
+			'iu',
+		);
+		if (pattern.test(lowered)) countries.add(country);
+	}
+
+	return countries.size === 1 ? [...countries][0] : undefined;
+};
+
+export const infer_query_language = (
+	query: string,
+): string | undefined => {
+	if (!query) return undefined;
+	const lowered = query.toLowerCase();
+	const words = new Set(lowered.match(/[\p{L}\p{N}_]+/gu) ?? []);
+	const counts: Record<string, number> = {};
+
+	for (const [language, stopwords] of Object.entries(
+		LANGUAGE_INFERENCE_STOPWORDS,
+	)) {
+		let count = 0;
+		for (const word of words) {
+			if (stopwords.has(word)) count += 1;
+		}
+		for (const char of LANGUAGE_INFERENCE_CHAR_HINTS[language] ??
+			'') {
+			if (lowered.includes(char)) count += 1;
+		}
+		if (count) counts[language] = count;
+	}
+
+	const ranked = Object.entries(counts).sort(
+		([left_lang, left_count], [right_lang, right_count]) =>
+			right_count - left_count || left_lang.localeCompare(right_lang),
+	);
+	if (!ranked.length) return undefined;
+
+	const [best_language, best_count] = ranked[0];
+	if (best_count < LANGUAGE_INFERENCE_MIN_MATCHES) {
+		return undefined;
+	}
+	if (ranked.length > 1 && ranked[1][1] === best_count) {
+		return undefined;
+	}
+	return best_language;
+};
+
+export const to_tavily_country = (value: string): string => {
+	const iso = parse_country(value);
+	if (iso) {
+		const name = new Intl.DisplayNames(['en'], {
+			type: 'region',
+		}).of(iso.toUpperCase());
+		if (name && name.toLowerCase() !== iso) {
+			return name.toLowerCase();
+		}
+	}
+
+	return normalize_alias_key(value);
+};
+
+export const is_locale_active = (input: LocaleInputs): boolean =>
+	Boolean(
+		parse_country(input.param_country) ||
+		parse_language(input.param_language) ||
+		parse_country(input.config_country) ||
+		parse_language(input.config_language),
+	);
+
+const pick_country = (
+	input: LocaleInputs,
+	operator_country?: string,
+): Pick<ResolvedLocale, 'country' | 'country_source'> => {
+	const from_param = parse_country(input.param_country);
+	if (from_param) {
+		return { country: from_param, country_source: 'param' };
+	}
+
+	const from_operator = parse_country(operator_country);
+	if (from_operator) {
+		return { country: from_operator, country_source: 'inferred' };
+	}
+
+	const from_hint = detect_location_country(input.query);
+	if (from_hint) {
+		return { country: from_hint, country_source: 'inferred' };
+	}
+
+	const from_config = parse_country(input.config_country);
+	if (from_config) {
+		return { country: from_config, country_source: 'config' };
+	}
+
+	return {};
+};
+
+const pick_language = (
+	input: LocaleInputs,
+	operator_language?: string,
+): Pick<ResolvedLocale, 'language' | 'language_source'> => {
+	const param_language = parse_language(input.param_language);
+	if (param_language && param_language !== AUTO_LANGUAGE) {
+		return { language: param_language, language_source: 'param' };
+	}
+
+	const from_operator = parse_language(operator_language);
+	if (from_operator && from_operator !== AUTO_LANGUAGE) {
+		return { language: from_operator, language_source: 'inferred' };
+	}
+
+	const config_language = parse_language(input.config_language);
+	const use_auto =
+		param_language === AUTO_LANGUAGE ||
+		(param_language === undefined &&
+			config_language === AUTO_LANGUAGE);
+
+	if (use_auto) {
+		const inferred = infer_query_language(input.query);
+		if (inferred) {
+			return { language: inferred, language_source: 'inferred' };
+		}
+		return {};
+	}
+
+	if (config_language && config_language !== AUTO_LANGUAGE) {
+		return { language: config_language, language_source: 'config' };
+	}
+
+	return {};
+};
+
+export const resolve_search_locale = (
+	input: LocaleInputs,
+): ResolvedLocale => {
+	const active = is_locale_active(input);
+	if (!active) {
+		return { active: false };
+	}
+
+	const operators = apply_search_operators(
+		parse_search_operators(input.query),
+	);
+	const country = pick_country(input, operators.location);
+	const language = pick_language(input, operators.language);
+
+	return {
+		active: true,
+		...country,
+		...language,
+	};
+};
+
+export const locale_query_language = (
+	locale: ResolvedLocale,
+): string | undefined =>
+	locale.language && locale.language !== AUTO_LANGUAGE
+		? locale.language
+		: undefined;
+
+export const locale_metadata_for_provider = (
+	provider: string,
+	locale: ResolvedLocale,
+): ProviderMetadata | undefined => {
+	if (!provider_supports_locale(provider) || !locale.active) {
+		return undefined;
+	}
+
+	const country = locale.country;
+	const language = provider_applies_language(provider)
+		? locale_query_language(locale)
+		: undefined;
+
+	if (!country && !language) return undefined;
+
+	const source: Record<string, LocaleSource> = {};
+	if (country && locale.country_source) {
+		source.country = locale.country_source;
+	}
+	if (language && locale.language_source) {
+		source.language = locale.language_source;
+	}
+
+	return {
+		locale: {
+			...(country ? { country } : {}),
+			...(language ? { language } : {}),
+			source,
+		},
+	};
+};
+
+export const with_locale_metadata = (
+	results: SearchResult[],
+	provider: string,
+	locale: ResolvedLocale,
+): SearchResult[] => {
+	const extra = locale_metadata_for_provider(provider, locale);
+	if (!extra) return results;
+
+	return results.map((result) => ({
+		...result,
+		metadata: {
+			...result.metadata,
+			...extra,
+		},
+	}));
+};

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -16,6 +16,8 @@ export interface BaseSearchParams {
 	limit?: number;
 	include_domains?: string[];
 	exclude_domains?: string[];
+	country?: string;
+	language?: string;
 }
 
 export interface ProcessingResult {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { ValibotJsonSchemaAdapter } from '@tmcp/adapter-valibot';
 import { StdioTransport } from '@tmcp/transport-stdio';
 import { McpServer } from 'tmcp';
 import type { GenericSchema } from 'valibot';
+import { warn_invalid_locale_config } from './common/locale.js';
 import { validate_config } from './config/env.js';
 import { setup_handlers } from './server/handlers.js';
 import {
@@ -46,6 +47,7 @@ class OmnisearchServer {
 
 		// Validate environment configuration
 		validate_config();
+		warn_invalid_locale_config();
 
 		// Initialize and register providers + tools
 		initialize_providers();

--- a/src/providers/search/brave/index.test.ts
+++ b/src/providers/search/brave/index.test.ts
@@ -55,6 +55,37 @@ describe('BraveSearchProvider', () => {
 		]);
 	});
 
+	it('sends country and search_lang without rewriting the query', async () => {
+		const fetch = vi.fn(async (_input: string, _init?: RequestInit) =>
+			json_response({
+				web: {
+					results: [
+						{
+							title: 'Result',
+							url: 'https://example.com',
+							description: 'Summary',
+						},
+					],
+				},
+			}),
+		);
+		vi.stubGlobal('fetch', fetch);
+		const { BraveSearchProvider } = await import('./index.js');
+
+		await new BraveSearchProvider().search({
+			query: 'nachhaltige energie loc:us lang:en',
+			limit: 1,
+			country: 'at',
+			language: 'de',
+		});
+
+		const request_url = String(fetch.mock.calls[0]?.[0]);
+		const query_params = new URL(request_url).searchParams;
+		expect(query_params.get('country')).toBe('AT');
+		expect(query_params.get('search_lang')).toBe('de');
+		expect(query_params.get('q')).toBe('nachhaltige energie');
+	});
+
 	it('returns no results when the web block is omitted', async () => {
 		vi.stubGlobal(
 			'fetch',

--- a/src/providers/search/brave/index.ts
+++ b/src/providers/search/brave/index.ts
@@ -47,7 +47,13 @@ export class BraveSearchProvider implements SearchProvider {
 
 		const search_request = async () => {
 			try {
-				// Build query with all operators using shared utility
+				if (params.country) {
+					search_params.location = undefined;
+				}
+				if (params.language) {
+					search_params.language = undefined;
+				}
+
 				const query = build_query_with_operators(
 					search_params,
 					params.include_domains,
@@ -58,6 +64,16 @@ export class BraveSearchProvider implements SearchProvider {
 					q: query,
 					count: (params.limit ?? 10).toString(),
 				});
+
+				if (params.country) {
+					query_params.set('country', params.country.toUpperCase());
+				}
+				if (params.language) {
+					query_params.set(
+						'search_lang',
+						params.language.toLowerCase(),
+					);
+				}
 
 				const raw_data = await http_json(
 					this.name,

--- a/src/providers/search/kagi/index.test.ts
+++ b/src/providers/search/kagi/index.test.ts
@@ -24,6 +24,30 @@ describe('KagiSearchProvider', () => {
 		vi.restoreAllMocks();
 	});
 
+	it('injects resolved locale into loc and lang query operators', async () => {
+		const fetch = vi.fn(async (_input: string, _init?: RequestInit) =>
+			json_response({
+				data: [{ title: 'Good', url: 'https://example.com' }],
+			}),
+		);
+		vi.stubGlobal('fetch', fetch);
+		const { KagiSearchProvider } = await import('./index.js');
+
+		await new KagiSearchProvider().search({
+			query: 'news loc:us lang:en',
+			limit: 5,
+			country: 'at',
+			language: 'de',
+		});
+
+		const request_url = String(fetch.mock.calls[0]?.[0]);
+		const query = new URL(request_url).searchParams.get('q');
+		expect(query).toContain('loc:at');
+		expect(query).toContain('lang:de');
+		expect(query).not.toContain('loc:us');
+		expect(query).not.toContain('lang:en');
+	});
+
 	it('skips non-result rows and accepts omitted snippets and total_hits', async () => {
 		vi.stubGlobal(
 			'fetch',

--- a/src/providers/search/kagi/index.ts
+++ b/src/providers/search/kagi/index.ts
@@ -59,6 +59,12 @@ export class KagiSearchProvider implements SearchProvider {
 		// Parse search operators from the query
 		const parsed_query = parse_search_operators(params.query);
 		const search_params = apply_search_operators(parsed_query);
+		if (params.country) {
+			search_params.location = params.country;
+		}
+		if (params.language) {
+			search_params.language = params.language;
+		}
 
 		const search_request = async () => {
 			try {

--- a/src/providers/search/tavily/index.test.ts
+++ b/src/providers/search/tavily/index.test.ts
@@ -93,4 +93,34 @@ describe('TavilySearchProvider', () => {
 			country: 'united kingdom',
 		});
 	});
+
+	it('prefers resolved country params over location operators', async () => {
+		const fetch = vi.fn(
+			async (_input: RequestInfo | URL, _init?: RequestInit) =>
+				json_response({
+					results: [
+						{
+							title: 'Result',
+							url: 'https://example.com',
+							content: 'Content',
+							score: 0.5,
+						},
+					],
+					response_time: 0.2,
+				}),
+		);
+		vi.stubGlobal('fetch', fetch);
+		const { TavilySearchProvider } = await import('./index.js');
+
+		await new TavilySearchProvider().search({
+			query: 'example loc:us',
+			limit: 1,
+			country: 'at',
+		});
+
+		const request_init = fetch.mock.calls[0]?.[1];
+		expect(JSON.parse(request_init?.body as string)).toMatchObject({
+			country: 'austria',
+		});
+	});
 });

--- a/src/providers/search/tavily/index.ts
+++ b/src/providers/search/tavily/index.ts
@@ -15,6 +15,7 @@ import {
 	SearchProvider,
 	SearchResult,
 } from '../../../common/types.js';
+import { to_tavily_country } from '../../../common/locale.js';
 import { validate_api_key } from '../../../common/validation.js';
 import { config } from '../../../config/env.js';
 
@@ -46,17 +47,6 @@ const normalize_tavily_date = (date: string) => {
 	if (/^\d{4}$/.test(date)) return `${date}-01-01`;
 	if (/^\d{4}-\d{2}$/.test(date)) return `${date}-01`;
 	return date;
-};
-
-const tavily_country_aliases: Record<string, string> = {
-	uk: 'united kingdom',
-	us: 'united states',
-	usa: 'united states',
-};
-
-const normalize_tavily_country = (location: string) => {
-	const normalized = location.toLowerCase().replace(/-/g, ' ');
-	return tavily_country_aliases[normalized] ?? normalized;
 };
 
 export class TavilySearchProvider implements SearchProvider {
@@ -122,11 +112,9 @@ export class TavilySearchProvider implements SearchProvider {
 						`${request_body.query} ${exact_query_parts.join(' ')}`.trim();
 				}
 
-				// Map location operator to Tavily's country param
-				if (search_params.location) {
-					request_body.country = normalize_tavily_country(
-						search_params.location,
-					);
+				const country = params.country ?? search_params.location;
+				if (country) {
+					request_body.country = to_tavily_country(country);
 				}
 
 				const raw_data = await http_json(

--- a/src/server/tools/contract.test.ts
+++ b/src/server/tools/contract.test.ts
@@ -17,6 +17,8 @@ const API_KEY_NAMES = [
 	'EXA_API_KEY',
 	'LINKUP_API_KEY',
 	'FIRECRAWL_API_KEY',
+	'OMNISEARCH_COUNTRY',
+	'OMNISEARCH_LANGUAGE',
 ];
 
 const create_mock_server = () => {
@@ -152,6 +154,21 @@ describe('MCP tool contract', () => {
 			v.safeParse(schema, { query: 'test', provider: 'kagi' })
 				.success,
 		).toBe(false);
+		expect(
+			v.safeParse(schema, {
+				query: 'test',
+				provider: 'brave',
+				country: 'at',
+				language: 'auto',
+			}).success,
+		).toBe(true);
+		expect(
+			v.safeParse(schema, {
+				query: 'test',
+				provider: 'brave',
+				country: 'austria',
+			}).success,
+		).toBe(false);
 	});
 
 	it('validates public web_extract payloads and unavailable modes at the MCP layer', async () => {
@@ -261,6 +278,67 @@ describe('MCP tool contract', () => {
 			provider: 'brave',
 			retryable: false,
 		});
+	});
+
+	it('applies locale defaults and reports resolved source metadata', async () => {
+		const { tools } = await load_contract({
+			BRAVE_API_KEY: 'brave-key',
+			OMNISEARCH_COUNTRY: 'at',
+			OMNISEARCH_LANGUAGE: 'de',
+		});
+		const tool = tools.find(
+			(entry) => entry.definition.name === 'web_search',
+		)!;
+		const fetch = vi.fn(
+			async (_input: string, _init?: RequestInit) =>
+				new Response(
+					JSON.stringify({
+						web: {
+							results: [
+								{
+									title: 'Example',
+									url: 'https://example.com',
+									description: 'Example result',
+								},
+							],
+						},
+					}),
+					{ status: 200 },
+				),
+		);
+		vi.stubGlobal('fetch', fetch);
+
+		const body = parse_tool_body(
+			await tool.handler({
+				query: 'news',
+				provider: 'brave',
+				country: 'ch',
+				large_result_mode: 'inline',
+			}),
+		);
+
+		const request_url = String(fetch.mock.calls[0]?.[0]);
+		const query_params = new URL(request_url).searchParams;
+		expect(query_params.get('country')).toBe('CH');
+		expect(query_params.get('search_lang')).toBe('de');
+		expect(body).toEqual([
+			{
+				title: 'Example',
+				url: 'https://example.com',
+				snippet: 'Example result',
+				source_provider: 'brave',
+				metadata: {
+					locale: {
+						country: 'ch',
+						language: 'de',
+						source: {
+							country: 'param',
+							language: 'config',
+						},
+					},
+				},
+			},
+		]);
 	});
 
 	it('covers large-result inline/file modes and compact extraction at the MCP layer', async () => {

--- a/src/server/tools/schemas.test.ts
+++ b/src/server/tools/schemas.test.ts
@@ -1,9 +1,11 @@
 import * as v from 'valibot';
 import { describe, expect, it } from 'vitest';
 import {
+	country_schema,
 	domain_schema,
 	http_url_schema,
 	include_raw_contents_schema,
+	language_schema,
 	large_result_mode_schema,
 	limit_schema,
 	query_schema,
@@ -45,6 +47,19 @@ describe('tool schemas', () => {
 		expect(
 			v.safeParse(include_raw_contents_schema, 'false').success,
 		).toBe(false);
+	});
+
+	it('accepts ISO country and language overrides', () => {
+		expect(v.parse(country_schema, 'at')).toBe('at');
+		expect(v.parse(country_schema, 'CH')).toBe('CH');
+		expect(v.safeParse(country_schema, 'austria').success).toBe(
+			false,
+		);
+		expect(v.parse(language_schema, 'de')).toBe('de');
+		expect(v.parse(language_schema, 'auto')).toBe('auto');
+		expect(v.safeParse(language_schema, 'german').success).toBe(
+			false,
+		);
 	});
 
 	it('accepts hostnames but rejects URLs as domain filters', () => {

--- a/src/server/tools/schemas.ts
+++ b/src/server/tools/schemas.ts
@@ -51,6 +51,32 @@ export const include_domains_schema = v.optional(
 	),
 );
 
+export const country_schema = v.optional(
+	v.pipe(
+		v.string(),
+		v.regex(
+			/^[A-Za-z]{2}$/,
+			'Country must be an ISO 3166-1 alpha-2 code',
+		),
+		v.description(
+			'ISO 3166-1 alpha-2 country code (e.g. at, de, ch). Overrides OMNISEARCH_COUNTRY. Query language never changes country.',
+		),
+	),
+);
+
+export const language_schema = v.optional(
+	v.pipe(
+		v.string(),
+		v.regex(
+			/^(?:auto|[A-Za-z]{2})$/i,
+			'Language must be an ISO 639-1 code or auto',
+		),
+		v.description(
+			'ISO 639-1 language code or auto. Overrides OMNISEARCH_LANGUAGE. auto enables conservative query-language inference.',
+		),
+	),
+);
+
 export const exclude_domains_schema = v.optional(
 	v.pipe(
 		v.array(domain_schema),

--- a/src/server/tools/web-search.ts
+++ b/src/server/tools/web-search.ts
@@ -1,6 +1,12 @@
 import { McpServer } from 'tmcp';
 import type { GenericSchema } from 'valibot';
 import * as v from 'valibot';
+import {
+	locale_query_language,
+	read_locale_env,
+	resolve_search_locale,
+	with_locale_metadata,
+} from '../../common/locale.js';
 import { SearchProvider } from '../../common/types.js';
 import {
 	web_search_provider_definitions,
@@ -9,8 +15,10 @@ import {
 import { ProviderRegistry } from '../provider-registry.js';
 import { handle_tool_result } from './responses.js';
 import {
+	country_schema,
 	exclude_domains_schema,
 	include_domains_schema,
+	language_schema,
 	large_result_mode_schema,
 	limit_schema,
 	query_schema,
@@ -41,7 +49,7 @@ export const register_web_search = (
 		{
 			name: 'web_search',
 			description:
-				'Search the web for information. Use when you need to find web pages, articles, or data. Providers: tavily (factual/citations), brave (privacy/operators), kagi (quality/operators), exa (AI-semantic), kagi_enrichment (specialized indexes). Brave/Kagi support query operators like site:, filetype:, lang:, before:, after:.',
+				'Search the web for information. Use when you need to find web pages, articles, or data. Providers: tavily (factual/citations), brave (privacy/operators), kagi (quality/operators), exa (AI-semantic), kagi_enrichment (specialized indexes). Brave/Kagi support query operators like site:, filetype:, lang:, before:, after:. Optional country/language apply only to locale-aware providers (brave, tavily, kagi).',
 			annotations: {
 				readOnlyHint: true,
 				destructiveHint: false,
@@ -57,6 +65,8 @@ export const register_web_search = (
 				limit: limit_schema,
 				include_domains: include_domains_schema,
 				exclude_domains: exclude_domains_schema,
+				country: country_schema,
+				language: language_schema,
 				large_result_mode: large_result_mode_schema,
 			}),
 		},
@@ -66,19 +76,33 @@ export const register_web_search = (
 			limit,
 			include_domains,
 			exclude_domains,
+			country,
+			language,
 			large_result_mode,
 		}) =>
 			handle_tool_result(
 				'web_search',
 				async () => {
 					const selected = providers.require(provider, 'web_search');
+					const locale_env = read_locale_env();
+					const locale = resolve_search_locale({
+						query,
+						param_country: country,
+						param_language: language,
+						config_country: locale_env.country,
+						config_language: locale_env.language,
+					});
 
-					return selected.search({
+					const results = await selected.search({
 						query,
 						limit,
 						include_domains,
 						exclude_domains,
+						country: locale.country,
+						language: locale_query_language(locale),
 					});
+
+					return with_locale_metadata(results, selected.name, locale);
 				},
 				{ large_result_mode },
 			),


### PR DESCRIPTION
## Summary

Adds optional server-wide and per-call locale defaults so non-US deploys (AT/DE/CH) can bias Brave, Tavily, and Kagi without changing providers that have no region/language parameters.

Per-call `country` / `language` win over `OMNISEARCH_COUNTRY` / `OMNISEARCH_LANGUAGE`. `language=auto` uses conservative query-language inference. Query language never changes country. Without config or overrides, current provider defaults stay.

## Scope

- Shared locale resolution and metadata in `src/common/locale.ts`
- `web_search` `country` / `language` params
- Locale-aware providers only: Brave (`country`, `search_lang`), Tavily (`country`), Kagi (`loc:` / `lang:`)
- Docs + changeset

`exa` and `kagi_enrichment` are unchanged.

## Verification

```bash
pnpm install
pnpm run format
pnpm test
pnpm run check
pnpm run build
```

- 136 tests passed, including locale resolution, provider request mapping, and MCP contract metadata
- Example: `web_search` with `provider: "brave"`, `country: "ch"`, and `OMNISEARCH_LANGUAGE=de` sends `country=CH` + `search_lang=de` and returns `metadata.locale.source`

## Impact

- No breaking change when unset
- No new API keys
- Invalid `OMNISEARCH_COUNTRY` / `OMNISEARCH_LANGUAGE` values are ignored with a warning

Fixes #200