### PR TITLE
feat: add optional spam/mirror filter and domain diversity

### DIFF
--- a/.changeset/spam-mirror-filter.md
+++ b/.changeset/spam-mirror-filter.md
@@ -1,0 +1,5 @@
+---
+'mcp-omnisearch': patch
+---
+
+feat: add optional spam/mirror filter and per-domain result cap

--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ Search the web with Tavily, Brave, Kagi, Exa, or Kagi Enrichment.
 }
 ```
 
+Known content mirrors are dropped by default and extra hits from the
+same registrable domain are moved behind more diverse results. Set
+`filter_spam` to `false` or `max_results_per_domain` to `0` to
+disable. `site:` and `include_domains` queries are exempt. See
+[result quality](docs/result-quality.md).
+
 ### `ai_search`
 
 Get sourced AI answers with Kagi FastGPT, Exa Answer, or Linkup.
@@ -99,6 +105,8 @@ Tavily, Kagi, Firecrawl, or Exa.
   by task, key, mode, and capability.
 - [Search operators](docs/search-operators.md) — operator support
   matrix and tested examples.
+- [Result quality](docs/result-quality.md) — spam/mirror filter,
+  per-domain cap, and `spam_filtered` metadata.
 - [Large results](docs/large-results.md) — inline vs file response
   behavior and remote deployment caveats.
 - [Deployment](docs/deployment.md) — MCP client, WSL, Docker, cloud,
@@ -117,6 +125,13 @@ Tavily, Kagi, Firecrawl, or Exa.
 - `FIRECRAWL_API_KEY`
 - `FIRECRAWL_BASE_URL` optional, for self-hosted Firecrawl
 - `OMNISEARCH_LARGE_RESULT_MODE` optional, `file` default or `inline`
+- `OMNISEARCH_FILTER_SPAM` optional, default `true`
+- `OMNISEARCH_MAX_RESULTS_PER_DOMAIN` optional, default `2`; `0`
+  disables the cap
+- `OMNISEARCH_BLOCKED_DOMAINS` optional, comma-separated extra
+  mirror/scraper hosts
+- `OMNISEARCH_ALLOWED_DOMAINS` optional, comma-separated blocklist
+  exceptions
 
 ## Development
 

--- a/docs/result-quality.md
+++ b/docs/result-quality.md
@@ -1,0 +1,65 @@
+# Result quality
+
+`web_search` applies an optional quality layer after the selected
+provider returns results. The default is conservative: known content
+mirrors are dropped, and extra hits from the same registrable domain
+are moved behind more diverse results.
+
+## What it does
+
+- Drops known Stack Overflow / GitHub / documentation mirrors and SEO
+  scrapers. The builtin list can be extended with `blocked_domains` or
+  `OMNISEARCH_BLOCKED_DOMAINS`.
+- Caps results per registrable domain (default 2). The first hits keep
+  their provider order; overflow is appended, not deleted.
+- Skips the domain cap for `site:` queries and `include_domains`.
+  Constrained hosts are also kept even if they appear on the
+  blocklist, so a deliberate `site:newbedev.com` search is not
+  "fixed".
+- Reports what changed in `metadata.spam_filtered`.
+
+## Disable or override
+
+```json
+{
+	"query": "fastapi upload example",
+	"provider": "brave",
+	"filter_spam": false,
+	"max_results_per_domain": 0
+}
+```
+
+Per-request fields override environment defaults:
+
+- `filter_spam` — default `true`, or `OMNISEARCH_FILTER_SPAM`
+- `max_results_per_domain` — default `2`, or
+  `OMNISEARCH_MAX_RESULTS_PER_DOMAIN`. `0` disables the cap.
+- `blocked_domains` — extra hosts to drop, merged with
+  `OMNISEARCH_BLOCKED_DOMAINS`
+- `allowed_domains` — rescue hosts from the blocklist, merged with
+  `OMNISEARCH_ALLOWED_DOMAINS`
+
+## Response shape
+
+```json
+{
+	"results": [
+		{
+			"title": "Example",
+			"url": "https://example.com",
+			"snippet": "Example result",
+			"source_provider": "brave"
+		}
+	],
+	"metadata": {
+		"spam_filtered": {
+			"removed_count": 1,
+			"domains": ["newbedev.com"],
+			"demoted_count": 0
+		}
+	}
+}
+```
+
+`removed_count` / `domains` are dropped mirrors. `demoted_count` is
+how many results were moved behind the diverse head.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -17,13 +17,14 @@ and configured providers remain available.
 
 ## Common failure modes
 
-| Symptom                                   | Likely cause                                              | Fix                                                                                                                              |
-| ----------------------------------------- | --------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| Provider is unavailable                   | Missing API key                                           | Set the provider key and restart the MCP server. Check `omnisearch://providers/status`.                                          |
-| Request fails with unauthorized/forbidden | Invalid key or plan mismatch                              | Verify the key belongs to the provider and has access to the endpoint or plan tier.                                              |
-| Query rejected before provider call       | Invalid input                                             | Check for empty queries, unsupported modes, malformed domains, or unsupported URL protocols.                                     |
-| Repeated transient errors                 | Rate limits, timeout, network failure, or provider 5xx    | Retry later or lower request volume. Retryable failures are handled separately from invalid credentials and validation failures. |
-| Returned file path cannot be read         | Server wrote a temp file on a remote/container filesystem | Retry with `large_result_mode: "inline"` or set `OMNISEARCH_LARGE_RESULT_MODE=inline`.                                           |
+| Symptom                                               | Likely cause                                              | Fix                                                                                                                              |
+| ----------------------------------------------------- | --------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| Provider is unavailable                               | Missing API key                                           | Set the provider key and restart the MCP server. Check `omnisearch://providers/status`.                                          |
+| Request fails with unauthorized/forbidden             | Invalid key or plan mismatch                              | Verify the key belongs to the provider and has access to the endpoint or plan tier.                                              |
+| Query rejected before provider call                   | Invalid input                                             | Check for empty queries, unsupported modes, malformed domains, or unsupported URL protocols.                                     |
+| Expected mirror or extra same-domain hits are missing | Default spam filter or per-domain cap                     | Set `filter_spam: false` and/or `max_results_per_domain: 0`, or use `site:` / `include_domains`. Check `metadata.spam_filtered`. |
+| Repeated transient errors                             | Rate limits, timeout, network failure, or provider 5xx    | Retry later or lower request volume. Retryable failures are handled separately from invalid credentials and validation failures. |
+| Returned file path cannot be read                     | Server wrote a temp file on a remote/container filesystem | Retry with `large_result_mode: "inline"` or set `OMNISEARCH_LARGE_RESULT_MODE=inline`.                                           |
 
 ## GitHub token setup
 

