### PR TITLE
feat: add optional request budgets for max providers, timeout, and estimated cost

### DIFF
--- a/.changeset/request-budgets.md
+++ b/.changeset/request-budgets.md
@@ -1,0 +1,6 @@
+---
+'mcp-omnisearch': patch
+---
+
+feat: add optional request budgets for max providers, timeout, and
+estimated cost

--- a/README.md
+++ b/README.md
@@ -120,10 +120,30 @@ Tavily, Kagi, Firecrawl, or Exa.
 }
 ```
 
+### Request budgets
+
+Optional on `web_search`, `ai_search`, and `web_extract`.
+Single-provider calls ignore these knobs. Multi-provider plans can cap
+how many providers run, how long the whole call may take, and how much
+estimated USD the plan may spend. Impossible USD plans fail before any
+provider is called.
+
+```json
+{
+	"query": "sveltekit remote functions",
+	"provider": "brave",
+	"max_providers": 3,
+	"timeout_seconds": 20,
+	"budget_usd": 0.02
+}
+```
+
 ## Documentation
 
 - [Provider selection](docs/provider-selection.md) — choose providers
   by task, key, mode, and capability.
+- [Request budgets](docs/request-budgets.md) — max providers,
+  whole-call timeout, and optional estimated USD.
 - [Search operators](docs/search-operators.md) — operator support
   matrix and tested examples.
 - [Large results](docs/large-results.md) — inline vs file response

--- a/docs/request-budgets.md
+++ b/docs/request-budgets.md
@@ -1,0 +1,72 @@
+# Request budgets
+
+Optional request-level caps for multi-provider plans. They exist so
+fan-out cannot become an accidental bill. **Single-provider calls
+ignore these knobs** and keep the current cheap path.
+
+Available on `web_search`, `ai_search`, and `web_extract`.
+
+## Knobs
+
+| Argument          | Default (multi-provider only) | Purpose                                                                 |
+| ----------------- | ----------------------------- | ----------------------------------------------------------------------- |
+| `max_providers`   | `3`                           | Maximum providers to run. A max, not a min.                             |
+| `timeout_seconds` | `20`                          | Whole-call wall time. Remaining provider work is cancelled on timeout.  |
+| `budget_usd`      | unset                         | Estimated USD cap. Impossible plans fail before any provider is called. |
+
+`github_search` is always one provider, so it does not accept these
+fields.
+
+## Single-provider no-op
+
+```json
+{
+	"query": "sveltekit remote functions",
+	"provider": "brave",
+	"budget_usd": 0,
+	"timeout_seconds": 1,
+	"max_providers": 1
+}
+```
+
+This still runs Brave. A one-provider plan does not apply the USD
+check or the whole-call timeout. Per-HTTP timeouts from
+`src/config/env.ts` still apply.
+
+## Multi-provider plans
+
+When a later orchestrator (or a caller) passes more than one candidate
+provider:
+
+1. Cap the list at `max_providers` (default 3), preserving caller
+   order.
+2. Sum per-provider **estimated** USD.
+3. If `budget_usd` is set and the sum is greater, throw
+   `INVALID_INPUT` immediately. No provider HTTP runs.
+4. Otherwise run under `timeout_seconds` (default 20).
+
+Estimates are planner hints, not invoices. They live in
+`src/common/request-budgets.ts` and can be updated when vendor pricing
+changes.
+
+| Provider / mode                                                         | Estimated USD |
+| ----------------------------------------------------------------------- | ------------- |
+| `brave`                                                                 | 0.005         |
+| `tavily`                                                                | 0.008         |
+| `exa`                                                                   | 0.007         |
+| `kagi`, `kagi_enrichment`, `kagi_fastgpt`                               | 0.01          |
+| `exa_answer`                                                            | 0.01          |
+| `linkup`                                                                | 0.012         |
+| `github`                                                                | 0             |
+| `tavily:extract`, `kagi:summarize`, `firecrawl:scrape`, `firecrawl:map` | 0.01          |
+| `exa:contents`, `exa:similar`                                           | 0.005         |
+| `firecrawl:extract`, `firecrawl:actions`                                | 0.02          |
+| `firecrawl:crawl`                                                       | 0.05          |
+| unknown                                                                 | 0.01          |
+
+## Example
+
+A two-provider plan of Brave + Tavily estimates `$0.013`. With
+`budget_usd: 0.01` the planner throws `INVALID_INPUT` before either
+vendor is contacted. Raise `budget_usd`, drop a provider, or pin a
+single `provider` to proceed.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -22,6 +22,7 @@ and configured providers remain available.
 | Provider is unavailable                   | Missing API key                                           | Set the provider key and restart the MCP server. Check `omnisearch://providers/status`.                                          |
 | Request fails with unauthorized/forbidden | Invalid key or plan mismatch                              | Verify the key belongs to the provider and has access to the endpoint or plan tier.                                              |
 | Query rejected before provider call       | Invalid input                                             | Check for empty queries, unsupported modes, malformed domains, or unsupported URL protocols.                                     |
