### PR TITLE
Add optional concurrent web_search provider fan-out

### DIFF
--- a/.changeset/feat-188-parallel-fanout.md
+++ b/.changeset/feat-188-parallel-fanout.md
@@ -1,0 +1,5 @@
+---
+'mcp-omnisearch': patch
+---
+
+feat: add optional concurrent web_search provider fan-out

--- a/README.md
+++ b/README.md
@@ -84,6 +84,19 @@ Search the web with Tavily, Brave, Kagi, Exa, or Kagi Enrichment.
 }
 ```
 
+Single-provider calls stay on one engine. To fan out selected
+configured providers concurrently under one timeout, pass `providers`
+instead. Missing API keys are skipped; this is opt-in and does not
+query every configured engine.
+
+```json
+{
+	"query": "sveltekit remote functions",
+	"providers": ["exa", "tavily"],
+	"limit": 10
+}
+```
+
 ### `ai_search`
 
 Get sourced AI answers with Kagi FastGPT, Exa Answer, or Linkup.

--- a/docs/provider-selection.md
+++ b/docs/provider-selection.md
@@ -42,6 +42,26 @@ search only. See
 | `firecrawl` | `FIRECRAWL_API_KEY` | `scrape`, `crawl`, `map`, `extract`, `actions` | Scraping, crawling, site maps, structured extraction, and browser actions. |
 | `exa`       | `EXA_API_KEY`       | `contents`, `similar`                          | Page content retrieval and semantically similar URLs.                      |
 
+## Optional concurrent `web_search`
+
+`web_search` stays single-path when you pass `provider`. Passing
+`providers` is an opt-in fan-out: only the named engines that are
+configured run, they start concurrently under one timeout, and missing
+API keys are skipped instead of failing the whole call. Do not send
+both fields. There is no implicit “search everything” mode.
+
+```json
+{
+	"query": "mcp provider routing",
+	"providers": ["exa", "tavily", "brave"]
+}
+```
+
+If none of the requested providers have keys, the tool returns
+`INVALID_INPUT`. If at least one configured provider returns results,
+those results are merged (first URL wins) and other failures are
+omitted.
+
 ## Provider choice cheatsheet
 
 - Need native operators like `filetype:pdf`, `intitle:`, or `before:`?

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -40,6 +40,9 @@ export const config = {
 			base_url: 'https://api.exa.ai',
 			timeout: 30000, // 30 seconds
 		},
+		fanout: {
+			timeout: 30000, // one deadline for optional concurrent web_search
+		},
 	},
 	ai_response: {
 		kagi_fastgpt: {

--- a/src/server/provider-definitions.test.ts
+++ b/src/server/provider-definitions.test.ts
@@ -6,11 +6,17 @@ import {
 	github_provider_definitions,
 	make_processing_provider_key,
 	web_extract_provider_definitions,
+	WEB_SEARCH_PROVIDER_NAMES,
 	web_search_provider_definitions,
 } from './provider-definitions.js';
 
 describe('provider definitions', () => {
 	it('declare provider metadata for every tool category', () => {
+		expect(
+			web_search_provider_definitions.map(
+				(definition) => definition.id,
+			),
+		).toEqual([...WEB_SEARCH_PROVIDER_NAMES]);
 		expect(
 			web_search_provider_definitions.map((definition) => ({
 				id: definition.id,

--- a/src/server/provider-definitions.ts
+++ b/src/server/provider-definitions.ts
@@ -23,12 +23,16 @@ import { KagiSearchProvider } from '../providers/search/kagi/index.js';
 import { TavilySearchProvider } from '../providers/search/tavily/index.js';
 import type { ProviderDefinition } from './provider-registry.js';
 
+export const WEB_SEARCH_PROVIDER_NAMES = [
+	'tavily',
+	'brave',
+	'kagi',
+	'exa',
+	'kagi_enrichment',
+] as const;
+
 export type WebSearchProviderName =
-	| 'tavily'
-	| 'brave'
-	| 'kagi'
-	| 'exa'
-	| 'kagi_enrichment';
+	(typeof WEB_SEARCH_PROVIDER_NAMES)[number];
 
 export type AISearchProviderName =
 	| 'kagi_fastgpt'

--- a/src/server/tools/contract.test.ts
+++ b/src/server/tools/contract.test.ts
@@ -55,6 +55,12 @@ const parse_tool_body = (response: {
 	content: Array<{ text: string }>;
 }) => JSON.parse(response.content[0].text);
 
+const request_url = (input: RequestInfo | URL) => {
+	if (typeof input === 'string') return input;
+	if (input instanceof URL) return input.href;
+	return input.url;
+};
+
 const mock_tavily_extract_response = (content: string) => {
 	vi.stubGlobal(
 		'fetch',
@@ -151,6 +157,19 @@ describe('MCP tool contract', () => {
 		expect(
 			v.safeParse(schema, { query: 'test', provider: 'kagi' })
 				.success,
+		).toBe(false);
+		expect(
+			v.safeParse(schema, {
+				query: 'test',
+				providers: ['exa', 'tavily'],
+			}).success,
+		).toBe(true);
+		expect(
+			v.safeParse(schema, {
+				query: 'test',
+				provider: 'brave',
+				providers: ['tavily'],
+			}).success,
 		).toBe(false);
 	});
 
@@ -261,6 +280,181 @@ describe('MCP tool contract', () => {
 			provider: 'brave',
 			retryable: false,
 		});
+	});
+
+	it('fans out web_search across selected configured providers and skips missing keys', async () => {
+		const { tools } = await load_contract({
+			EXA_API_KEY: 'exa-key',
+			TAVILY_API_KEY: 'tavily-key',
+		});
+		const tool = tools.find(
+			(entry) => entry.definition.name === 'web_search',
+		)!;
+		const fetch = vi.fn(async (input: RequestInfo | URL) => {
+			const url = request_url(input);
+			if (url.includes('api.exa.ai')) {
+				return new Response(
+					JSON.stringify({
+						requestId: 'req-1',
+						results: [
+							{
+								id: 'id-1',
+								title: 'Exa result',
+								url: 'https://exa.example',
+								text: 'From Exa',
+								score: 0.8,
+							},
+						],
+					}),
+					{ status: 200 },
+				);
+			}
+			if (url.includes('api.tavily.com')) {
+				return new Response(
+					JSON.stringify({
+						results: [
+							{
+								title: 'Tavily result',
+								url: 'https://tavily.example',
+								content: 'From Tavily',
+								score: 0.7,
+							},
+						],
+					}),
+					{ status: 200 },
+				);
+			}
+			return new Response('unexpected', { status: 404 });
+		});
+		vi.stubGlobal('fetch', fetch);
+
+		const body = parse_tool_body(
+			await tool.handler({
+				query: 'sveltekit',
+				providers: ['exa', 'tavily'],
+				large_result_mode: 'inline',
+			}),
+		);
+
+		expect(fetch).toHaveBeenCalledTimes(2);
+		expect(body).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					title: 'Exa result',
+					url: 'https://exa.example',
+					source_provider: 'exa',
+				}),
+				expect.objectContaining({
+					title: 'Tavily result',
+					url: 'https://tavily.example',
+					source_provider: 'tavily',
+				}),
+			]),
+		);
+	});
+
+	it('keeps single-provider web_search on one path and skips unconfigured fan-out names', async () => {
+		const { tools } = await load_contract({
+			EXA_API_KEY: 'exa-key',
+			TAVILY_API_KEY: 'tavily-key',
+		});
+		const tool = tools.find(
+			(entry) => entry.definition.name === 'web_search',
+		)!;
+		const fetch = vi.fn(async (input: RequestInfo | URL) => {
+			const url = request_url(input);
+			if (url.includes('api.exa.ai')) {
+				return new Response(
+					JSON.stringify({
+						requestId: 'req-1',
+						results: [
+							{
+								id: 'id-1',
+								title: 'Exa only',
+								url: 'https://exa.example',
+								text: 'Single path',
+							},
+						],
+					}),
+					{ status: 200 },
+				);
+			}
+			return new Response('unexpected', { status: 404 });
+		});
+		vi.stubGlobal('fetch', fetch);
+
+		const single = parse_tool_body(
+			await tool.handler({
+				query: 'sveltekit',
+				provider: 'exa',
+				large_result_mode: 'inline',
+			}),
+		);
+
+		expect(fetch).toHaveBeenCalledTimes(1);
+		expect(
+			request_url(fetch.mock.calls[0]?.[0] as RequestInfo | URL),
+		).toContain('api.exa.ai');
+		expect(single).toEqual([
+			expect.objectContaining({
+				title: 'Exa only',
+				source_provider: 'exa',
+			}),
+		]);
+
+		const { tools: exa_only_tools } = await load_contract({
+			EXA_API_KEY: 'exa-key',
+		});
+		const exa_only = exa_only_tools.find(
+			(entry) => entry.definition.name === 'web_search',
+		)!;
+		const skipped_fetch = vi.fn(async () => {
+			return new Response(
+				JSON.stringify({
+					requestId: 'req-2',
+					results: [
+						{
+							id: 'id-2',
+							title: 'Exa after skip',
+							url: 'https://exa.example/skip',
+							text: 'Skipped tavily',
+						},
+					],
+				}),
+				{ status: 200 },
+			);
+		});
+		vi.stubGlobal('fetch', skipped_fetch);
+
+		const skipped = parse_tool_body(
+			await exa_only.handler({
+				query: 'sveltekit',
+				providers: ['exa', 'tavily'],
+				large_result_mode: 'inline',
+			}),
+		);
+
+		expect(skipped_fetch).toHaveBeenCalledTimes(1);
+		expect(skipped).toEqual([
+			expect.objectContaining({
+				title: 'Exa after skip',
+				source_provider: 'exa',
+			}),
+		]);
+
+		const missing = parse_tool_body(
+			await exa_only.handler({
+				query: 'sveltekit',
+				providers: ['tavily', 'brave'],
+			}),
+		);
+		expect(missing).toEqual(
+			expect.objectContaining({
+				type: 'INVALID_INPUT',
+				provider: 'web_search',
+				retryable: false,
+			}),
+		);
 	});
 
 	it('covers large-result inline/file modes and compact extraction at the MCP layer', async () => {

--- a/src/server/tools/schemas.test.ts
+++ b/src/server/tools/schemas.test.ts
@@ -1,11 +1,14 @@
 import * as v from 'valibot';
 import { describe, expect, it } from 'vitest';
 import {
+	create_web_search_schema,
 	domain_schema,
+	has_exactly_one_provider_selector,
 	http_url_schema,
 	include_raw_contents_schema,
 	large_result_mode_schema,
 	limit_schema,
+	providers_schema,
 	query_schema,
 	url_or_urls_schema,
 } from './schemas.js';
@@ -75,6 +78,66 @@ describe('tool schemas', () => {
 		expect(v.safeParse(http_url_schema, 'not a url').success).toBe(
 			false,
 		);
+	});
+
+	it('accepts known concurrent providers and rejects empty lists', () => {
+		expect(
+			v.safeParse(providers_schema, ['exa', 'tavily']).success,
+		).toBe(true);
+		expect(v.safeParse(providers_schema, undefined).success).toBe(
+			true,
+		);
+		expect(v.safeParse(providers_schema, []).success).toBe(false);
+		expect(
+			v.safeParse(providers_schema, ['exa', 'unknown']).success,
+		).toBe(false);
+	});
+
+	it('requires exactly one of provider or providers', () => {
+		expect(
+			has_exactly_one_provider_selector({ provider: 'exa' }),
+		).toBe(true);
+		expect(
+			has_exactly_one_provider_selector({
+				providers: ['exa', 'tavily'],
+			}),
+		).toBe(true);
+		expect(has_exactly_one_provider_selector({})).toBe(false);
+		expect(
+			has_exactly_one_provider_selector({
+				provider: 'exa',
+				providers: ['tavily'],
+			}),
+		).toBe(false);
+	});
+
+	it('keeps single-provider web_search payloads valid and rejects mixed selectors', () => {
+		const schema = create_web_search_schema(['exa', 'tavily']);
+
+		expect(
+			v.safeParse(schema, { query: 'sveltekit', provider: 'exa' })
+				.success,
+		).toBe(true);
+		expect(
+			v.safeParse(schema, {
+				query: 'sveltekit',
+				providers: ['exa', 'tavily'],
+			}).success,
+		).toBe(true);
+		expect(
+			v.safeParse(schema, {
+				query: 'sveltekit',
+				provider: 'exa',
+				providers: ['tavily'],
+			}).success,
+		).toBe(false);
+		expect(v.safeParse(schema, { query: 'sveltekit' }).success).toBe(
+			false,
+		);
+		expect(
+			v.safeParse(schema, { query: 'sveltekit', provider: 'brave' })
+				.success,
+		).toBe(false);
 	});
 
 	it('bounds extraction URL arrays', () => {

--- a/src/server/tools/schemas.ts
+++ b/src/server/tools/schemas.ts
@@ -1,4 +1,8 @@
 import * as v from 'valibot';
+import {
+	WEB_SEARCH_PROVIDER_NAMES,
+	type WebSearchProviderName,
+} from '../provider-definitions.js';
 
 const DOMAIN_PATTERN =
 	/^(?:\*\.)?(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,63}$/;
@@ -76,3 +80,53 @@ export const url_or_urls_schema = v.pipe(
 	]),
 	v.description('URL or array of URLs to process'),
 );
+
+export const providers_schema = v.optional(
+	v.pipe(
+		v.array(v.picklist(WEB_SEARCH_PROVIDER_NAMES)),
+		v.minLength(1, 'Provide at least one provider'),
+		v.maxLength(
+			WEB_SEARCH_PROVIDER_NAMES.length,
+			`Use at most ${WEB_SEARCH_PROVIDER_NAMES.length} providers`,
+		),
+		v.description(
+			'Optional concurrent search providers. Selected configured providers run in parallel under one timeout. Missing API keys are skipped. Do not send together with provider.',
+		),
+	),
+);
+
+export const has_exactly_one_provider_selector = (input: {
+	provider?: string;
+	providers?: readonly string[];
+}) => {
+	const has_provider = input.provider !== undefined;
+	const has_providers = input.providers !== undefined;
+	return has_provider !== has_providers;
+};
+
+export const create_web_search_schema = (
+	available_provider_names: [
+		WebSearchProviderName,
+		...WebSearchProviderName[],
+	],
+) =>
+	v.pipe(
+		v.object({
+			query: query_schema,
+			provider: v.optional(
+				v.pipe(
+					v.picklist(available_provider_names),
+					v.description('Search provider to use'),
+				),
+			),
+			providers: providers_schema,
+			limit: limit_schema,
+			include_domains: include_domains_schema,
+			exclude_domains: exclude_domains_schema,
+			large_result_mode: large_result_mode_schema,
+		}),
+		v.check(
+			(input) => has_exactly_one_provider_selector(input),
+			'Provide exactly one of provider or providers',
+		),
+	);

--- a/src/server/tools/web-search-fanout.test.ts
+++ b/src/server/tools/web-search-fanout.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ErrorType, ProviderError } from '../../common/types.js';
+import type {
+	SearchProvider,
+	SearchResult,
+} from '../../common/types.js';
+import {
+	merge_search_results,
+	resolve_configured_providers,
+	search_providers_concurrently,
+} from './web-search-fanout.js';
+
+const result = (
+	provider: string,
+	url: string,
+	title = provider,
+): SearchResult => ({
+	title,
+	url,
+	snippet: title,
+	source_provider: provider,
+});
+
+const provider_of = (
+	name: string,
+	search: SearchProvider['search'],
+): SearchProvider => ({
+	name,
+	description: name,
+	search,
+});
+
+const deferred = <T>() => {
+	let resolve!: (value: T | PromiseLike<T>) => void;
+	const promise = new Promise<T>((res) => {
+		resolve = res;
+	});
+	return { promise, resolve };
+};
+
+describe('resolve_configured_providers', () => {
+	it('keeps requested order, skips missing keys, and deduplicates names', () => {
+		const exa = provider_of('exa', async () => []);
+		const registry = new Map<string, SearchProvider>([['exa', exa]]);
+
+		expect(
+			resolve_configured_providers(
+				['tavily', 'exa', 'exa', 'brave'],
+				(id) => registry.get(id),
+			),
+		).toEqual([{ id: 'exa', provider: exa }]);
+	});
+});
+
+describe('merge_search_results', () => {
+	it('concatenates groups in order and keeps the first URL', () => {
+		expect(
+			merge_search_results([
+				[result('exa', 'https://shared.test', 'Exa')],
+				[
+					result('tavily', 'https://shared.test', 'Tavily'),
+					result('tavily', 'https://tavily.test'),
+				],
+			]),
+		).toEqual([
+			result('exa', 'https://shared.test', 'Exa'),
+			result('tavily', 'https://tavily.test'),
+		]);
+	});
+});
+
+describe('search_providers_concurrently', () => {
+	it('starts selected providers before either search resolves', async () => {
+		const started: string[] = [];
+		const exa_gate = deferred<void>();
+		const tavily_gate = deferred<void>();
+
+		const pending = search_providers_concurrently(
+			[
+				{
+					id: 'exa',
+					provider: provider_of('exa', async () => {
+						started.push('exa');
+						await exa_gate.promise;
+						return [result('exa', 'https://exa.test')];
+					}),
+				},
+				{
+					id: 'tavily',
+					provider: provider_of('tavily', async () => {
+						started.push('tavily');
+						await tavily_gate.promise;
+						return [result('tavily', 'https://tavily.test')];
+					}),
+				},
+			],
+			{ query: 'sveltekit' },
+			1000,
+		);
+
+		await vi.waitFor(() => {
+			expect(started).toEqual(
+				expect.arrayContaining(['exa', 'tavily']),
+			);
+		});
+		expect(started).toHaveLength(2);
+
+		exa_gate.resolve();
+		tavily_gate.resolve();
+
+		await expect(pending).resolves.toEqual([
+			result('exa', 'https://exa.test'),
+			result('tavily', 'https://tavily.test'),
+		]);
+	});
+
+	it('keeps successful results when another selected provider fails', async () => {
+		await expect(
+			search_providers_concurrently(
+				[
+					{
+						id: 'exa',
+						provider: provider_of('exa', async () => [
+							result('exa', 'https://exa.test'),
+						]),
+					},
+					{
+						id: 'tavily',
+						provider: provider_of('tavily', async () => {
+							throw new ProviderError(
+								ErrorType.API_ERROR,
+								'upstream failed',
+								'tavily',
+							);
+						}),
+					},
+				],
+				{ query: 'sveltekit' },
+				1000,
+			),
+		).resolves.toEqual([result('exa', 'https://exa.test')]);
+	});
+
+	it('returns completed results when the shared timeout fires', async () => {
+		await expect(
+			search_providers_concurrently(
+				[
+					{
+						id: 'exa',
+						provider: provider_of('exa', async () => [
+							result('exa', 'https://exa.test'),
+						]),
+					},
+					{
+						id: 'tavily',
+						provider: provider_of(
+							'tavily',
+							() => new Promise(() => {}),
+						),
+					},
+				],
+				{ query: 'sveltekit' },
+				25,
+			),
+		).resolves.toEqual([result('exa', 'https://exa.test')]);
+	});
+
+	it('throws when the shared timeout elapses before any provider returns', async () => {
+		await expect(
+			search_providers_concurrently(
+				[
+					{
+						id: 'exa',
+						provider: provider_of('exa', () => new Promise(() => {})),
+					},
+				],
+				{ query: 'sveltekit' },
+				20,
+			),
+		).rejects.toMatchObject({
+			type: ErrorType.TIMEOUT,
+			provider: 'web_search',
+		});
+	});
+
+	it('throws the first provider error when every selected provider fails', async () => {
+		const failure = new ProviderError(
+			ErrorType.AUTH_ERROR,
+			'Invalid API key',
+			'exa',
+			{ retryable: false },
+		);
+
+		await expect(
+			search_providers_concurrently(
+				[
+					{
+						id: 'exa',
+						provider: provider_of('exa', async () => {
+							throw failure;
+						}),
+					},
+				],
+				{ query: 'sveltekit' },
+				1000,
+			),
+		).rejects.toBe(failure);
+	});
+});

--- a/src/server/tools/web-search-fanout.ts
+++ b/src/server/tools/web-search-fanout.ts
@@ -1,0 +1,120 @@
+import { retry_with_backoff } from '../../common/retry.js';
+import {
+	ErrorType,
+	ProviderError,
+	type BaseSearchParams,
+	type SearchProvider,
+	type SearchResult,
+} from '../../common/types.js';
+
+export interface SelectedSearchProvider {
+	id: string;
+	provider: SearchProvider;
+}
+
+const fanout_timeout_error = () =>
+	new ProviderError(
+		ErrorType.TIMEOUT,
+		'Concurrent web_search timed out',
+		'web_search',
+		{ retryable: true },
+	);
+
+const deadline_from_signal = (signal: AbortSignal) =>
+	new Promise<never>((_, reject) => {
+		if (signal.aborted) {
+			reject(fanout_timeout_error());
+			return;
+		}
+
+		signal.addEventListener(
+			'abort',
+			() => {
+				reject(fanout_timeout_error());
+			},
+			{ once: true },
+		);
+	});
+
+export const resolve_configured_providers = (
+	requested: readonly string[],
+	get_provider: (id: string) => SearchProvider | undefined,
+): SelectedSearchProvider[] => {
+	const seen = new Set<string>();
+	const selected: SelectedSearchProvider[] = [];
+
+	for (const id of requested) {
+		if (seen.has(id)) continue;
+		seen.add(id);
+
+		const provider = get_provider(id);
+		if (!provider) continue;
+
+		selected.push({ id, provider });
+	}
+
+	return selected;
+};
+
+export const merge_search_results = (
+	groups: readonly SearchResult[][],
+): SearchResult[] => {
+	const seen_urls = new Set<string>();
+	const merged: SearchResult[] = [];
+
+	for (const group of groups) {
+		for (const result of group) {
+			if (seen_urls.has(result.url)) continue;
+			seen_urls.add(result.url);
+			merged.push(result);
+		}
+	}
+
+	return merged;
+};
+
+export const search_providers_concurrently = async (
+	selected: readonly SelectedSearchProvider[],
+	params: BaseSearchParams,
+	timeout_ms: number,
+): Promise<SearchResult[]> => {
+	const deadline = deadline_from_signal(
+		AbortSignal.timeout(timeout_ms),
+	);
+
+	const settled = await Promise.allSettled(
+		selected.map(({ provider }) =>
+			Promise.race([
+				retry_with_backoff(() => provider.search(params)),
+				deadline,
+			]),
+		),
+	);
+
+	const groups: SearchResult[][] = [];
+	const errors: unknown[] = [];
+
+	for (const result of settled) {
+		if (result.status === 'fulfilled') {
+			groups.push(result.value);
+			continue;
+		}
+
+		errors.push(result.reason);
+	}
+
+	if (groups.length === 0) {
+		const first_error = errors[0];
+		if (first_error instanceof ProviderError) {
+			throw first_error;
+		}
+
+		throw new ProviderError(
+			ErrorType.PROVIDER_ERROR,
+			'All requested providers failed',
+			'web_search',
+		);
+	}
+
+	return merge_search_results(groups);
+};

--- a/src/server/tools/web-search.ts
+++ b/src/server/tools/web-search.ts
@@ -1,20 +1,22 @@
 import { McpServer } from 'tmcp';
 import type { GenericSchema } from 'valibot';
-import * as v from 'valibot';
-import { SearchProvider } from '../../common/types.js';
+import {
+	ErrorType,
+	ProviderError,
+	SearchProvider,
+} from '../../common/types.js';
+import { config } from '../../config/env.js';
 import {
 	web_search_provider_definitions,
 	type WebSearchProviderName,
 } from '../provider-definitions.js';
 import { ProviderRegistry } from '../provider-registry.js';
 import { handle_tool_result } from './responses.js';
+import { create_web_search_schema } from './schemas.js';
 import {
-	exclude_domains_schema,
-	include_domains_schema,
-	large_result_mode_schema,
-	limit_schema,
-	query_schema,
-} from './schemas.js';
+	resolve_configured_providers,
+	search_providers_concurrently,
+} from './web-search-fanout.js';
 
 const providers = new ProviderRegistry<SearchProvider>();
 
@@ -35,34 +37,28 @@ export const register_web_search = (
 ) => {
 	if (providers.size === 0) return;
 
-	const provider_names = providers.ids() as WebSearchProviderName[];
+	const provider_names = providers.ids() as [
+		WebSearchProviderName,
+		...WebSearchProviderName[],
+	];
 
 	server.tool(
 		{
 			name: 'web_search',
 			description:
-				'Search the web for information. Use when you need to find web pages, articles, or data. Providers: tavily (factual/citations), brave (privacy/operators), kagi (quality/operators), exa (AI-semantic), kagi_enrichment (specialized indexes). Brave/Kagi support query operators like site:, filetype:, lang:, before:, after:.',
+				'Search the web for information. Use when you need to find web pages, articles, or data. Providers: tavily (factual/citations), brave (privacy/operators), kagi (quality/operators), exa (AI-semantic), kagi_enrichment (specialized indexes). Brave/Kagi support query operators like site:, filetype:, lang:, before:, after:. Pass provider for a single engine. Pass providers to run selected configured engines concurrently under one timeout; missing keys are skipped. Do not send both.',
 			annotations: {
 				readOnlyHint: true,
 				destructiveHint: false,
 				idempotentHint: true,
 				openWorldHint: true,
 			},
-			schema: v.object({
-				query: query_schema,
-				provider: v.pipe(
-					v.picklist(provider_names),
-					v.description('Search provider to use'),
-				),
-				limit: limit_schema,
-				include_domains: include_domains_schema,
-				exclude_domains: exclude_domains_schema,
-				large_result_mode: large_result_mode_schema,
-			}),
+			schema: create_web_search_schema(provider_names),
 		},
 		async ({
 			query,
 			provider,
+			providers: requested_providers,
 			limit,
 			include_domains,
 			exclude_domains,
@@ -71,14 +67,40 @@ export const register_web_search = (
 			handle_tool_result(
 				'web_search',
 				async () => {
-					const selected = providers.require(provider, 'web_search');
-
-					return selected.search({
+					const search_params = {
 						query,
 						limit,
 						include_domains,
 						exclude_domains,
-					});
+					};
+
+					if (requested_providers) {
+						const selected = resolve_configured_providers(
+							requested_providers,
+							(id) => providers.get(id),
+						);
+
+						if (selected.length === 0) {
+							throw new ProviderError(
+								ErrorType.INVALID_INPUT,
+								`None of the requested providers are configured: ${requested_providers.join(', ')}. Available: ${providers.ids().join(', ')}`,
+								'web_search',
+							);
+						}
+
+						return search_providers_concurrently(
+							selected,
+							search_params,
+							config.search.fanout.timeout,
+						);
+					}
+
+					const selected = providers.require(
+						provider as WebSearchProviderName,
+						'web_search',
+					);
+
+					return selected.search(search_params);
 				},
 				{ large_result_mode },
 			),


### PR DESCRIPTION
## Summary

Fixes #188.

`web_search` currently accepts one `provider` and makes one vendor call. Covering Exa + Tavily (or similar) requires multiple tool calls. This PR adds an **optional** `providers` array that fans out only the named, configured engines concurrently under one timeout.

## Problem

Self-hosted Omnisearch users who already have several keys want one tool call to hit those indexes at the same time, then merge. Single-path must remain the cheap default.

## Approach

- Keep `provider: "exa"` (and the other current values) on the existing single-path call. That path is unchanged.
- Add optional `providers: ["exa", "tavily"]`. Exactly one of `provider` or `providers` is required.
- Start selected configured providers concurrently under `config.search.fanout.timeout` (`AbortSignal.timeout` from `env.ts`).
- Skip missing API keys instead of failing the whole call. If none of the requested providers are configured, return `INVALID_INPUT`.
- Merge successful results (first URL wins). A runtime failure or timeout on one engine does not discard results from the others.
- Do not add `provider: "all"` or any implicit “search everything” mode. Providers stay opt-in at registration time.

Uses existing conventions: `ProviderError`, `env.ts` timeouts, and `retry_with_backoff` on each selected provider call.

## Scope

- `src/server/tools/web-search.ts` — schema + handler branch
- `src/server/tools/web-search-fanout.ts` — resolve / concurrent search / merge
- `src/server/tools/schemas.ts` — `providers` field and XOR check
- `src/config/env.ts` — shared fan-out timeout
- Tests and docs for this feature only (`README.md`, `docs/provider-selection.md`)

## Verification

```bash
pnpm run format
pnpm test
pnpm run build
```

Local result: format/lint clean, **120 tests passed**, build succeeded.

Example MCP calls:

```json
{ "query": "sveltekit remote functions", "provider": "exa" }
```

```json
{ "query": "sveltekit remote functions", "providers": ["exa", "tavily"] }
```

## Impact

No breaking change. Existing `provider` clients keep working. Fan-out is opt-in, and unconfigured providers are still not registered.