--- a/src/common/quality.test.ts
+++ b/src/common/quality.test.ts
@@ -1,0 +1,342 @@
+import { describe, expect, it } from 'vitest';
+import {
+	apply_search_quality,
+	domain_matches_rule,
+	extract_domain_constraints,
+	filter_spam_results,
+	hostname_from_url,
+	registrable_domain,
+	rerank_domain_diversity,
+} from './quality.js';
+
+const result = (url: string, title = 't') => ({
+	title,
+	url,
+	snippet: 'snippet text',
+	source_provider: 'brave',
+});
+
+describe('hostname helpers', () => {
+	it('strips www and ignores invalid URLs', () => {
+		expect(hostname_from_url('https://www.NewBedev.com/x')).toBe(
+			'newbedev.com',
+		);
+		expect(hostname_from_url('not-a-url')).toBe('');
+	});
+
+	it('uses eTLD+1 so subdomains share a registrable domain', () => {
+		expect(registrable_domain('blog.example.com')).toBe(
+			'example.com',
+		);
+		expect(registrable_domain('docs.example.co.uk')).toBe(
+			'example.co.uk',
+		);
+		expect(registrable_domain('user.github.io')).toBe(
+			'user.github.io',
+		);
+		expect(registrable_domain('a.example')).toBe('a.example');
+	});
+
+	it('matches exact domains and true subdomains only', () => {
+		expect(
+			domain_matches_rule('de.newbedev.com', 'newbedev.com'),
+		).toBe(true);
+		expect(
+			domain_matches_rule(
+				'newbedev.com.evil.example',
+				'newbedev.com',
+			),
+		).toBe(false);
+		expect(
+			domain_matches_rule('newbedev.community', 'newbedev.com'),
+		).toBe(false);
+	});
+});
+
+describe('filter_spam_results', () => {
+	it('removes known mirror domains', () => {
+		const { kept, removed } = filter_spam_results([
+			result('https://stackoverflow.com/q/1'),
+			result('https://newbedev.com/some-copied-answer'),
+			result('https://githubmemory.com/repo/issue'),
+		]);
+
+		expect(kept.map((item) => item.url)).toEqual([
+			'https://stackoverflow.com/q/1',
+		]);
+		expect(removed).toEqual(['githubmemory.com', 'newbedev.com']);
+	});
+
+	it('matches www and subdomains', () => {
+		const { kept, removed } = filter_spam_results([
+			result('https://www.newbedev.com/x'),
+			result('https://de.newbedev.com/x'),
+		]);
+
+		expect(kept).toEqual([]);
+		expect(removed).toEqual(['de.newbedev.com', 'newbedev.com']);
+	});
+
+	it('does not treat lookalike registrations as blocked', () => {
+		const { kept, removed } = filter_spam_results([
+			result('https://newbedev.com.evil.example/post'),
+			result('https://newbedev.community/post'),
+		]);
+
+		expect(kept.map((item) => item.url)).toEqual([
+			'https://newbedev.com.evil.example/post',
+			'https://newbedev.community/post',
+		]);
+		expect(removed).toEqual([]);
+	});
+
+	it('covers live-sighted documentation mirrors', () => {
+		const { kept, removed } = filter_spam_results([
+			result('https://fixmycodeerror.com/q'),
+			result('https://stacklesson.com/q'),
+			result('https://docs.w3cub.com/python~3/library/ssl'),
+		]);
+
+		expect(kept).toEqual([]);
+		expect(removed).toEqual([
+			'docs.w3cub.com',
+			'fixmycodeerror.com',
+			'stacklesson.com',
+		]);
+	});
+
+	it('accepts extra blocked domains and allowlist rescues', () => {
+		expect(
+			filter_spam_results(
+				[result('https://content-farm.example/post')],
+				['content-farm.example'],
+			).removed,
+		).toEqual(['content-farm.example']);
+
+		const rescued = filter_spam_results(
+			[result('https://newbedev.com/x')],
+			[],
+			['newbedev.com'],
+		);
+		expect(rescued.kept).toHaveLength(1);
+		expect(rescued.removed).toEqual([]);
+	});
+
+	it('passes clean results through unchanged', () => {
+		const results = [
+			result('https://docs.python.org/3/'),
+			result('https://github.com/x/y'),
+		];
+
+		expect(filter_spam_results(results)).toEqual({
+			kept: results,
+			removed: [],
+		});
+	});
+});
+
+describe('rerank_domain_diversity', () => {
+	it('demotes overflow results from the same registrable domain', () => {
+		const { results, demoted } = rerank_domain_diversity(
+			[
+				result('https://a.example/1'),
+				result('https://a.example/2'),
+				result('https://a.example/3'),
+				result('https://b.example/1'),
+			],
+			2,
+		);
+
+		expect(results.map((item) => item.url)).toEqual([
+			'https://a.example/1',
+			'https://a.example/2',
+			'https://b.example/1',
+			'https://a.example/3',
+		]);
+		expect(demoted).toBe(1);
+	});
+
+	it('caps subdomains of one registrable domain together', () => {
+		const { results, demoted } = rerank_domain_diversity(
+			[
+				result('https://blog.example.com/1'),
+				result('https://docs.example.com/2'),
+				result('https://www.example.com/3'),
+				result('https://other.example/1'),
+			],
+			2,
+		);
+
+		expect(results.map((item) => item.url)).toEqual([
+			'https://blog.example.com/1',
+			'https://docs.example.com/2',
+			'https://other.example/1',
+			'https://www.example.com/3',
+		]);
+		expect(demoted).toBe(1);
+	});
+
+	it('leaves short or already-diverse lists untouched', () => {
+		const short_list = [
+			result('https://a.example/1'),
+			result('https://a.example/2'),
+		];
+		expect(rerank_domain_diversity(short_list, 1)).toEqual({
+			results: short_list,
+			demoted: 0,
+		});
+
+		const diverse = [
+			result('https://a.example/1'),
+			result('https://b.example/1'),
+			result('https://c.example/1'),
+		];
+		expect(rerank_domain_diversity(diverse)).toEqual({
+			results: diverse,
+			demoted: 0,
+		});
+	});
+});
+
+describe('extract_domain_constraints', () => {
+	it('collects site operators and include_domains', () => {
+		expect(
+			extract_domain_constraints(
+				'site:github.com site:Docs.Python.org asyncio',
+				['arxiv.org'],
+			),
+		).toEqual(['arxiv.org', 'docs.python.org', 'github.com']);
+	});
+
+	it('returns no constraints for plain queries', () => {
+		expect(
+			extract_domain_constraints('fastapi upload file example'),
+		).toEqual([]);
+		expect(extract_domain_constraints('', undefined)).toEqual([]);
+	});
+});
+
+describe('apply_search_quality', () => {
+	it('filters mirrors and reports spam_filtered metadata', () => {
+		const output = apply_search_quality([
+			result('https://stackoverflow.com/q/1'),
+			result('https://newbedev.com/copy'),
+			result('https://docs.python.org/3/'),
+		]);
+
+		expect(output.results.map((item) => item.url)).toEqual([
+			'https://stackoverflow.com/q/1',
+			'https://docs.python.org/3/',
+		]);
+		expect(output.metadata.spam_filtered).toEqual({
+			removed_count: 1,
+			domains: ['newbedev.com'],
+			demoted_count: 0,
+		});
+	});
+
+	it('applies the per-domain cap and reports demotions', () => {
+		const output = apply_search_quality([
+			result('https://a.example/1'),
+			result('https://a.example/2'),
+			result('https://a.example/3'),
+			result('https://b.example/1'),
+		]);
+
+		expect(
+			output.results.map((item) => item.url).slice(0, 3),
+		).toEqual([
+			'https://a.example/1',
+			'https://a.example/2',
+			'https://b.example/1',
+		]);
+		expect(output.metadata.spam_filtered.demoted_count).toBe(1);
+	});
+
+	it('can disable spam filtering and the domain cap', () => {
+		const spam = apply_search_quality(
+			[result('https://newbedev.com/copy')],
+			{ filter_spam: false },
+		);
+		expect(spam.results).toHaveLength(1);
+		expect(spam.metadata.spam_filtered.removed_count).toBe(0);
+
+		const crowded = [
+			result('https://a.example/1'),
+			result('https://a.example/2'),
+			result('https://a.example/3'),
+		];
+		const uncapped = apply_search_quality(crowded, {
+			max_results_per_domain: 0,
+		});
+		expect(uncapped.results.map((item) => item.url)).toEqual(
+			crowded.map((item) => item.url),
+		);
+	});
+
+	it('rescues allowlisted domains from the blocklist', () => {
+		const output = apply_search_quality(
+			[result('https://newbedev.com/copy')],
+			{ allowed_domains: ['newbedev.com'] },
+		);
+
+		expect(output.results).toHaveLength(1);
+	});
+
+	it('skips diversity rerank for site: and include_domains', () => {
+		const github = [
+			result('https://github.com/x/1'),
+			result('https://github.com/x/2'),
+			result('https://github.com/x/3'),
+			result('https://randomblog.example/post'),
+		];
+		const site_query = apply_search_quality(github, {
+			query: 'site:github.com fastapi upload example',
+		});
+		expect(site_query.results.map((item) => item.url)).toEqual(
+			github.map((item) => item.url),
+		);
+		expect(site_query.metadata.spam_filtered.demoted_count).toBe(0);
+
+		const arxiv = [
+			result('https://arxiv.org/abs/1'),
+			result('https://arxiv.org/abs/2'),
+			result('https://arxiv.org/abs/3'),
+			result('https://other.example/x'),
+		];
+		const included = apply_search_quality(arxiv, {
+			query: 'attention is all you need',
+			include_domains: ['arxiv.org'],
+		});
+		expect(
+			included.results.map((item) => item.url).slice(0, 3),
+		).toEqual([
+			'https://arxiv.org/abs/1',
+			'https://arxiv.org/abs/2',
+			'https://arxiv.org/abs/3',
+		]);
+	});
+
+	it('lets an explicit site: query keep a blocked domain', () => {
+		const output = apply_search_quality(
+			[result('https://newbedev.com/copy')],
+			{ query: 'site:newbedev.com some query' },
+		);
+
+		expect(output.results).toHaveLength(1);
+	});
+
+	it('still reranks unconstrained queries', () => {
+		const output = apply_search_quality(
+			[
+				result('https://a.example/1'),
+				result('https://a.example/2'),
+				result('https://a.example/3'),
+				result('https://b.example/1'),
+			],
+			{ query: 'fastapi upload file example' },
+		);
+
+		expect(output.metadata.spam_filtered.demoted_count).toBe(1);
+	});
+});