+| Request budget exceeded                   | Multi-provider estimated cost is above `budget_usd`       | Raise `budget_usd`, lower `max_providers`, or pin a single `provider`. Single-provider calls ignore the USD cap.                 |
 | Repeated transient errors                 | Rate limits, timeout, network failure, or provider 5xx    | Retry later or lower request volume. Retryable failures are handled separately from invalid credentials and validation failures. |
 | Returned file path cannot be read         | Server wrote a temp file on a remote/container filesystem | Retry with `large_result_mode: "inline"` or set `OMNISEARCH_LARGE_RESULT_MODE=inline`.                                           |
 

--- a/src/common/request-budgets.test.ts
+++ b/src/common/request-budgets.test.ts
@@ -1,0 +1,249 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+	DEFAULT_ESTIMATED_COST_USD,
+	DEFAULT_MAX_PROVIDERS,
+	DEFAULT_TIMEOUT_SECONDS,
+	estimated_provider_cost_usd,
+	plan_and_run,
+	plan_request_budgets,
+	run_with_request_timeout,
+	type RequestBudgetPlan,
+} from './request-budgets.js';
+import { ErrorType } from './types.js';
+
+const multi_provider_candidates = [
+	{ id: 'brave', estimated_cost_usd: 0.005 },
+	{ id: 'tavily', estimated_cost_usd: 0.008 },
+	{ id: 'kagi', estimated_cost_usd: 0.01 },
+	{ id: 'exa', estimated_cost_usd: 0.007 },
+	{ id: 'kagi_enrichment', estimated_cost_usd: 0.01 },
+];
+
+describe('estimated_provider_cost_usd', () => {
+	it('returns known search and processing estimates', () => {
+		expect(estimated_provider_cost_usd('brave')).toBe(0.005);
+		expect(estimated_provider_cost_usd('tavily')).toBe(0.008);
+		expect(estimated_provider_cost_usd('github')).toBe(0);
+		expect(estimated_provider_cost_usd('firecrawl', 'crawl')).toBe(
+			0.05,
+		);
+		expect(estimated_provider_cost_usd('tavily', 'extract')).toBe(
+			0.01,
+		);
+	});
+
+	it('falls back to a conservative default for unknown providers', () => {
+		expect(estimated_provider_cost_usd('unknown')).toBe(
+			DEFAULT_ESTIMATED_COST_USD,
+		);
+		expect(estimated_provider_cost_usd('firecrawl', 'other')).toBe(
+			DEFAULT_ESTIMATED_COST_USD,
+		);
+	});
+});
+
+describe('plan_request_budgets', () => {
+	it('rejects an empty candidate list before any work', () => {
+		expect(() =>
+			plan_request_budgets({
+				tool: 'web_search',
+				candidates: [],
+			}),
+		).toThrow(
+			expect.objectContaining({
+				type: ErrorType.INVALID_INPUT,
+				provider: 'web_search',
+				message: 'Request plan has no providers',
+			}),
+		);
+	});
+
+	it('treats a single-provider plan as a no-op for all knobs', () => {
+		const plan = plan_request_budgets({
+			tool: 'web_search',
+			candidates: [{ id: 'brave', estimated_cost_usd: 0.005 }],
+			max_providers: 1,
+			timeout_seconds: 1,
+			budget_usd: 0,
+		});
+
+		expect(plan).toEqual({
+			tool: 'web_search',
+			providers: [{ id: 'brave', estimated_cost_usd: 0.005 }],
+			estimated_cost_usd: 0.005,
+			applied: false,
+		});
+		expect(plan.timeout_ms).toBeUndefined();
+	});
+
+	it('caps multi-provider plans at max_providers or the default of 3', () => {
+		const default_plan = plan_request_budgets({
+			tool: 'web_search',
+			candidates: multi_provider_candidates,
+		});
+		expect(
+			default_plan.providers.map((provider) => provider.id),
+		).toEqual(['brave', 'tavily', 'kagi']);
+		expect(default_plan.providers).toHaveLength(
+			DEFAULT_MAX_PROVIDERS,
+		);
+
+		const capped = plan_request_budgets({
+			tool: 'web_search',
+			candidates: multi_provider_candidates,
+			max_providers: 2,
+		});
+		expect(capped.providers.map((provider) => provider.id)).toEqual([
+			'brave',
+			'tavily',
+		]);
+		expect(capped.estimated_cost_usd).toBe(0.013);
+		expect(capped.applied).toBe(true);
+	});
+
+	it('applies the default whole-call timeout only to multi-provider plans', () => {
+		const plan = plan_request_budgets({
+			tool: 'web_search',
+			candidates: multi_provider_candidates.slice(0, 2),
+		});
+
+		expect(plan.timeout_ms).toBe(DEFAULT_TIMEOUT_SECONDS * 1000);
+
+		const custom = plan_request_budgets({
+			tool: 'web_search',
+			candidates: multi_provider_candidates.slice(0, 2),
+			timeout_seconds: 8,
+		});
+		expect(custom.timeout_ms).toBe(8000);
+	});
+
+	it('rejects a multi-provider plan that cannot fit budget_usd', () => {
+		expect(() =>
+			plan_request_budgets({
+				tool: 'web_search',
+				candidates: multi_provider_candidates.slice(0, 2),
+				budget_usd: 0.01,
+			}),
+		).toThrow(
+			expect.objectContaining({
+				type: ErrorType.INVALID_INPUT,
+				provider: 'web_search',
+				details: expect.objectContaining({
+					retryable: false,
+					estimated_cost_usd: 0.013,
+					budget_usd: 0.01,
+					providers: ['brave', 'tavily'],
+				}),
+			}),
+		);
+	});
+
+	it('allows a multi-provider plan that fits the USD budget exactly', () => {
+		const plan = plan_request_budgets({
+			tool: 'web_search',
+			candidates: [
+				{ id: 'brave', estimated_cost_usd: 0.005 },
+				{ id: 'exa', estimated_cost_usd: 0.007 },
+			],
+			budget_usd: 0.012,
+		});
+
+		expect(plan.estimated_cost_usd).toBe(0.012);
+		expect(plan.applied).toBe(true);
+	});
+});
+
+describe('run_with_request_timeout', () => {
+	it('does not wrap single-provider no-op plans', async () => {
+		const work = vi.fn().mockResolvedValue('ok');
+		const plan: RequestBudgetPlan = {
+			tool: 'web_search',
+			providers: [{ id: 'brave', estimated_cost_usd: 0.005 }],
+			estimated_cost_usd: 0.005,
+			applied: false,
+		};
+
+		await expect(run_with_request_timeout(plan, work)).resolves.toBe(
+			'ok',
+		);
+		expect(work).toHaveBeenCalledWith();
+	});
+
+	it('times out multi-provider work and cancels the rest', async () => {
+		const completed: string[] = [];
+		const plan: RequestBudgetPlan = {
+			tool: 'web_search',
+			providers: [
+				{ id: 'brave', estimated_cost_usd: 0.005 },
+				{ id: 'tavily', estimated_cost_usd: 0.008 },
+			],
+			estimated_cost_usd: 0.013,
+			timeout_ms: 40,
+			applied: true,
+		};
+
+		const sleep = (ms: number, signal?: AbortSignal) =>
+			new Promise<void>((resolve, reject) => {
+				const timer = setTimeout(resolve, ms);
+				signal?.addEventListener(
+					'abort',
+					() => {
+						clearTimeout(timer);
+						reject(new DOMException('Aborted', 'AbortError'));
+					},
+					{ once: true },
+				);
+			});
+
+		await expect(
+			run_with_request_timeout(plan, async (signal) => {
+				const run = async (id: string, delay: number) => {
+					await sleep(delay, signal);
+					completed.push(id);
+					return id;
+				};
+
+				return Promise.all([run('brave', 10), run('tavily', 200)]);
+			}),
+		).rejects.toMatchObject({
+			type: ErrorType.TIMEOUT,
+			provider: 'web_search',
+			details: { retryable: true },
+		});
+
+		expect(completed).not.toContain('tavily');
+	});
+});
+
+describe('plan_and_run', () => {
+	it('does not call work when a multi-provider budget is impossible', async () => {
+		const work = vi.fn();
+
+		await expect(
+			plan_and_run(
+				'web_search',
+				multi_provider_candidates.slice(0, 2),
+				{ budget_usd: 0.001 },
+				work,
+			),
+		).rejects.toMatchObject({
+			type: ErrorType.INVALID_INPUT,
+			message: expect.stringContaining('Request budget exceeded'),
+		});
+		expect(work).not.toHaveBeenCalled();
+	});
+
+	it('runs single-provider work even with a zero USD budget', async () => {
+		const work = vi.fn().mockResolvedValue(['hit']);
+
+		await expect(
+			plan_and_run(
+				'web_search',
+				[{ id: 'brave', estimated_cost_usd: 0.005 }],
+				{ budget_usd: 0, timeout_seconds: 1, max_providers: 1 },
+				work,
+			),
+		).resolves.toEqual(['hit']);
+		expect(work).toHaveBeenCalledTimes(1);
+	});
+});

