### PR TITLE
Add read-only provider benchmark CLI and MCP tool

### DIFF
--- a/.changeset/provider-bench-203.md
+++ b/.changeset/provider-bench-203.md
@@ -1,0 +1,5 @@
+---
+'mcp-omnisearch': patch
+---
+
+feat: add a read-only provider benchmark CLI and MCP tool

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 A Model Context Protocol (MCP) server that provides unified access to
 Tavily, Brave, Kagi, Exa AI, GitHub, Linkup, and Firecrawl through
-four consolidated tools.
+four consolidated tools, plus an optional provider benchmark.
 
 <a href="https://glama.ai/mcp/servers/gz5wgmptd8">
   <img width="380" height="200" src="https://glama.ai/mcp/servers/gz5wgmptd8/badge" alt="Glama badge" />
@@ -91,6 +91,31 @@ Tavily, Kagi, Firecrawl, or Exa.
 	"provider": "kagi",
 	"mode": "summarize"
 }
+```
+
+### `provider_bench`
+
+Race configured `web_search` providers on a small fixed suite (docs,
+vendor release, community, non-English). Reports success rate, median
+latency, result volume, unique URLs, snippet coverage, and a
+recommended provider priority.
+
+This spends real API calls and quota. It does not write config and
+does not update cooldown or adaptive routing stats.
+
+```json
+{
+	"providers": ["brave", "tavily"],
+	"limit": 5
+}
+```
+
+CLI equivalent:
+
+```bash
+node ./dist/index.js --bench
+node ./dist/index.js --bench --json
+node ./dist/index.js --bench --providers tavily,brave --limit 5
 ```
 
 ## Documentation

--- a/docs/provider-selection.md
+++ b/docs/provider-selection.md
@@ -42,6 +42,17 @@ search only. See
 | `firecrawl` | `FIRECRAWL_API_KEY` | `scrape`, `crawl`, `map`, `extract`, `actions` | Scraping, crawling, site maps, structured extraction, and browser actions. |
 | `exa`       | `EXA_API_KEY`       | `contents`, `similar`                          | Page content retrieval and semantically similar URLs.                      |
 
+## Measure your providers
+
+`provider_bench` (or `mcp-omnisearch --bench`) races every configured
+`web_search` provider on a small fixed suite. Use it to rank providers
+on your keys and region before you pick a default `provider` for
+`web_search`.
+
+The command spends real API calls. It is read-only: it does not write
+MCP client config and does not feed cooldown or adaptive routing
+stats. Add `--json` for structured output.
+
 ## Provider choice cheatsheet
 
 - Need native operators like `filetype:pdf`, `intitle:`, or `before:`?

--- a/src/bench/cli.test.ts
+++ b/src/bench/cli.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from 'vitest';
+import { ErrorType, ProviderError } from '../common/types.js';
+import { PROVIDER_BENCH_WARNING } from './provider-bench.js';
+import {
+	format_help,
+	parse_bench_args,
+	parse_startup,
+	run_provider_bench_cli,
+} from './cli.js';
+
+describe('provider bench CLI', () => {
+	it('parses help, server, and bench startup actions', () => {
+		expect(parse_startup(['--help']).action).toBe('help');
+		expect(parse_startup(['-h']).action).toBe('help');
+		expect(parse_startup([])).toEqual({ action: 'server' });
+		expect(parse_startup(['--bench'])).toEqual({
+			action: 'bench',
+			options: { json: false },
+		});
+		expect(parse_startup(['bench', '--json'])).toEqual({
+			action: 'bench',
+			options: { json: true },
+		});
+		expect(parse_startup(['--bench', '--unknown'])).toEqual({
+			action: 'error',
+			message: 'Unknown bench option: --unknown',
+		});
+	});
+
+	it('parses bench flags and rejects invalid values', () => {
+		expect(
+			parse_bench_args([
+				'--bench',
+				'--json',
+				'--providers',
+				'tavily, brave',
+				'--limit',
+				'3',
+			]),
+		).toEqual({
+			json: true,
+			providers: ['tavily', 'brave'],
+			limit: 3,
+		});
+
+		expect(() => parse_bench_args(['--providers'])).toThrow(
+			/`--providers` requires a comma-separated list/,
+		);
+		expect(() => parse_bench_args(['--providers', ' , '])).toThrow(
+			/`--providers` requires a comma-separated list/,
+		);
+		expect(() => parse_bench_args(['--limit', '0'])).toThrow(
+			/`--limit` must be an integer from 1 to 50/,
+		);
+		expect(() => parse_bench_args(['--limit', 'nope'])).toThrow(
+			/`--limit` must be an integer from 1 to 50/,
+		);
+	});
+
+	it('prints help text that warns about quota spend', () => {
+		const help = format_help();
+		expect(help).toContain('mcp-omnisearch --bench');
+		expect(help).toContain(PROVIDER_BENCH_WARNING);
+	});
+
+	it('prints JSON and stays read-only', async () => {
+		const stdout: string[] = [];
+		const stderr: string[] = [];
+
+		const code = await run_provider_bench_cli({
+			args: ['--bench', '--json', '--limit', '2'],
+			providers: [
+				{
+					id: 'brave',
+					search: async () => [
+						{
+							title: 'Docs',
+							url: 'https://example.com',
+							snippet: 'Hello',
+							source_provider: 'brave',
+						},
+					],
+				},
+			],
+			stdout: (line) => stdout.push(line),
+			stderr: (line) => stderr.push(line),
+		});
+
+		expect(code).toBe(0);
+		expect(stderr[0]).toBe(PROVIDER_BENCH_WARNING);
+		expect(stderr[1]).toContain('Estimated requests: 4');
+		const report = JSON.parse(stdout[0]);
+		expect(report.wrote_config).toBe(false);
+		expect(report.feeds_adaptive_stats).toBe(false);
+		expect(report.recommended_priority).toEqual(['brave']);
+		expect(report.limit).toBe(2);
+	});
+
+	it('returns an error when no providers are configured', async () => {
+		const stderr: string[] = [];
+		const code = await run_provider_bench_cli({
+			args: ['--bench'],
+			providers: [],
+			stdout: () => {},
+			stderr: (line) => stderr.push(line),
+		});
+
+		expect(code).toBe(1);
+		expect(stderr.join('\n')).toContain(
+			'No web_search providers are configured',
+		);
+	});
+
+	it('returns an error for unknown provider filters', async () => {
+		const stderr: string[] = [];
+		const code = await run_provider_bench_cli({
+			args: ['--bench', '--providers', 'missing'],
+			providers: [
+				{
+					id: 'brave',
+					search: async () => {
+						throw new ProviderError(
+							ErrorType.API_ERROR,
+							'should not run',
+							'brave',
+						);
+					},
+				},
+			],
+			stdout: () => {},
+			stderr: (line) => stderr.push(line),
+		});
+
+		expect(code).toBe(1);
+		expect(stderr.join('\n')).toContain(
+			'Unknown or unconfigured provider',
+		);
+	});
+
+	it('prints help from the CLI runner', async () => {
+		const stdout: string[] = [];
+		const code = await run_provider_bench_cli({
+			args: ['--help'],
+			providers: [],
+			stdout: (line) => stdout.push(line),
+			stderr: () => {},
+		});
+
+		expect(code).toBe(0);
+		expect(stdout[0]).toContain('Usage:');
+	});
+
+	it('prints a table by default and rejects a server-only invocation', async () => {
+		const stdout: string[] = [];
+		const table_code = await run_provider_bench_cli({
+			args: ['--bench'],
+			providers: [
+				{
+					id: 'brave',
+					search: async () => [
+						{
+							title: 'Docs',
+							url: 'https://example.com',
+							snippet: 'Hello',
+							source_provider: 'brave',
+						},
+					],
+				},
+			],
+			stdout: (line) => stdout.push(line),
+			stderr: () => {},
+		});
+
+		expect(table_code).toBe(0);
+		expect(stdout[0]).toContain('Recommended provider priority:');
+
+		const stderr: string[] = [];
+		const server_code = await run_provider_bench_cli({
+			args: [],
+			providers: [],
+			stdout: () => {},
+			stderr: (line) => stderr.push(line),
+		});
+		expect(server_code).toBe(1);
+		expect(stderr[0]).toBe('Expected a bench command');
+	});
+});

--- a/src/bench/cli.ts
+++ b/src/bench/cli.ts
@@ -1,0 +1,182 @@
+import {
+	PROVIDER_BENCH_DEFAULT_LIMIT,
+	PROVIDER_BENCH_SUITE,
+	PROVIDER_BENCH_WARNING,
+	format_bench_text,
+	run_provider_bench,
+	select_bench_providers,
+	type BenchableProvider,
+	type ProviderBenchReport,
+} from './provider-bench.js';
+
+export interface ParsedBenchArgs {
+	json: boolean;
+	providers?: string[];
+	limit?: number;
+}
+
+export type StartupAction =
+	| { action: 'help'; text: string }
+	| { action: 'bench'; options: ParsedBenchArgs }
+	| { action: 'server' }
+	| { action: 'error'; message: string };
+
+export const format_help = (): string =>
+	[
+		'mcp-omnisearch — MCP server for Tavily, Brave, Kagi, Exa, GitHub, Linkup, and Firecrawl',
+		'',
+		'Usage:',
+		'  mcp-omnisearch                 Start the MCP server on stdio',
+		'  mcp-omnisearch --bench [opts]  Race configured web_search providers',
+		'  mcp-omnisearch --help          Show this help',
+		'',
+		'Bench options:',
+		'  --json              Print structured JSON instead of a table',
+		'  --providers a,b     Limit to these configured web_search providers',
+		'  --limit n           Results per query (default: 5, max: 50)',
+		'',
+		`Warning: ${PROVIDER_BENCH_WARNING}`,
+	].join('\n');
+
+export const is_help_request = (args: readonly string[]): boolean =>
+	args.includes('--help') || args.includes('-h');
+
+export const is_bench_request = (args: readonly string[]): boolean =>
+	args[0] === 'bench' || args.includes('--bench');
+
+export const parse_bench_args = (
+	args: readonly string[],
+): ParsedBenchArgs => {
+	const options: ParsedBenchArgs = { json: false };
+	const tokens = args.filter(
+		(arg) => arg !== '--bench' && arg !== 'bench',
+	);
+
+	for (let index = 0; index < tokens.length; index += 1) {
+		const token = tokens[index];
+		if (token === '--json') {
+			options.json = true;
+			continue;
+		}
+		if (token === '--help' || token === '-h') {
+			continue;
+		}
+		if (token === '--providers') {
+			const value = tokens[index + 1];
+			index += 1;
+			if (!value || value.startsWith('-')) {
+				throw new Error(
+					'`--providers` requires a comma-separated list',
+				);
+			}
+			const ids = value
+				.split(',')
+				.map((id) => id.trim())
+				.filter(Boolean);
+			if (ids.length === 0) {
+				throw new Error(
+					'`--providers` requires a comma-separated list',
+				);
+			}
+			options.providers = ids;
+			continue;
+		}
+		if (token === '--limit') {
+			const value = tokens[index + 1];
+			index += 1;
+			const limit = Number(value);
+			if (!Number.isInteger(limit) || limit < 1 || limit > 50) {
+				throw new Error('`--limit` must be an integer from 1 to 50');
+			}
+			options.limit = limit;
+			continue;
+		}
+		throw new Error(`Unknown bench option: ${token}`);
+	}
+
+	return options;
+};
+
+export const parse_startup = (
+	args: readonly string[],
+): StartupAction => {
+	if (is_help_request(args)) {
+		return { action: 'help', text: format_help() };
+	}
+
+	if (!is_bench_request(args)) {
+		return { action: 'server' };
+	}
+
+	try {
+		return { action: 'bench', options: parse_bench_args(args) };
+	} catch (error) {
+		return {
+			action: 'error',
+			message:
+				error instanceof Error
+					? error.message
+					: 'Invalid bench arguments',
+		};
+	}
+};
+
+export const format_bench_output = (
+	report: ProviderBenchReport,
+	json: boolean,
+): string =>
+	json ? JSON.stringify(report, null, 2) : format_bench_text(report);
+
+export interface RunProviderBenchCliOptions {
+	args: readonly string[];
+	providers: readonly BenchableProvider[];
+	stdout?: (line: string) => void;
+	stderr?: (line: string) => void;
+}
+
+export const run_provider_bench_cli = async ({
+	args,
+	providers,
+	stdout = console.log,
+	stderr = console.error,
+}: RunProviderBenchCliOptions): Promise<number> => {
+	const startup = parse_startup(args);
+	if (startup.action === 'help') {
+		stdout(startup.text);
+		return 0;
+	}
+	if (startup.action === 'error') {
+		stderr(startup.message);
+		return 1;
+	}
+	if (startup.action !== 'bench') {
+		stderr('Expected a bench command');
+		return 1;
+	}
+
+	try {
+		const selected = select_bench_providers(
+			providers,
+			startup.options.providers,
+		);
+		const estimated = selected.length * PROVIDER_BENCH_SUITE.length;
+		stderr(PROVIDER_BENCH_WARNING);
+		stderr(
+			`Estimated requests: ${estimated} (${selected.length} providers × 4 queries). Limit ${startup.options.limit ?? PROVIDER_BENCH_DEFAULT_LIMIT} results each.`,
+		);
+
+		const report = await run_provider_bench({
+			providers: selected,
+			limit: startup.options.limit,
+		});
+		stdout(format_bench_output(report, startup.options.json));
+		return 0;
+	} catch (error) {
+		stderr(
+			error instanceof Error
+				? error.message
+				: 'Provider bench failed',
+		);
+		return 1;
+	}
+};

--- a/src/bench/provider-bench.test.ts
+++ b/src/bench/provider-bench.test.ts
@@ -1,0 +1,305 @@
+import { describe, expect, it } from 'vitest';
+import { ErrorType, ProviderError } from '../common/types.js';
+import {
+	PROVIDER_BENCH_SUITE,
+	PROVIDER_BENCH_WARNING,
+	bench_error_code,
+	bench_error_message,
+	format_bench_text,
+	median,
+	normalize_result_url,
+	rank_providers,
+	run_provider_bench,
+	select_bench_providers,
+	type BenchProviderSummary,
+	type BenchableProvider,
+} from './provider-bench.js';
+
+const result = (
+	url: string,
+	snippet = 'A useful snippet',
+	title = 'Example',
+) => ({
+	title,
+	url,
+	snippet,
+	source_provider: 'test',
+});
+
+const provider = (
+	id: string,
+	search: BenchableProvider['search'],
+): BenchableProvider => ({ id, search });
+
+const summary = (
+	overrides: Partial<BenchProviderSummary> & { provider: string },
+): BenchProviderSummary => ({
+	attempts: 4,
+	successes: 4,
+	success_rate: 1,
+	median_latency_ms: 100,
+	result_volume: 8,
+	unique_urls: 8,
+	snippet_coverage: 1,
+	...overrides,
+});
+
+describe('provider bench helpers', () => {
+	it('normalizes URLs for uniqueness', () => {
+		expect(
+			normalize_result_url('https://Docs.Example.com/Path/'),
+		).toBe('https://docs.example.com/Path');
+		expect(normalize_result_url('not a url')).toBe('not a url');
+	});
+
+	it('computes median for odd, even, and empty lists', () => {
+		expect(median([])).toBeNull();
+		expect(median([3])).toBe(3);
+		expect(median([1, 3, 2])).toBe(2);
+		expect(median([4, 2])).toBe(3);
+	});
+
+	it('maps provider errors to bounded bench codes', () => {
+		expect(
+			bench_error_code(
+				new ProviderError(ErrorType.AUTH_ERROR, 'bad key', 'brave'),
+			),
+		).toBe('auth_error');
+		expect(
+			bench_error_code(
+				new ProviderError(ErrorType.RATE_LIMIT, 'slow down', 'brave'),
+			),
+		).toBe('rate_limited');
+		expect(
+			bench_error_code(
+				new ProviderError(ErrorType.TIMEOUT, 'late', 'brave'),
+			),
+		).toBe('timeout');
+		expect(
+			bench_error_code(
+				new ProviderError(ErrorType.INVALID_INPUT, 'nope', 'brave'),
+			),
+		).toBe('invalid_input');
+		expect(
+			bench_error_code(
+				new ProviderError(ErrorType.API_ERROR, 'boom', 'brave'),
+			),
+		).toBe('provider_error');
+		expect(bench_error_code('string')).toBe('provider_error');
+		expect(bench_error_message('string')).toBe(
+			'Unknown provider error',
+		);
+		expect(
+			bench_error_message(
+				new Error(`  too   wide  ${'x'.repeat(300)}`),
+			),
+		).toHaveLength(240);
+	});
+
+	it('selects configured providers and rejects unknown ids', () => {
+		const available = [
+			provider('brave', async () => []),
+			provider('tavily', async () => []),
+		];
+
+		expect(
+			select_bench_providers(available).map((entry) => entry.id),
+		).toEqual(['brave', 'tavily']);
+		expect(
+			select_bench_providers(available, ['tavily']).map(
+				(entry) => entry.id,
+			),
+		).toEqual(['tavily']);
+		expect(() => select_bench_providers([])).toThrow(ProviderError);
+		expect(() =>
+			select_bench_providers(available, ['missing']),
+		).toThrow(/Unknown or unconfigured provider/);
+	});
+
+	it('ranks by success, latency, quality, then volume', () => {
+		expect(
+			rank_providers([
+				summary({
+					provider: 'slow',
+					success_rate: 0.5,
+					median_latency_ms: 10,
+				}),
+				summary({ provider: 'reliable', success_rate: 1 }),
+			]),
+		).toEqual(['reliable', 'slow']);
+
+		expect(
+			rank_providers([
+				summary({ provider: 'slow', median_latency_ms: 300 }),
+				summary({ provider: 'fast', median_latency_ms: 80 }),
+			]),
+		).toEqual(['fast', 'slow']);
+
+		expect(
+			rank_providers([
+				summary({
+					provider: 'failed',
+					success_rate: 0,
+					median_latency_ms: null,
+				}),
+				summary({ provider: 'ok', median_latency_ms: 200 }),
+			]),
+		).toEqual(['ok', 'failed']);
+
+		expect(
+			rank_providers([
+				summary({
+					provider: 'thin',
+					unique_urls: 2,
+					snippet_coverage: 0.2,
+				}),
+				summary({
+					provider: 'rich',
+					unique_urls: 8,
+					snippet_coverage: 1,
+				}),
+			]),
+		).toEqual(['rich', 'thin']);
+
+		expect(
+			rank_providers([
+				summary({
+					provider: 'few',
+					result_volume: 2,
+					unique_urls: 2,
+				}),
+				summary({
+					provider: 'many',
+					result_volume: 10,
+					unique_urls: 10,
+				}),
+			]),
+		).toEqual(['many', 'few']);
+
+		expect(
+			rank_providers([
+				summary({ provider: 'zeta' }),
+				summary({ provider: 'alpha' }),
+			]),
+		).toEqual(['alpha', 'zeta']);
+	});
+});
+
+describe('run_provider_bench', () => {
+	it('races the fixed suite and recommends a priority without writing config', async () => {
+		let clock = 0;
+		const report = await run_provider_bench({
+			now: () => {
+				clock += 40;
+				return clock;
+			},
+			providers: [
+				provider('tavily', async () => [
+					result('https://svelte.dev/docs'),
+					result('https://svelte.dev/docs/'),
+				]),
+				provider('brave', async ({ query }) => {
+					if (query.includes('documentación')) {
+						throw new ProviderError(
+							ErrorType.TIMEOUT,
+							'timed out',
+							'brave',
+						);
+					}
+					return [result('https://example.com/a', '')];
+				}),
+			],
+		});
+
+		expect(report.warning).toBe(PROVIDER_BENCH_WARNING);
+		expect(report.spent_api_calls).toBe(true);
+		expect(report.wrote_config).toBe(false);
+		expect(report.feeds_cooldown).toBe(false);
+		expect(report.feeds_adaptive_stats).toBe(false);
+		expect(report.estimated_requests).toBe(8);
+		expect(report.suite.map((entry) => entry.id)).toEqual(
+			PROVIDER_BENCH_SUITE.map((entry) => entry.id),
+		);
+		expect(report.recommended_priority[0]).toBe('tavily');
+		expect(report.config_change.applied).toBe(false);
+		expect(report.config_change.recommended_provider).toBe('tavily');
+		expect(report.config_change.apply).toContain(
+			'does not write MCP client or env files',
+		);
+
+		const tavily = report.summary.find(
+			(entry) => entry.provider === 'tavily',
+		)!;
+		expect(tavily.successes).toBe(4);
+		expect(tavily.unique_urls).toBe(1);
+		expect(tavily.snippet_coverage).toBe(1);
+
+		const brave = report.summary.find(
+			(entry) => entry.provider === 'brave',
+		)!;
+		expect(brave.successes).toBe(3);
+		expect(brave.snippet_coverage).toBe(0);
+		expect(
+			report.runs.find(
+				(run) =>
+					run.provider === 'brave' && run.case_id === 'non_english',
+			),
+		).toEqual(
+			expect.objectContaining({
+				ok: false,
+				error: {
+					code: 'timeout',
+					message: 'timed out',
+				},
+			}),
+		);
+
+		const text = format_bench_text(report);
+		expect(text).toContain('Warning:');
+		expect(text).toContain('Wrote config: no');
+		expect(text).toContain('Recommended provider priority: tavily');
+		expect(text).toContain('Config change (not applied)');
+	});
+
+	it('keeps recommendations empty when every provider fails', async () => {
+		const report = await run_provider_bench({
+			suite: [PROVIDER_BENCH_SUITE[0]],
+			providers: [
+				provider('brave', async () => {
+					throw new Error('nope');
+				}),
+			],
+		});
+
+		expect(report.config_change.recommended_provider).toBeNull();
+		expect(report.config_change.apply).toContain(
+			'No provider completed a successful search',
+		);
+		expect(format_bench_text(report)).toContain('n/a');
+	});
+
+	it('formats an empty recommendation list', () => {
+		const text = format_bench_text({
+			warning: PROVIDER_BENCH_WARNING,
+			spent_api_calls: true,
+			estimated_requests: 0,
+			wrote_config: false,
+			feeds_cooldown: false,
+			feeds_adaptive_stats: false,
+			limit: 5,
+			suite: [],
+			providers: [],
+			runs: [],
+			summary: [],
+			recommended_priority: [],
+			config_change: {
+				applied: false,
+				recommended_provider: null,
+				recommended_priority: [],
+				apply: 'none',
+			},
+		});
+
+		expect(text).toContain('Recommended provider priority: (none)');
+	});
+});

--- a/src/bench/provider-bench.ts
+++ b/src/bench/provider-bench.ts
@@ -1,0 +1,436 @@
+import {
+	ErrorType,
+	ProviderError,
+	type BaseSearchParams,
+	type SearchResult,
+} from '../common/types.js';
+
+export const PROVIDER_BENCH_WARNING =
+	'This benchmark spends real API calls and quota. It is read-only: it does not write config and does not update cooldown or adaptive routing stats.';
+
+export const PROVIDER_BENCH_DEFAULT_LIMIT = 5;
+
+export interface BenchCase {
+	id: 'docs' | 'vendor_release' | 'community' | 'non_english';
+	label: string;
+	query: string;
+}
+
+export const PROVIDER_BENCH_SUITE: readonly BenchCase[] = [
+	{
+		id: 'docs',
+		label: 'docs',
+		query: 'SvelteKit remote functions official documentation',
+	},
+	{
+		id: 'vendor_release',
+		label: 'vendor release',
+		query: 'Node.js 22 release notes',
+	},
+	{
+		id: 'community',
+		label: 'community',
+		query: 'Svelte 5 runes community discussion',
+	},
+	{
+		id: 'non_english',
+		label: 'non-English',
+		query: 'documentación oficial de SvelteKit',
+	},
+];
+
+export interface BenchableProvider {
+	id: string;
+	search: (params: BaseSearchParams) => Promise<SearchResult[]>;
+}
+
+export type BenchErrorCode =
+	| 'auth_error'
+	| 'rate_limited'
+	| 'timeout'
+	| 'invalid_input'
+	| 'provider_error';
+
+export interface BenchRun {
+	provider: string;
+	case_id: BenchCase['id'];
+	ok: boolean;
+	latency_ms: number;
+	result_count: number;
+	unique_urls: number;
+	snippet_coverage: number;
+	error?: {
+		code: BenchErrorCode;
+		message: string;
+	};
+}
+
+export interface BenchProviderSummary {
+	provider: string;
+	attempts: number;
+	successes: number;
+	success_rate: number;
+	median_latency_ms: number | null;
+	result_volume: number;
+	unique_urls: number;
+	snippet_coverage: number;
+}
+
+export interface ProviderBenchReport {
+	warning: string;
+	spent_api_calls: true;
+	estimated_requests: number;
+	wrote_config: false;
+	feeds_cooldown: false;
+	feeds_adaptive_stats: false;
+	limit: number;
+	suite: Array<{ id: BenchCase['id']; label: string; query: string }>;
+	providers: string[];
+	runs: BenchRun[];
+	summary: BenchProviderSummary[];
+	recommended_priority: string[];
+	config_change: {
+		applied: false;
+		recommended_provider: string | null;
+		recommended_priority: string[];
+		apply: string;
+	};
+}
+
+export interface RunProviderBenchOptions {
+	providers: BenchableProvider[];
+	suite?: readonly BenchCase[];
+	limit?: number;
+	now?: () => number;
+}
+
+export const normalize_result_url = (url: string): string => {
+	try {
+		const parsed = new URL(url);
+		parsed.hash = '';
+		parsed.hostname = parsed.hostname.toLowerCase();
+		if (parsed.pathname.endsWith('/') && parsed.pathname !== '/') {
+			parsed.pathname = parsed.pathname.slice(0, -1);
+		}
+		return parsed.toString();
+	} catch {
+		return url.trim();
+	}
+};
+
+export const median = (values: readonly number[]): number | null => {
+	if (values.length === 0) return null;
+	const sorted = [...values].sort((a, b) => a - b);
+	const middle = Math.floor(sorted.length / 2);
+	if (sorted.length % 2 === 0) {
+		return (sorted[middle - 1] + sorted[middle]) / 2;
+	}
+	return sorted[middle];
+};
+
+export const bench_error_code = (error: unknown): BenchErrorCode => {
+	if (error instanceof ProviderError) {
+		switch (error.type) {
+			case ErrorType.AUTH_ERROR:
+				return 'auth_error';
+			case ErrorType.RATE_LIMIT:
+				return 'rate_limited';
+			case ErrorType.TIMEOUT:
+				return 'timeout';
+			case ErrorType.INVALID_INPUT:
+				return 'invalid_input';
+			default:
+				return 'provider_error';
+		}
+	}
+	return 'provider_error';
+};
+
+export const bench_error_message = (error: unknown): string => {
+	if (error instanceof Error && error.message.trim()) {
+		return error.message.replace(/\s+/g, ' ').slice(0, 240);
+	}
+	return 'Unknown provider error';
+};
+
+export const select_bench_providers = (
+	available: readonly BenchableProvider[],
+	requested?: readonly string[],
+): BenchableProvider[] => {
+	if (available.length === 0) {
+		throw new ProviderError(
+			ErrorType.INVALID_INPUT,
+			'No web_search providers are configured. Set at least one search API key.',
+			'provider_bench',
+		);
+	}
+
+	const sorted_available = [...available].sort((left, right) =>
+		left.id.localeCompare(right.id),
+	);
+
+	if (!requested || requested.length === 0) {
+		return sorted_available;
+	}
+
+	const by_id = new Map(
+		sorted_available.map((provider) => [provider.id, provider]),
+	);
+	const missing = requested.filter((id) => !by_id.has(id));
+	if (missing.length > 0) {
+		throw new ProviderError(
+			ErrorType.INVALID_INPUT,
+			`Unknown or unconfigured provider(s): ${missing.join(', ')}. Available: ${sorted_available.map((provider) => provider.id).join(', ')}`,
+			'provider_bench',
+		);
+	}
+
+	return requested.map((id) => by_id.get(id)!);
+};
+
+const quality_score = (summary: BenchProviderSummary): number => {
+	const unique_ratio =
+		summary.result_volume === 0
+			? 0
+			: summary.unique_urls / summary.result_volume;
+	return unique_ratio * 0.5 + summary.snippet_coverage * 0.5;
+};
+
+export const rank_providers = (
+	summaries: readonly BenchProviderSummary[],
+): string[] =>
+	[...summaries]
+		.sort((left, right) => {
+			if (right.success_rate !== left.success_rate) {
+				return right.success_rate - left.success_rate;
+			}
+
+			const left_latency = left.median_latency_ms;
+			const right_latency = right.median_latency_ms;
+			if (left_latency === null && right_latency !== null) return 1;
+			if (left_latency !== null && right_latency === null) return -1;
+			if (
+				left_latency !== null &&
+				right_latency !== null &&
+				left_latency !== right_latency
+			) {
+				return left_latency - right_latency;
+			}
+
+			const quality_delta =
+				quality_score(right) - quality_score(left);
+			if (quality_delta !== 0) return quality_delta;
+
+			if (right.result_volume !== left.result_volume) {
+				return right.result_volume - left.result_volume;
+			}
+
+			return left.provider.localeCompare(right.provider);
+		})
+		.map((summary) => summary.provider);
+
+const summarize_provider = (
+	provider: string,
+	runs: readonly BenchRun[],
+	url_union: ReadonlySet<string>,
+	snippet_hits: number,
+	snippet_total: number,
+): BenchProviderSummary => {
+	const successes = runs.filter((run) => run.ok);
+	const result_volume = successes.reduce(
+		(sum, run) => sum + run.result_count,
+		0,
+	);
+
+	return {
+		provider,
+		attempts: runs.length,
+		successes: successes.length,
+		success_rate:
+			runs.length === 0 ? 0 : successes.length / runs.length,
+		median_latency_ms: median(successes.map((run) => run.latency_ms)),
+		result_volume,
+		unique_urls: url_union.size,
+		snippet_coverage:
+			snippet_total === 0 ? 0 : snippet_hits / snippet_total,
+	};
+};
+
+const run_case = async (
+	provider: BenchableProvider,
+	test_case: BenchCase,
+	limit: number,
+	now: () => number,
+): Promise<{
+	run: BenchRun;
+	urls: string[];
+	snippet_hits: number;
+}> => {
+	const started = now();
+	try {
+		const results = await provider.search({
+			query: test_case.query,
+			limit,
+		});
+		const latency_ms = Math.max(0, Math.round(now() - started));
+		const urls = results.map((result) =>
+			normalize_result_url(result.url),
+		);
+		const snippet_hits = results.filter(
+			(result) => result.snippet.trim().length > 0,
+		).length;
+
+		return {
+			run: {
+				provider: provider.id,
+				case_id: test_case.id,
+				ok: true,
+				latency_ms,
+				result_count: results.length,
+				unique_urls: new Set(urls).size,
+				snippet_coverage:
+					results.length === 0 ? 0 : snippet_hits / results.length,
+			},
+			urls,
+			snippet_hits,
+		};
+	} catch (error) {
+		return {
+			run: {
+				provider: provider.id,
+				case_id: test_case.id,
+				ok: false,
+				latency_ms: Math.max(0, Math.round(now() - started)),
+				result_count: 0,
+				unique_urls: 0,
+				snippet_coverage: 0,
+				error: {
+					code: bench_error_code(error),
+					message: bench_error_message(error),
+				},
+			},
+			urls: [],
+			snippet_hits: 0,
+		};
+	}
+};
+
+export const run_provider_bench = async ({
+	providers,
+	suite = PROVIDER_BENCH_SUITE,
+	limit = PROVIDER_BENCH_DEFAULT_LIMIT,
+	now = () => performance.now(),
+}: RunProviderBenchOptions): Promise<ProviderBenchReport> => {
+	const selected = select_bench_providers(providers);
+	const runs: BenchRun[] = [];
+	const urls_by_provider = new Map<string, Set<string>>();
+	const snippets_by_provider = new Map<
+		string,
+		{ hits: number; total: number }
+	>();
+
+	for (const provider of selected) {
+		urls_by_provider.set(provider.id, new Set());
+		snippets_by_provider.set(provider.id, { hits: 0, total: 0 });
+	}
+
+	for (const test_case of suite) {
+		for (const provider of selected) {
+			const { run, urls, snippet_hits } = await run_case(
+				provider,
+				test_case,
+				limit,
+				now,
+			);
+			runs.push(run);
+			for (const url of urls) {
+				urls_by_provider.get(provider.id)!.add(url);
+			}
+			const snippets = snippets_by_provider.get(provider.id)!;
+			snippets.hits += snippet_hits;
+			snippets.total += run.result_count;
+		}
+	}
+
+	const summary = selected.map((provider) => {
+		const snippets = snippets_by_provider.get(provider.id)!;
+		return summarize_provider(
+			provider.id,
+			runs.filter((run) => run.provider === provider.id),
+			urls_by_provider.get(provider.id)!,
+			snippets.hits,
+			snippets.total,
+		);
+	});
+
+	const recommended_priority = rank_providers(summary);
+	const recommended_provider =
+		summary.find(
+			(entry) =>
+				entry.provider === recommended_priority[0] &&
+				entry.successes > 0,
+		)?.provider ?? null;
+
+	const apply = recommended_provider
+		? `Use provider "${recommended_provider}" first on web_search. Suggested priority: ${recommended_priority.join(',')}. This command does not write MCP client or env files.`
+		: 'No provider completed a successful search. Check API keys and retry. This command does not write MCP client or env files.';
+
+	return {
+		warning: PROVIDER_BENCH_WARNING,
+		spent_api_calls: true,
+		estimated_requests: selected.length * suite.length,
+		wrote_config: false,
+		feeds_cooldown: false,
+		feeds_adaptive_stats: false,
+		limit,
+		suite: suite.map((test_case) => ({
+			id: test_case.id,
+			label: test_case.label,
+			query: test_case.query,
+		})),
+		providers: selected.map((provider) => provider.id),
+		runs,
+		summary,
+		recommended_priority,
+		config_change: {
+			applied: false,
+			recommended_provider,
+			recommended_priority,
+			apply,
+		},
+	};
+};
+
+export const format_bench_text = (
+	report: ProviderBenchReport,
+): string => {
+	const lines = [
+		`Warning: ${report.warning}`,
+		`Estimated requests: ${report.estimated_requests} (${report.providers.length} providers × ${report.suite.length} queries)`,
+		'Wrote config: no',
+		'Feeds cooldown / adaptive stats: no',
+		'',
+		'Provider          Success  Median   Volume  Unique  Snippets',
+	];
+
+	for (const entry of report.summary) {
+		const median_label =
+			entry.median_latency_ms === null
+				? 'n/a'
+				: `${Math.round(entry.median_latency_ms)}ms`;
+		const snippets = `${Math.round(entry.snippet_coverage * 100)}%`;
+		lines.push(
+			`${entry.provider.padEnd(17)} ${String(entry.successes).padStart(1)}/${entry.attempts}     ${median_label.padEnd(7)} ${String(entry.result_volume).padEnd(7)} ${String(entry.unique_urls).padEnd(7)} ${snippets}`,
+		);
+	}
+
+	lines.push('');
+	lines.push(
+		`Recommended provider priority: ${report.recommended_priority.join(', ') || '(none)'}`,
+	);
+	lines.push(
+		`Config change (not applied): ${report.config_change.apply}`,
+	);
+
+	return lines.join('\n');
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,16 +4,21 @@ import { ValibotJsonSchemaAdapter } from '@tmcp/adapter-valibot';
 import { StdioTransport } from '@tmcp/transport-stdio';
 import { McpServer } from 'tmcp';
 import type { GenericSchema } from 'valibot';
-import { validate_config } from './config/env.js';
-import { setup_handlers } from './server/handlers.js';
-import {
-	initialize_providers,
-	register_tools,
-} from './server/tools/index.js';
-
 import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import {
+	parse_startup,
+	run_provider_bench_cli,
+} from './bench/cli.js';
+import { validate_config } from './config/env.js';
+import { setup_handlers } from './server/handlers.js';
+import {
+	get_search_provider_entries,
+	initialize_providers,
+	register_tools,
+} from './server/tools/index.js';
+import { to_benchable_providers } from './server/tools/provider-bench.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -65,5 +70,23 @@ class OmnisearchServer {
 	}
 }
 
-const server = new OmnisearchServer();
-server.run().catch(console.error);
+const startup = parse_startup(process.argv.slice(2));
+
+if (startup.action === 'help') {
+	console.log(startup.text);
+} else if (startup.action === 'error') {
+	console.error(startup.message);
+	process.exitCode = 1;
+} else if (startup.action === 'bench') {
+	validate_config();
+	initialize_providers();
+	void run_provider_bench_cli({
+		args: process.argv.slice(2),
+		providers: to_benchable_providers(get_search_provider_entries()),
+	}).then((code) => {
+		process.exit(code);
+	});
+} else {
+	const server = new OmnisearchServer();
+	server.run().catch(console.error);
+}

--- a/src/server/tools/contract.test.ts
+++ b/src/server/tools/contract.test.ts
@@ -82,7 +82,7 @@ afterEach(() => {
 	vi.restoreAllMocks();
 });
 
-describe('MCP tool contract', () => {
+describe('MCP tool contract', { timeout: 15_000 }, () => {
 	it('registers no public tools when no providers are configured', async () => {
 		const { tools, tools_module } = await load_contract({});
 
@@ -108,6 +108,7 @@ describe('MCP tool contract', () => {
 
 		expect(tools.map((tool) => tool.definition.name)).toEqual([
 			'web_search',
+			'provider_bench',
 			'github_search',
 			'ai_search',
 			'web_extract',
@@ -310,6 +311,81 @@ describe('MCP tool contract', () => {
 				file_path: expect.stringContaining('mcp-web_extract-'),
 				estimated_tokens: expect.any(Number),
 				read_hint: expect.stringContaining('Use Read tool'),
+			}),
+		);
+	});
+
+	it('registers provider_bench only when a web_search provider is configured', async () => {
+		const github_only = await load_contract({
+			GITHUB_API_KEY: 'github-token',
+		});
+		expect(
+			github_only.tools.map((tool) => tool.definition.name),
+		).toEqual(['github_search']);
+
+		const { tools } = await load_contract({
+			BRAVE_API_KEY: 'brave-key',
+		});
+		expect(tools.map((tool) => tool.definition.name)).toEqual([
+			'web_search',
+			'provider_bench',
+		]);
+
+		const schema = tools.find(
+			(tool) => tool.definition.name === 'provider_bench',
+		)!.definition.schema;
+		expect(v.safeParse(schema, {}).success).toBe(true);
+		expect(
+			v.safeParse(schema, { providers: ['brave'], limit: 3 }).success,
+		).toBe(true);
+		expect(v.safeParse(schema, { providers: ['kagi'] }).success).toBe(
+			false,
+		);
+		expect(v.safeParse(schema, { providers: [] }).success).toBe(
+			false,
+		);
+
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockImplementation(
+				() =>
+					new Response(
+						JSON.stringify({
+							web: {
+								results: [
+									{
+										title: 'Example',
+										url: 'https://example.com',
+										description: 'Example result',
+									},
+								],
+							},
+						}),
+						{ status: 200 },
+					),
+			),
+		);
+
+		const tool = tools.find(
+			(entry) => entry.definition.name === 'provider_bench',
+		)!;
+		const body = parse_tool_body(
+			await tool.handler({
+				limit: 2,
+				large_result_mode: 'inline',
+			}),
+		);
+
+		expect(body.warning).toContain('real API calls');
+		expect(body.wrote_config).toBe(false);
+		expect(body.feeds_cooldown).toBe(false);
+		expect(body.feeds_adaptive_stats).toBe(false);
+		expect(body.recommended_priority).toEqual(['brave']);
+		expect(body.summary[0]).toEqual(
+			expect.objectContaining({
+				provider: 'brave',
+				successes: 4,
+				attempts: 4,
 			}),
 		);
 	});

--- a/src/server/tools/index.ts
+++ b/src/server/tools/index.ts
@@ -19,12 +19,16 @@ import {
 	initialize_web_extract,
 	register_web_extract,
 } from './web-extract.js';
+import { register_provider_bench } from './provider-bench.js';
 import {
 	get_provider_status_entries as get_search_provider_status_entries,
 	get_available_providers as get_search_providers,
+	get_search_provider_entries,
 	initialize_web_search,
 	register_web_search,
 } from './web-search.js';
+
+export { get_search_provider_entries };
 
 // Track providers by category for the status resource
 export const available_providers = {
@@ -104,6 +108,7 @@ export const initialize_providers = () => {
 
 export const register_tools = (server: McpServer<GenericSchema>) => {
 	register_web_search(server);
+	register_provider_bench(server);
 	register_github_search(server);
 	register_ai_search(server);
 	register_web_extract(server);

--- a/src/server/tools/provider-bench.test.ts
+++ b/src/server/tools/provider-bench.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import type { SearchProvider } from '../../common/types.js';
+import type { RegisteredProvider } from '../provider-registry.js';
+import { to_benchable_providers } from './provider-bench.js';
+
+describe('provider_bench tool helpers', () => {
+	it('adapts registered search providers for the bench runner', async () => {
+		const search = async () => [
+			{
+				title: 'Example',
+				url: 'https://example.com',
+				snippet: 'Hello',
+				source_provider: 'brave',
+			},
+		];
+		const entries = [
+			{
+				id: 'brave',
+				name: 'brave',
+				category: 'search',
+				instance: {
+					name: 'brave',
+					description: 'Brave Search',
+					search,
+				},
+				tools: ['web_search'],
+				modes: [],
+				capabilities: ['web_search'],
+			},
+		] as RegisteredProvider<SearchProvider>[];
+
+		const benchable = to_benchable_providers(entries);
+		expect(benchable).toHaveLength(1);
+		expect(benchable[0].id).toBe('brave');
+		await expect(
+			benchable[0].search({ query: 'test' }),
+		).resolves.toEqual([
+			{
+				title: 'Example',
+				url: 'https://example.com',
+				snippet: 'Hello',
+				source_provider: 'brave',
+			},
+		]);
+	});
+});

--- a/src/server/tools/provider-bench.ts
+++ b/src/server/tools/provider-bench.ts
@@ -1,0 +1,72 @@
+import { McpServer } from 'tmcp';
+import type { GenericSchema } from 'valibot';
+import * as v from 'valibot';
+import {
+	PROVIDER_BENCH_WARNING,
+	run_provider_bench,
+	select_bench_providers,
+	type BenchableProvider,
+} from '../../bench/provider-bench.js';
+import type { SearchProvider } from '../../common/types.js';
+import type { RegisteredProvider } from '../provider-registry.js';
+import { handle_tool_result } from './responses.js';
+import { large_result_mode_schema, limit_schema } from './schemas.js';
+import { get_search_provider_entries } from './web-search.js';
+
+export const to_benchable_providers = (
+	entries: readonly RegisteredProvider<SearchProvider>[],
+): BenchableProvider[] =>
+	entries.map((entry) => ({
+		id: entry.id,
+		search: (params) => entry.instance.search(params),
+	}));
+
+export const register_provider_bench = (
+	server: McpServer<GenericSchema>,
+) => {
+	const available = to_benchable_providers(
+		get_search_provider_entries(),
+	);
+	if (available.length === 0) return;
+
+	const provider_names = available.map((provider) => provider.id);
+
+	server.tool(
+		{
+			name: 'provider_bench',
+			description: `Race configured web_search providers on a small fixed suite (docs, vendor release, community, non-English). WARNING: ${PROVIDER_BENCH_WARNING} Returns success rate, median latency, result volume, unique URLs, snippet coverage, and a recommended provider priority.`,
+			annotations: {
+				readOnlyHint: true,
+				destructiveHint: false,
+				idempotentHint: false,
+				openWorldHint: true,
+			},
+			schema: v.object({
+				providers: v.optional(
+					v.pipe(
+						v.array(v.picklist(provider_names)),
+						v.minLength(1, 'Provide at least one provider'),
+						v.description(
+							'Limit the bench to these configured web_search providers',
+						),
+					),
+				),
+				limit: limit_schema,
+				large_result_mode: large_result_mode_schema,
+			}),
+		},
+		async ({ providers, limit, large_result_mode }) =>
+			handle_tool_result(
+				'provider_bench',
+				async () =>
+					run_provider_bench({
+						providers: select_bench_providers(
+							to_benchable_providers(get_search_provider_entries()),
+							providers,
+						),
+						limit,
+					}),
+				{ large_result_mode },
+			),
+	);
+};

--- a/src/server/tools/web-search.ts
+++ b/src/server/tools/web-search.ts
@@ -27,6 +27,8 @@ export const initialize_web_search = (): boolean => {
 
 export const get_available_providers = () => providers.names();
 
+export const get_search_provider_entries = () => providers.entries();
+
 export const get_provider_status_entries = () =>
 	providers.status_entries();
 


### PR DESCRIPTION
## Summary

Adds a focused, read-only way to race configured `web_search` providers on a small fixed suite (docs, vendor release, community, non-English) so recommended provider priority is measured on the caller’s keys and region.

The CLI (`mcp-omnisearch --bench`, optional `--json`) and MCP tool (`provider_bench`) report success rate, median latency, result volume, unique URLs, and snippet coverage. They warn that the run spends real API calls, do not write config, and do not update cooldown or adaptive routing stats.

Fixes #203.

## Scope

- `src/bench/*` — suite, metrics, ranking, text/JSON formatting, CLI parsing
- `src/server/tools/provider-bench.ts` — MCP tool registered only when a web search provider is configured
- `src/index.ts` — `--help` / `--bench` dispatch before starting stdio
- README, provider-selection docs, changeset, and contract tests

No provider HTTP adapters, retry, or config-file writers were added.

## Verification

- `pnpm test` — 126 tests passed
- `vp check` — format, lint, and types clean
- `pnpm run build` then `node ./dist/index.js --help`
- `node ./dist/index.js --bench --json` with no keys exits `1` and prints the quota warning plus “does not write config”

## Impact

- Non-breaking. Existing tools are unchanged.
- `provider_bench` is opt-in and only registered when at least one `web_search` provider has a key.
- Running the bench spends real provider quota (`providers × 4` requests). It never writes MCP client or env files.