--- a/src/common/quality.ts
+++ b/src/common/quality.ts
@@ -1,0 +1,255 @@
+import { parse_search_operators } from './search-operators.js';
+import { SPAM_MIRROR_DOMAINS } from './spam-domains.js';
+import type { SpamFilteredMetadata } from './types.js';
+
+export interface SearchQualityOptions {
+	query?: string;
+	include_domains?: string[];
+	filter_spam?: boolean;
+	max_results_per_domain?: number;
+	blocked_domains?: string[];
+	allowed_domains?: string[];
+}
+
+export interface SearchQualityResult<T> {
+	results: T[];
+	metadata: {
+		spam_filtered: SpamFilteredMetadata;
+	};
+}
+
+// Common multi-part public suffixes so blog.example.co.uk and
+// docs.example.co.uk share a registrable domain. Keep this list
+// small; unknown suffixes fall back to the last two labels.
+const MULTI_PART_PUBLIC_SUFFIXES = new Set([
+	'ac.uk',
+	'co.uk',
+	'gov.uk',
+	'ltd.uk',
+	'me.uk',
+	'net.uk',
+	'org.uk',
+	'plc.uk',
+	'com.au',
+	'net.au',
+	'org.au',
+	'edu.au',
+	'gov.au',
+	'co.nz',
+	'net.nz',
+	'org.nz',
+	'govt.nz',
+	'ac.nz',
+	'co.jp',
+	'ne.jp',
+	'or.jp',
+	'ac.jp',
+	'go.jp',
+	'com.br',
+	'com.mx',
+	'com.ar',
+	'co.in',
+	'com.sg',
+	'com.hk',
+	'co.za',
+	'com.tw',
+	'co.kr',
+	'github.io',
+	'gitlab.io',
+]);
+
+export const normalize_hostname = (value: string): string => {
+	let host = value.trim().toLowerCase();
+	if (!host) return '';
+
+	host = host.replace(/^https?:\/\//, '');
+	host = host.split('/')[0] ?? '';
+	host = host.replace(/:\d+$/, '');
+	host = host.replace(/^\*\./, '').replace(/\.$/, '');
+
+	if (host.startsWith('www.')) host = host.slice(4);
+
+	return host;
+};
+
+export const hostname_from_url = (url: string): string => {
+	try {
+		return normalize_hostname(new URL(url).hostname);
+	} catch {
+		return '';
+	}
+};
+
+export const registrable_domain = (hostname: string): string => {
+	const host = normalize_hostname(hostname);
+	if (!host) return '';
+
+	const parts = host.split('.').filter(Boolean);
+	if (parts.length <= 2) return parts.join('.');
+
+	const last_two = parts.slice(-2).join('.');
+	if (MULTI_PART_PUBLIC_SUFFIXES.has(last_two) && parts.length >= 3) {
+		return parts.slice(-3).join('.');
+	}
+
+	return last_two;
+};
+
+export const domain_matches_rule = (
+	domain: string,
+	rule: string,
+): boolean => {
+	const normalized_domain = normalize_hostname(domain);
+	const normalized_rule = normalize_hostname(rule);
+	if (!normalized_domain || !normalized_rule) return false;
+
+	return (
+		normalized_domain === normalized_rule ||
+		normalized_domain.endsWith(`.${normalized_rule}`)
+	);
+};
+
+export const extract_domain_constraints = (
+	query: string,
+	include_domains?: string[],
+): string[] => {
+	const from_site = parse_search_operators(query)
+		.operators.filter((operator) => operator.type === 'site')
+		.map((operator) => normalize_hostname(operator.value))
+		.filter(Boolean);
+	const from_include = (include_domains ?? [])
+		.map(normalize_hostname)
+		.filter(Boolean);
+
+	return [...new Set([...from_site, ...from_include])].sort();
+};
+
+export const filter_spam_results = <T extends { url: string }>(
+	results: T[],
+	extra_blocked: string[] = [],
+	allowed: string[] = [],
+): { kept: T[]; removed: string[] } => {
+	const blocked_rules = [
+		...SPAM_MIRROR_DOMAINS,
+		...extra_blocked.map(normalize_hostname).filter(Boolean),
+	];
+	const allowed_rules = allowed
+		.map(normalize_hostname)
+		.filter(Boolean);
+	const kept: T[] = [];
+	const removed_domains: string[] = [];
+
+	for (const item of results) {
+		const domain = hostname_from_url(item.url);
+		const is_allowed = allowed_rules.some((rule) =>
+			domain_matches_rule(domain, rule),
+		);
+		const is_blocked = blocked_rules.some((rule) =>
+			domain_matches_rule(domain, rule),
+		);
+
+		if (domain && !is_allowed && is_blocked) {
+			removed_domains.push(domain);
+			continue;
+		}
+
+		kept.push(item);
+	}
+
+	return {
+		kept,
+		removed: [...new Set(removed_domains)].sort(),
+	};
+};
+
+export const rerank_domain_diversity = <T extends { url: string }>(
+	results: T[],
+	max_per_domain = 2,
+): { results: T[]; demoted: number } => {
+	if (max_per_domain < 1 || results.length < 3) {
+		return { results, demoted: 0 };
+	}
+
+	const head: T[] = [];
+	const overflow: T[] = [];
+	const per_domain = new Map<string, number>();
+
+	for (const item of results) {
+		const host = hostname_from_url(item.url);
+		const domain = host ? registrable_domain(host) : '';
+		if (!domain) {
+			head.push(item);
+			continue;
+		}
+
+		const count = per_domain.get(domain) ?? 0;
+		if (count >= max_per_domain) {
+			overflow.push(item);
+			continue;
+		}
+
+		per_domain.set(domain, count + 1);
+		head.push(item);
+	}
+
+	return {
+		results: [...head, ...overflow],
+		demoted: overflow.length,
+	};
+};
+
+const empty_spam_filtered = (): SpamFilteredMetadata => ({
+	removed_count: 0,
+	domains: [],
+	demoted_count: 0,
+});
+
+export const apply_search_quality = <T extends { url: string }>(
+	results: T[],
+	options: SearchQualityOptions = {},
+): SearchQualityResult<T> => {
+	const filter_spam = options.filter_spam ?? true;
+	const max_per_domain = options.max_results_per_domain ?? 2;
+	const constraints = extract_domain_constraints(
+		options.query ?? '',
+		options.include_domains,
+	);
+	const allowed = [
+		...(options.allowed_domains ?? []),
+		...constraints,
+	];
+
+	let kept = results;
+	let removed: string[] = [];
+	let removed_count = 0;
+	let demoted = 0;
+
+	if (filter_spam) {
+		const filtered = filter_spam_results(
+			kept,
+			options.blocked_domains,
+			allowed,
+		);
+		removed_count = kept.length - filtered.kept.length;
+		kept = filtered.kept;
+		removed = filtered.removed;
+	}
+
+	if (constraints.length === 0 && max_per_domain > 0) {
+		const reranked = rerank_domain_diversity(kept, max_per_domain);
+		kept = reranked.results;
+		demoted = reranked.demoted;
+	}
+
+	return {
+		results: kept,
+		metadata: {
+			spam_filtered: {
+				...empty_spam_filtered(),
+				removed_count,
+				domains: removed,
+				demoted_count: demoted,
+			},
+		},
+	};
+};

--- a/src/common/spam-domains.ts
+++ b/src/common/spam-domains.ts
@@ -1,0 +1,27 @@
+// Known content mirrors and SEO scrapers that republish Stack
+// Overflow, GitHub, and documentation. These add no information over
+// the canonical source and are dropped rather than demoted.
+export const SPAM_MIRROR_DOMAINS = [
+	// Stack Overflow / Q&A scrapers
+	'newbedev.com',
+	'stackoom.com',
+	'stackovergo.com',
+	'syntaxfix.com',
+	'copyprogramming.com',
+	'devcodef1.com',
+	'exceptionshub.com',
+	'code-examples.net',
+	'i-harness.com',
+	'fixmycodeerror.com',
+	'stacklesson.com',
+	// GitHub issue/readme mirrors
+	'githubmemory.com',
+	'gitmemory.com',
+	'issueexplorer.com',
+	'bleepcoder.com',
+	'gitanswer.com',
+	// Documentation mirrors
+	'w3cub.com',
+	// Generic AI/SEO content farms
+	'aizolo.com',
+] as const;

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -11,6 +11,19 @@ export interface SearchResult {
 	metadata?: ProviderMetadata;
 }
 
+export interface SpamFilteredMetadata {
+	removed_count: number;
+	domains: string[];
+	demoted_count: number;
+}
+
+export interface SearchToolResult {
+	results: SearchResult[];
+	metadata: {
+		spam_filtered: SpamFilteredMetadata;
+	};
+}
+
 export interface BaseSearchParams {
 	query: string;
 	limit?: number;

--- a/src/config/env.test.ts
+++ b/src/config/env.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
+	get_quality_settings,
+	parse_boolean_env,
+	parse_domain_list_env,
+	parse_integer_env,
 	should_warn_for_local_file_offload,
 	warn_for_local_file_offload,
 } from './env.js';
@@ -36,5 +40,58 @@ describe('large-result local file offload warnings', () => {
 				OMNISEARCH_LARGE_RESULT_MODE: 'file',
 			}),
 		).toBe(false);