--- a/src/common/request-budgets.ts
+++ b/src/common/request-budgets.ts
@@ -1,0 +1,191 @@
+import { ErrorType, ProviderError } from './types.js';
+
+// Request-level provider, time, and estimated-cost budgets.
+// Single-provider plans ignore these knobs so the default path
+// stays a cheap no-op. Multi-provider callers share this planner
+// so impossible USD plans fail before work.
+
+export const DEFAULT_MAX_PROVIDERS = 3;
+export const DEFAULT_TIMEOUT_SECONDS = 20;
+export const DEFAULT_ESTIMATED_COST_USD = 0.01;
+
+const ESTIMATED_COST_USD: Record<string, number> = {
+	brave: 0.005,
+	tavily: 0.008,
+	kagi: 0.01,
+	exa: 0.007,
+	kagi_enrichment: 0.01,
+	github: 0,
+	kagi_fastgpt: 0.01,
+	exa_answer: 0.01,
+	linkup: 0.012,
+	'tavily:extract': 0.01,
+	'kagi:summarize': 0.01,
+	'firecrawl:scrape': 0.01,
+	'firecrawl:crawl': 0.05,
+	'firecrawl:map': 0.01,
+	'firecrawl:extract': 0.02,
+	'firecrawl:actions': 0.02,
+	'exa:contents': 0.005,
+	'exa:similar': 0.005,
+};
+
+export interface PlannedProvider {
+	id: string;
+	estimated_cost_usd: number;
+}
+
+export interface RequestBudgetInput {
+	max_providers?: number;
+	timeout_seconds?: number;
+	budget_usd?: number;
+}
+
+export interface RequestBudgetPlan {
+	tool: string;
+	providers: PlannedProvider[];
+	estimated_cost_usd: number;
+	timeout_ms?: number;
+	applied: boolean;
+}
+
+const round_usd = (value: number) =>
+	Math.round(value * 1_000_000) / 1_000_000;
+
+const is_abort_error = (error: unknown) =>
+	error instanceof Error && error.name === 'AbortError';
+
+export const estimated_provider_cost_usd = (
+	provider: string,
+	mode?: string,
+): number => {
+	if (mode) {
+		const keyed = ESTIMATED_COST_USD[`${provider}:${mode}`];
+		if (keyed !== undefined) return keyed;
+	}
+
+	return ESTIMATED_COST_USD[provider] ?? DEFAULT_ESTIMATED_COST_USD;
+};
+
+const request_timeout_error = (plan: RequestBudgetPlan) =>
+	new ProviderError(
+		ErrorType.TIMEOUT,
+		`Request exceeded timeout_seconds=${(plan.timeout_ms ?? 0) / 1000}`,
+		plan.tool,
+		{ retryable: true },
+	);
+
+export const plan_request_budgets = ({
+	tool,
+	candidates,
+	max_providers,
+	timeout_seconds,
+	budget_usd,
+}: RequestBudgetInput & {
+	tool: string;
+	candidates: readonly PlannedProvider[];
+}): RequestBudgetPlan => {
+	if (candidates.length === 0) {
+		throw new ProviderError(
+			ErrorType.INVALID_INPUT,
+			'Request plan has no providers',
+			tool,
+			{ retryable: false },
+		);
+	}
+
+	// One explicit provider is the cheap default: ignore caps,
+	// wall-clock timeout, and USD so existing calls stay a no-op.
+	if (candidates.length === 1) {
+		return {
+			tool,
+			providers: [...candidates],
+			estimated_cost_usd: round_usd(candidates[0].estimated_cost_usd),
+			applied: false,
+		};
+	}
+
+	const cap = max_providers ?? DEFAULT_MAX_PROVIDERS;
+	const providers = candidates.slice(0, cap).map((provider) => ({
+		...provider,
+		estimated_cost_usd: round_usd(provider.estimated_cost_usd),
+	}));
+	const estimated_cost_usd = round_usd(
+		providers.reduce(
+			(sum, provider) => sum + provider.estimated_cost_usd,
+			0,
+		),
+	);
+
+	if (
+		budget_usd !== undefined &&
+		estimated_cost_usd > round_usd(budget_usd)
+	) {
+		const names = providers.map((provider) => provider.id).join(', ');
+		throw new ProviderError(
+			ErrorType.INVALID_INPUT,
+			`Request budget exceeded: estimated $${estimated_cost_usd.toFixed(4)} for ${names} exceeds budget_usd=${budget_usd}`,
+			tool,
+			{
+				retryable: false,
+				estimated_cost_usd,
+				budget_usd,
+				providers: providers.map((provider) => provider.id),
+			},
+		);
+	}
+
+	return {
+		tool,
+		providers,
+		estimated_cost_usd,
+		timeout_ms: (timeout_seconds ?? DEFAULT_TIMEOUT_SECONDS) * 1000,
+		applied: true,
+	};
+};
+
+export const run_with_request_timeout = async <T>(
+	plan: RequestBudgetPlan,
+	work: (signal?: AbortSignal) => Promise<T>,
+): Promise<T> => {
+	if (!plan.applied || plan.timeout_ms === undefined) {
+		return work();
+	}
+
+	const signal = AbortSignal.timeout(plan.timeout_ms);
+	const timeout = new Promise<never>((_, reject) => {
+		const fail = () => reject(request_timeout_error(plan));
+		if (signal.aborted) {
+			fail();
+			return;
+		}
+		signal.addEventListener('abort', fail, { once: true });
+	});
+
+	try {
+		return await Promise.race([work(signal), timeout]);
+	} catch (error) {
+		if (error instanceof ProviderError) throw error;
+		if (signal.aborted || is_abort_error(error)) {
+			throw request_timeout_error(plan);
+		}
+		throw error;
+	}
+};
+
+export const plan_and_run = async <T>(
+	tool: string,
+	candidates: readonly PlannedProvider[],
+	budget: RequestBudgetInput,
+	work: (plan: RequestBudgetPlan, signal?: AbortSignal) => Promise<T>,
+): Promise<T> => {
+	const plan = plan_request_budgets({
+		tool,
+		candidates,
+		...budget,
+	});
+
+	return run_with_request_timeout(plan, (signal) =>
+		work(plan, signal),
+	);
+};

--- a/src/server/tools/ai-search.ts
+++ b/src/server/tools/ai-search.ts
@@ -1,6 +1,10 @@
 import { McpServer } from 'tmcp';
 import type { GenericSchema } from 'valibot';
 import * as v from 'valibot';
+import {
+	estimated_provider_cost_usd,
+	plan_and_run,
+} from '../../common/request-budgets.js';
 import { SearchProvider } from '../../common/types.js';
 import {
 	ai_search_provider_definitions,
@@ -12,6 +16,7 @@ import {
 	large_result_mode_schema,
 	limit_schema,
 	query_schema,
+	request_budget_schema_fields,
 } from './schemas.js';
 
 const providers = new ProviderRegistry<SearchProvider>();
@@ -54,19 +59,43 @@ export const register_ai_search = (
 				),
 				limit: limit_schema,
 				large_result_mode: large_result_mode_schema,
+				...request_budget_schema_fields,
 			}),
 		},
-		async ({ query, provider, limit, large_result_mode }) =>
+		async ({
+			query,
+			provider,
+			limit,
+			large_result_mode,
+			max_providers,
+			timeout_seconds,
+			budget_usd,
+		}) =>
 			handle_tool_result(
 				'ai_search',
-				async () => {
-					const selected = providers.require(provider, 'ai_search');
+				async () =>
+					plan_and_run(
+						'ai_search',
+						[
+							{
+								id: provider,
+								estimated_cost_usd:
+									estimated_provider_cost_usd(provider),
+							},
+						],
+						{ max_providers, timeout_seconds, budget_usd },
+						async (plan) => {
+							const selected = providers.require(
+								plan.providers[0].id,
+								'ai_search',
+							);
 
-					return selected.search({
-						query,
-						limit,
-					});
-				},
+							return selected.search({
+								query,
+								limit,
+							});
+						},
+					),
 				{ large_result_mode },
 			),
 	);