+	});
+});
+
+describe('quality settings', () => {
+	it('parses boolean, integer, and domain-list env values', () => {
+		expect(parse_boolean_env(undefined, true)).toBe(true);
+		expect(parse_boolean_env('false', true)).toBe(false);
+		expect(parse_boolean_env('YES', false)).toBe(true);
+		expect(parse_boolean_env('nope', true)).toBe(true);
+		expect(parse_integer_env(undefined, 2)).toBe(2);
+		expect(parse_integer_env('4', 2)).toBe(4);
+		expect(parse_integer_env('nope', 2)).toBe(2);
+		expect(
+			parse_domain_list_env(' NewBedev.com, ,spam.dev '),
+		).toEqual(['newbedev.com', 'spam.dev']);
+	});
+
+	it('defaults to conservative spam filtering and a domain cap of 2', () => {
+		expect(get_quality_settings({})).toEqual({
+			filter_spam: true,
+			max_results_per_domain: 2,
+			blocked_domains: [],
+			allowed_domains: [],
+		});
+	});
+
+	it('reads quality overrides from the environment', () => {
+		expect(
+			get_quality_settings({
+				OMNISEARCH_FILTER_SPAM: '0',
+				OMNISEARCH_MAX_RESULTS_PER_DOMAIN: '0',
+				OMNISEARCH_BLOCKED_DOMAINS: 'spam.dev,mirror.example',
+				OMNISEARCH_ALLOWED_DOMAINS: 'newbedev.com',
+			}),
+		).toEqual({
+			filter_spam: false,
+			max_results_per_domain: 0,
+			blocked_domains: ['spam.dev', 'mirror.example'],
+			allowed_domains: ['newbedev.com'],
+		});
+	});
+
+	it('clamps the per-domain cap to 0-50', () => {
+		expect(
+			get_quality_settings({
+				OMNISEARCH_MAX_RESULTS_PER_DOMAIN: '-3',
+			}).max_results_per_domain,
+		).toBe(0);
+		expect(
+			get_quality_settings({
+				OMNISEARCH_MAX_RESULTS_PER_DOMAIN: '99',
+			}).max_results_per_domain,
+		).toBe(50);
 	});
 });

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -198,3 +198,62 @@ export const validate_config = () => {
 
 	warn_for_local_file_offload();
 };
+
+export const parse_boolean_env = (
+	value: string | undefined,
+	fallback: boolean,
+): boolean => {
+	if (value === undefined) return fallback;
+
+	const normalized = value.trim().toLowerCase();
+	if (normalized === '') return fallback;
+	if (['1', 'true', 'yes', 'on'].includes(normalized)) {
+		return true;
+	}
+	if (['0', 'false', 'no', 'off'].includes(normalized)) {
+		return false;
+	}
+
+	return fallback;
+};
+
+export const parse_integer_env = (
+	value: string | undefined,
+	fallback: number,
+): number => {
+	if (value === undefined || value.trim() === '') return fallback;
+
+	const parsed = Number.parseInt(value, 10);
+	return Number.isFinite(parsed) ? parsed : fallback;
+};
+
+export const parse_domain_list_env = (
+	value: string | undefined,
+): string[] =>
+	(value ?? '')
+		.split(',')
+		.map((entry) => entry.trim().toLowerCase())
+		.filter(Boolean);
+
+export const get_quality_settings = (
+	env: NodeJS.ProcessEnv = process.env,
+) => {
+	const max_results_per_domain = Math.min(
+		50,
+		Math.max(
+			0,
+			parse_integer_env(env.OMNISEARCH_MAX_RESULTS_PER_DOMAIN, 2),
+		),
+	);
+
+	return {
+		filter_spam: parse_boolean_env(env.OMNISEARCH_FILTER_SPAM, true),
+		max_results_per_domain,
+		blocked_domains: parse_domain_list_env(
+			env.OMNISEARCH_BLOCKED_DOMAINS,
+		),
+		allowed_domains: parse_domain_list_env(
+			env.OMNISEARCH_ALLOWED_DOMAINS,
+		),
+	};
+};