--- a/src/server/tools/contract.test.ts
+++ b/src/server/tools/contract.test.ts
@@ -152,6 +152,22 @@ describe('MCP tool contract', () => {
 			v.safeParse(schema, { query: 'test', provider: 'kagi' })
 				.success,
 		).toBe(false);
+		expect(
+			v.safeParse(schema, {
+				query: 'test',
+				provider: 'brave',
+				max_providers: 3,
+				timeout_seconds: 20,
+				budget_usd: 0.02,
+			}).success,
+		).toBe(true);
+		expect(
+			v.safeParse(schema, {
+				query: 'test',
+				provider: 'brave',
+				max_providers: 0,
+			}).success,
+		).toBe(false);
 	});
 
 	it('validates public web_extract payloads and unavailable modes at the MCP layer', async () => {
@@ -233,6 +249,9 @@ describe('MCP tool contract', () => {
 			query: 'example',
 			provider: 'brave',
 			large_result_mode: 'inline',
+			max_providers: 1,
+			timeout_seconds: 1,
+			budget_usd: 0,
 		});
 		expect(parse_tool_body(success)).toEqual([
 			{

--- a/src/server/tools/schemas.test.ts
+++ b/src/server/tools/schemas.test.ts
@@ -1,12 +1,15 @@
 import * as v from 'valibot';
 import { describe, expect, it } from 'vitest';
 import {
+	budget_usd_schema,
 	domain_schema,
 	http_url_schema,
 	include_raw_contents_schema,
 	large_result_mode_schema,
 	limit_schema,
+	max_providers_schema,
 	query_schema,
+	timeout_seconds_schema,
 	url_or_urls_schema,
 } from './schemas.js';
 
@@ -75,6 +78,38 @@ describe('tool schemas', () => {
 		expect(v.safeParse(http_url_schema, 'not a url').success).toBe(
 			false,
 		);
+	});
+
+	it('accepts optional request-budget knobs and rejects invalid values', () => {
+		expect(v.safeParse(max_providers_schema, undefined).success).toBe(
+			true,
+		);
+		expect(v.safeParse(max_providers_schema, 3).success).toBe(true);
+		expect(v.safeParse(max_providers_schema, 0).success).toBe(false);
+		expect(v.safeParse(max_providers_schema, 21).success).toBe(false);
+		expect(v.safeParse(max_providers_schema, 1.5).success).toBe(
+			false,
+		);
+
+		expect(
+			v.safeParse(timeout_seconds_schema, undefined).success,
+		).toBe(true);
+		expect(v.safeParse(timeout_seconds_schema, 20).success).toBe(
+			true,
+		);
+		expect(v.safeParse(timeout_seconds_schema, 0).success).toBe(
+			false,
+		);
+		expect(v.safeParse(timeout_seconds_schema, 121).success).toBe(
+			false,
+		);
+
+		expect(v.safeParse(budget_usd_schema, undefined).success).toBe(
+			true,
+		);
+		expect(v.safeParse(budget_usd_schema, 0).success).toBe(true);
+		expect(v.safeParse(budget_usd_schema, 0.02).success).toBe(true);
+		expect(v.safeParse(budget_usd_schema, -0.01).success).toBe(false);
 	});
 
 	it('bounds extraction URL arrays', () => {

--- a/src/server/tools/schemas.ts
+++ b/src/server/tools/schemas.ts
@@ -76,3 +76,43 @@ export const url_or_urls_schema = v.pipe(
 	]),
 	v.description('URL or array of URLs to process'),
 );
+
+export const max_providers_schema = v.optional(
+	v.pipe(
+		v.number(),
+		v.integer('max_providers must be an integer'),
+		v.minValue(1, 'max_providers must be at least 1'),
+		v.maxValue(20, 'max_providers must be at most 20'),
+		v.description(
+			'Maximum providers to run for a multi-provider plan (default: 3). Ignored for single-provider calls.',
+		),
+	),
+);
+
+export const timeout_seconds_schema = v.optional(
+	v.pipe(
+		v.number(),
+		v.integer('timeout_seconds must be an integer'),
+		v.minValue(1, 'timeout_seconds must be at least 1'),
+		v.maxValue(120, 'timeout_seconds must be at most 120'),
+		v.description(
+			'Whole-call timeout in seconds for multi-provider fan-out (default: 20). Ignored for single-provider calls.',
+		),
+	),
+);
+
+export const budget_usd_schema = v.optional(
+	v.pipe(
+		v.number(),
+		v.minValue(0, 'budget_usd must be at least 0'),
+		v.description(
+			'Optional estimated USD cap for a multi-provider plan. Impossible plans fail before any provider call. Ignored for single-provider calls.',
+		),
+	),
+);
+
+export const request_budget_schema_fields = {
+	max_providers: max_providers_schema,
+	timeout_seconds: timeout_seconds_schema,
+	budget_usd: budget_usd_schema,
+};

--- a/src/server/tools/web-extract.ts
+++ b/src/server/tools/web-extract.ts
@@ -1,6 +1,10 @@
 import { McpServer } from 'tmcp';
 import type { GenericSchema } from 'valibot';
 import * as v from 'valibot';
+import {
+	estimated_provider_cost_usd,
+	plan_and_run,
+} from '../../common/request-budgets.js';
 import { omit_raw_contents } from '../../common/results.js';
 import {
 	ErrorType,
@@ -19,6 +23,7 @@ import { handle_tool_result } from './responses.js';
 import {
 	include_raw_contents_schema,
 	large_result_mode_schema,
+	request_budget_schema_fields,
 	url_or_urls_schema,
 } from './schemas.js';
 
@@ -84,6 +89,7 @@ export const register_web_extract = (
 				),
 				large_result_mode: large_result_mode_schema,
 				include_raw_contents: include_raw_contents_schema,
+				...request_budget_schema_fields,
 			}),
 		},
 		async ({
@@ -93,6 +99,9 @@ export const register_web_extract = (
 			extract_depth,
 			large_result_mode,
 			include_raw_contents = true,
+			max_providers,
+			timeout_seconds,
+			budget_usd,
 		}) =>
 			handle_tool_result(
 				'web_extract',
@@ -110,24 +119,39 @@ export const register_web_extract = (
 						);
 					}
 
-					const key = make_processing_provider_key(
-						provider,
-						resolved_mode,
-					);
-					const selected = providers.require(
-						key,
+					return plan_and_run(
 						'web_extract',
-						`Provider "${provider}" with mode "${resolved_mode}" is not available. Available modes for configured providers: ${allowed.join(', ') || 'none'}.`,
-					);
+						[
+							{
+								id: provider,
+								estimated_cost_usd: estimated_provider_cost_usd(
+									provider,
+									resolved_mode,
+								),
+							},
+						],
+						{ max_providers, timeout_seconds, budget_usd },
+						async () => {
+							const key = make_processing_provider_key(
+								provider,
+								resolved_mode,
+							);
+							const selected = providers.require(
+								key,
+								'web_extract',
+								`Provider "${provider}" with mode "${resolved_mode}" is not available. Available modes for configured providers: ${allowed.join(', ') || 'none'}.`,
+							);
 
-					const result = await selected.process_content(
-						url,
-						extract_depth,
-					);
+							const result = await selected.process_content(
+								url,
+								extract_depth,
+							);
 
-					return include_raw_contents
-						? result
-						: omit_raw_contents(result);
+							return include_raw_contents
+								? result
+								: omit_raw_contents(result);
+						},
+					);
 				},
 				{ large_result_mode },
 			),

--- a/src/server/tools/web-search.ts
+++ b/src/server/tools/web-search.ts
@@ -1,6 +1,10 @@
 import { McpServer } from 'tmcp';
 import type { GenericSchema } from 'valibot';
 import * as v from 'valibot';
+import {
+	estimated_provider_cost_usd,
+	plan_and_run,
+} from '../../common/request-budgets.js';
 import { SearchProvider } from '../../common/types.js';
 import {
 	web_search_provider_definitions,
@@ -14,6 +18,7 @@ import {
 	large_result_mode_schema,
 	limit_schema,
 	query_schema,
+	request_budget_schema_fields,
 } from './schemas.js';
 
 const providers = new ProviderRegistry<SearchProvider>();
@@ -58,6 +63,7 @@ export const register_web_search = (
 				include_domains: include_domains_schema,
 				exclude_domains: exclude_domains_schema,
 				large_result_mode: large_result_mode_schema,
+				...request_budget_schema_fields,
 			}),
 		},
 		async ({
@@ -67,19 +73,37 @@ export const register_web_search = (
 			include_domains,
 			exclude_domains,
 			large_result_mode,
+			max_providers,
+			timeout_seconds,
+			budget_usd,
 		}) =>
 			handle_tool_result(
 				'web_search',
-				async () => {
-					const selected = providers.require(provider, 'web_search');
+				async () =>
+					plan_and_run(
+						'web_search',
+						[
+							{
+								id: provider,
+								estimated_cost_usd:
+									estimated_provider_cost_usd(provider),
+							},
+						],
+						{ max_providers, timeout_seconds, budget_usd },
+						async (plan) => {
+							const selected = providers.require(
+								plan.providers[0].id,
+								'web_search',
+							);
 
-					return selected.search({
-						query,
-						limit,
-						include_domains,
-						exclude_domains,
-					});
-				},
+							return selected.search({
+								query,
+								limit,
+								include_domains,
+								exclude_domains,
+							});
+						},
+					),
 				{ large_result_mode },
 			),
 	);


### PR DESCRIPTION
## Summary

Add optional request-level budgets so a future multi-provider fan-out cannot become an accidental bill. Single-provider calls ignore the knobs and stay on the current cheap path.

- `max_providers` — cap how many providers may run (default 3 for multi-provider plans; a max, not a min)
- `timeout_seconds` — whole-call wall time (default 20s for multi-provider plans); remaining work is cancelled
- `budget_usd` — optional estimated USD cap; impossible plans throw `INVALID_INPUT` before any provider HTTP

Fixes #194.

## Scope

- Shared planner in `src/common/request-budgets.ts` (`plan_request_budgets`, `run_with_request_timeout`, `plan_and_run`)
- Optional schema fields on `web_search`, `ai_search`, and `web_extract`
- Docs in `docs/request-budgets.md` plus README / troubleshooting pointers
- Patch changeset

No fan-out, routing, or daily ledger in this PR. `github_search` stays single-provider and does not take these fields.

## Verification

```bash
pnpm test    # 121 passed
pnpm check   # format + lint + advisories
pnpm build
```

Covered cases:

- Single-provider plans ignore `max_providers`, `timeout_seconds`, and `budget_usd` (including `budget_usd: 0`)
- Multi-provider plans cap at `max_providers` / default 3
- Impossible `budget_usd` fails before `work()` is called
- Whole-call timeout cancels remaining provider work
- Tool schemas accept the knobs and reject invalid values

## Impact

- No breaking changes and no new API keys
- Default single-`provider` behavior is unchanged
- Estimates are planner hints, not invoices (see `docs/request-budgets.md`)