--- a/src/server/tools/contract.test.ts
+++ b/src/server/tools/contract.test.ts
@@ -82,7 +82,7 @@ afterEach(() => {
 	vi.restoreAllMocks();
 });
 
-describe('MCP tool contract', () => {
+describe('MCP tool contract', { timeout: 15_000 }, () => {
 	it('registers no public tools when no providers are configured', async () => {
 		const { tools, tools_module } = await load_contract({});
 
@@ -128,6 +128,10 @@ describe('MCP tool contract', () => {
 				provider: 'brave',
 				limit: 5,
 				include_domains: ['svelte.dev'],
+				filter_spam: false,
+				max_results_per_domain: 0,
+				blocked_domains: ['spam.dev'],
+				allowed_domains: ['newbedev.com'],
 				large_result_mode: 'inline',
 			}).success,
 		).toBe(true);
@@ -234,14 +238,23 @@ describe('MCP tool contract', () => {
 			provider: 'brave',
 			large_result_mode: 'inline',
 		});
-		expect(parse_tool_body(success)).toEqual([
-			{
-				title: 'Example',
-				url: 'https://example.com',
-				snippet: 'Example result',
-				source_provider: 'brave',
+		expect(parse_tool_body(success)).toEqual({
+			results: [
+				{
+					title: 'Example',
+					url: 'https://example.com',
+					snippet: 'Example result',
+					source_provider: 'brave',
+				},
+			],
+			metadata: {
+				spam_filtered: {
+					removed_count: 0,
+					domains: [],
+					demoted_count: 0,
+				},
 			},
-		]);
+		});
 
 		vi.stubGlobal(
 			'fetch',
@@ -261,6 +274,69 @@ describe('MCP tool contract', () => {
 			provider: 'brave',
 			retryable: false,
 		});
+	});
+
+	it('filters known mirrors from web_search and reports spam_filtered', async () => {
+		const { tools } = await load_contract({
+			BRAVE_API_KEY: 'brave-key',
+		});
+		const tool = tools.find(
+			(entry) => entry.definition.name === 'web_search',
+		)!;
+
+		const brave_results = {
+			web: {
+				results: [
+					{
+						title: 'Canonical',
+						url: 'https://stackoverflow.com/q/1',
+						description: 'Original answer',
+					},
+					{
+						title: 'Mirror',
+						url: 'https://newbedev.com/copied',
+						description: 'Scraped answer',
+					},
+				],
+			},
+		};
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockImplementation(
+				() =>
+					new Response(JSON.stringify(brave_results), {
+						status: 200,
+					}),
+			),
+		);
+
+		const filtered = parse_tool_body(
+			await tool.handler({
+				query: 'example',
+				provider: 'brave',
+				large_result_mode: 'inline',
+			}),
+		);
+		expect(
+			filtered.results.map((item: { url: string }) => item.url),
+		).toEqual(['https://stackoverflow.com/q/1']);
+		expect(filtered.metadata.spam_filtered).toEqual({
+			removed_count: 1,
+			domains: ['newbedev.com'],
+			demoted_count: 0,
+		});
+
+		const disabled = parse_tool_body(
+			await tool.handler({
+				query: 'example',
+				provider: 'brave',
+				filter_spam: false,
+				max_results_per_domain: 0,
+				large_result_mode: 'inline',
+			}),
+		);
+		expect(disabled.results).toHaveLength(2);
+		expect(disabled.metadata.spam_filtered.removed_count).toBe(0);
 	});
 
 	it('covers large-result inline/file modes and compact extraction at the MCP layer', async () => {

--- a/src/server/tools/schemas.test.ts
+++ b/src/server/tools/schemas.test.ts
@@ -1,11 +1,15 @@
 import * as v from 'valibot';
 import { describe, expect, it } from 'vitest';
 import {
+	allowed_domains_schema,
+	blocked_domains_schema,
 	domain_schema,
+	filter_spam_schema,
 	http_url_schema,
 	include_raw_contents_schema,
 	large_result_mode_schema,
 	limit_schema,
+	max_results_per_domain_schema,
 	query_schema,
 	url_or_urls_schema,
 } from './schemas.js';
@@ -44,6 +48,38 @@ describe('tool schemas', () => {
 		).toBe(true);
 		expect(
 			v.safeParse(include_raw_contents_schema, 'false').success,
+		).toBe(false);
+	});
+
+	it('accepts optional spam-filter and domain-cap controls', () => {
+		expect(v.safeParse(filter_spam_schema, undefined).success).toBe(
+			true,
+		);
+		expect(v.safeParse(filter_spam_schema, false).success).toBe(true);
+		expect(v.safeParse(filter_spam_schema, 'false').success).toBe(
+			false,
+		);
+		expect(
+			v.safeParse(max_results_per_domain_schema, 0).success,
+		).toBe(true);
+		expect(
+			v.safeParse(max_results_per_domain_schema, 2).success,
+		).toBe(true);
+		expect(
+			v.safeParse(max_results_per_domain_schema, -1).success,
+		).toBe(false);
+		expect(
+			v.safeParse(max_results_per_domain_schema, 51).success,
+		).toBe(false);
+		expect(
+			v.safeParse(blocked_domains_schema, ['spam.dev']).success,
+		).toBe(true);
+		expect(
+			v.safeParse(allowed_domains_schema, ['newbedev.com']).success,
+		).toBe(true);
+		expect(
+			v.safeParse(blocked_domains_schema, ['https://spam.dev'])
+				.success,
 		).toBe(false);
 	});
 

--- a/src/server/tools/schemas.ts
+++ b/src/server/tools/schemas.ts
@@ -59,6 +59,47 @@ export const exclude_domains_schema = v.optional(
 	),
 );
 
+export const filter_spam_schema = v.optional(
+	v.pipe(
+		v.boolean(),
+		v.description(
+			'Drop known content mirrors and SEO scrapers. Defaults to OMNISEARCH_FILTER_SPAM or true. site: and include_domains keep those hosts.',
+		),
+	),
+);
+
+export const max_results_per_domain_schema = v.optional(
+	v.pipe(
+		v.number(),
+		v.integer('max_results_per_domain must be an integer'),
+		v.minValue(0, 'max_results_per_domain must be at least 0'),
+		v.maxValue(50, 'max_results_per_domain must be at most 50'),
+		v.description(
+			'Keep this many results per registrable domain in place; overflow moves behind. 0 disables. Defaults to OMNISEARCH_MAX_RESULTS_PER_DOMAIN or 2. Skipped for site: and include_domains queries.',
+		),
+	),
+);
+
+export const blocked_domains_schema = v.optional(
+	v.pipe(
+		v.array(domain_schema),
+		v.maxLength(50, 'Use at most 50 extra blocked domains'),
+		v.description(
+			'Additional mirror or scraper domains to drop. Merged with OMNISEARCH_BLOCKED_DOMAINS.',
+		),
+	),
+);
+
+export const allowed_domains_schema = v.optional(
+	v.pipe(
+		v.array(domain_schema),
+		v.maxLength(50, 'Use at most 50 allowed domains'),
+		v.description(
+			'Keep these domains even if they appear on the spam/mirror blocklist. Merged with OMNISEARCH_ALLOWED_DOMAINS.',
+		),
+	),
+);
+
 export const http_url_schema = v.pipe(
 	v.string(),
 	v.url('URL must be valid'),

--- a/src/server/tools/web-search.ts
+++ b/src/server/tools/web-search.ts
@@ -1,7 +1,9 @@
 import { McpServer } from 'tmcp';
 import type { GenericSchema } from 'valibot';
 import * as v from 'valibot';
+import { apply_search_quality } from '../../common/quality.js';
 import { SearchProvider } from '../../common/types.js';
+import { get_quality_settings } from '../../config/env.js';
 import {
 	web_search_provider_definitions,
 	type WebSearchProviderName,
@@ -9,10 +11,14 @@ import {
 import { ProviderRegistry } from '../provider-registry.js';
 import { handle_tool_result } from './responses.js';
 import {
+	allowed_domains_schema,
+	blocked_domains_schema,
 	exclude_domains_schema,
+	filter_spam_schema,
 	include_domains_schema,
 	large_result_mode_schema,
 	limit_schema,
+	max_results_per_domain_schema,
 	query_schema,
 } from './schemas.js';
 
@@ -41,7 +47,7 @@ export const register_web_search = (
 		{
 			name: 'web_search',
 			description:
-				'Search the web for information. Use when you need to find web pages, articles, or data. Providers: tavily (factual/citations), brave (privacy/operators), kagi (quality/operators), exa (AI-semantic), kagi_enrichment (specialized indexes). Brave/Kagi support query operators like site:, filetype:, lang:, before:, after:.',
+				'Search the web for information. Use when you need to find web pages, articles, or data. Providers: tavily (factual/citations), brave (privacy/operators), kagi (quality/operators), exa (AI-semantic), kagi_enrichment (specialized indexes). Brave/Kagi support query operators like site:, filetype:, lang:, before:, after:. Known content mirrors are filtered by default and results are capped per registrable domain; disable with filter_spam=false or max_results_per_domain=0. site: and include_domains queries are exempt.',
 			annotations: {
 				readOnlyHint: true,
 				destructiveHint: false,
@@ -57,6 +63,10 @@ export const register_web_search = (
 				limit: limit_schema,
 				include_domains: include_domains_schema,
 				exclude_domains: exclude_domains_schema,
+				filter_spam: filter_spam_schema,
+				max_results_per_domain: max_results_per_domain_schema,
+				blocked_domains: blocked_domains_schema,
+				allowed_domains: allowed_domains_schema,
 				large_result_mode: large_result_mode_schema,
 			}),
 		},
@@ -66,18 +76,39 @@ export const register_web_search = (
 			limit,
 			include_domains,
 			exclude_domains,
+			filter_spam,
+			max_results_per_domain,
+			blocked_domains,
+			allowed_domains,
 			large_result_mode,
 		}) =>
 			handle_tool_result(
 				'web_search',
 				async () => {
 					const selected = providers.require(provider, 'web_search');
-
-					return selected.search({
+					const settings = get_quality_settings();
+					const results = await selected.search({
 						query,
 						limit,
 						include_domains,
 						exclude_domains,
+					});
+
+					return apply_search_quality(results, {
+						query,
+						include_domains,
+						filter_spam: filter_spam ?? settings.filter_spam,
+						max_results_per_domain:
+							max_results_per_domain ??
+							settings.max_results_per_domain,
+						blocked_domains: [
+							...settings.blocked_domains,
+							...(blocked_domains ?? []),
+						],
+						allowed_domains: [
+							...settings.allowed_domains,
+							...(allowed_domains ?? []),
+						],
 					});
 				},
 				{ large_result_mode },


### PR DESCRIPTION
## Summary

Fan-out search makes SEO scrapers and same-domain piles worse: the same mirrored Stack Overflow or GitHub page can appear from several engines. This adds an optional quality layer on `web_search` so known mirrors are dropped, extra hits from one registrable domain move behind more diverse results, and the change is visible in `metadata.spam_filtered`.

Fixes #202.

## Scope

- Builtin, overridable blocklist for known SO/GitHub/docs mirrors (`blocked_domains` / `OMNISEARCH_BLOCKED_DOMAINS`, `allowed_domains` to rescue).
- Cap of 2 results per registrable domain by default; overflow keeps order but is appended. `0` disables.
- `site:` and `include_domains` queries are exempt so constrained searches are not “fixed”.
- Per-request `filter_spam` / `max_results_per_domain` override env defaults (`OMNISEARCH_FILTER_SPAM`, `OMNISEARCH_MAX_RESULTS_PER_DOMAIN`).
- `web_search` now returns `{ results, metadata }` so filtering is inspectable.

No provider HTTP/auth changes.

## Verification

```bash
pnpm test
pnpm run check
pnpm run build
```

All 135 tests passed locally, including unit coverage for lookalike domains, `site:` / `include_domains` exemption, disable paths, and an MCP contract test that drops `newbedev.com` and reports `spam_filtered`.

Example: a Brave-style list with `https://stackoverflow.com/q/1` and `https://newbedev.com/copied` keeps only the canonical URL and returns `metadata.spam_filtered.removed_count: 1`. `filter_spam: false` plus `max_results_per_domain: 0` restores the vendor list.

## Impact

- **Behavior:** spam filter and domain cap are on by default; disable per request or via env.
- **Response shape:** `web_search` returns `{ results, metadata }` instead of a bare array. Clients that assumed an array need to read `results`.
- No new API keys. No provider registration changes.