### PR TITLE
feat: opt-in web_search research mode

### DIFF
--- a/.changeset/research-mode-192.md
+++ b/.changeset/research-mode-192.md
@@ -1,0 +1,6 @@
+---
+'mcp-omnisearch': patch
+---
+
+feat: add opt-in web_search research mode with multi-provider fan-out,
+optional extract, and a time budget

--- a/README.md
+++ b/README.md
@@ -84,6 +84,22 @@ Search the web with Tavily, Brave, Kagi, Exa, or Kagi Enrichment.
 }
 ```
 
+Single-provider search is the default. Opt in to research mode when
+you want several configured search providers plus optional extract
+under a time budget:
+
+```json
+{
+	"query": "turntable reviews under 1000",
+	"provider": "brave",
+	"mode": "research",
+	"research_time_budget": 45
+}
+```
+
+See [research mode](docs/research-mode.md) for budget, early-stop, and
+partial-failure behavior.
+
 ### `ai_search`
 
 Get sourced AI answers with Kagi FastGPT, Exa Answer, or Linkup.
@@ -124,6 +140,8 @@ Tavily, Kagi, Firecrawl, or Exa.
 
 - [Provider selection](docs/provider-selection.md) — choose providers
   by task, key, mode, and capability.
+- [Research mode](docs/research-mode.md) — opt-in multi-provider
+  search plus extract under a time budget.
 - [Search operators](docs/search-operators.md) — operator support
   matrix and tested examples.
 - [Large results](docs/large-results.md) — inline vs file response

--- a/docs/provider-selection.md
+++ b/docs/provider-selection.md
@@ -53,3 +53,7 @@ search only. See
   `kagi_fastgpt`, `exa_answer`, or `linkup`.
 - Need to crawl/scrape/map a site? Use `web_extract` with `firecrawl`.
 - Need public code/repository/user discovery? Use `github_search`.
+- Need several search engines plus page extracts in one call? Use
+  `web_search` with `mode: "research"`. See
+  [research mode](research-mode.md). Daily search should stay on one
+  explicit `provider`.

--- a/docs/research-mode.md
+++ b/docs/research-mode.md
@@ -1,0 +1,88 @@
+# Research mode
+
+`web_search` stays single-provider by default. Set `mode` to
+`research` only when you want a deeper, more expensive pass.
+
+## What it does
+
+1. Fans out the same query to several eligible configured search
+   providers. The requested `provider` is tried first. Specialized
+   indexes such as `kagi_enrichment` are included only when they are
+   the requested provider.
+2. Deduplicates results by normalized URL (first provider wins) and
+   keeps at most `limit` rows (default 10).
+3. Optionally extracts a bounded set of top URLs through an existing
+   `web_extract` provider. Preference order: Tavily extract, Firecrawl
+   scrape, Exa contents, Kagi summarize.
+4. Honors a best-effort `research_time_budget` (default 55 seconds,
+   range 1–75). The budget is checked before launching more search
+   providers and before extract.
+
+## Partial results and early-stop
+
+Research mode does not fail the whole call when a later provider or
+extract step fails. Search hits that already arrived are returned with
+diagnostics.
+
+After two providers have contributed unique URLs, remaining in-flight
+providers are abandoned and labeled `early_stop`. Providers that were
+never launched after the budget ran out are labeled
+`time_budget_exhausted`. In-flight work that exceeds the remaining
+budget is listed in `timed_out`.
+
+The response is an object, not a bare result array.
+
+Request:
+
+```json
+{
+	"query": "turntable reviews under 1000",
+	"provider": "brave",
+	"mode": "research",
+	"research_time_budget": 45,
+	"research_extract": true,
+	"research_extract_count": 3
+}
+```
+
+Response:
+
+```json
+{
+	"mode": "research",
+	"results": [
+		{
+			"title": "Example review",
+			"url": "https://example.com",
+			"snippet": "...",
+			"source_provider": "brave"
+		}
+	],
+	"extracts": {
+		"content": "...",
+		"source_provider": "tavily_extract"
+	},
+	"research": {
+		"time_budget_seconds": 45,
+		"elapsed_ms": 1200,
+		"selected": ["brave", "tavily"],
+		"succeeded": ["brave"],
+		"failed": [{ "provider": "tavily", "error": "..." }],
+		"skipped": [],
+		"timed_out": [],
+		"extract": {
+			"provider": "tavily:extract",
+			"status": "succeeded",
+			"urls": ["https://example.com"]
+		}
+	}
+}
+```
+
+`research_extract` defaults to `true` in research mode.
+`research_extract_count` defaults to 3 (max 10).
+
+## Cost
+
+Research mode can call several search APIs plus one extract API. Keep
+daily search on a single `provider` without `mode: "research"`.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -17,13 +17,14 @@ and configured providers remain available.
 
 ## Common failure modes
 
-| Symptom                                   | Likely cause                                              | Fix                                                                                                                              |
-| ----------------------------------------- | --------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| Provider is unavailable                   | Missing API key                                           | Set the provider key and restart the MCP server. Check `omnisearch://providers/status`.                                          |
-| Request fails with unauthorized/forbidden | Invalid key or plan mismatch                              | Verify the key belongs to the provider and has access to the endpoint or plan tier.                                              |
-| Query rejected before provider call       | Invalid input                                             | Check for empty queries, unsupported modes, malformed domains, or unsupported URL protocols.                                     |
-| Repeated transient errors                 | Rate limits, timeout, network failure, or provider 5xx    | Retry later or lower request volume. Retryable failures are handled separately from invalid credentials and validation failures. |
-| Returned file path cannot be read         | Server wrote a temp file on a remote/container filesystem | Retry with `large_result_mode: "inline"` or set `OMNISEARCH_LARGE_RESULT_MODE=inline`.                                           |
+| Symptom                                           | Likely cause                                                | Fix                                                                                                                                           |
+| ------------------------------------------------- | ----------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| Provider is unavailable                           | Missing API key                                             | Set the provider key and restart the MCP server. Check `omnisearch://providers/status`.                                                       |
+| Request fails with unauthorized/forbidden         | Invalid key or plan mismatch                                | Verify the key belongs to the provider and has access to the endpoint or plan tier.                                                           |
+| Query rejected before provider call               | Invalid input                                               | Check for empty queries, unsupported modes, malformed domains, or unsupported URL protocols.                                                  |
+| Repeated transient errors                         | Rate limits, timeout, network failure, or provider 5xx      | Retry later or lower request volume. Retryable failures are handled separately from invalid credentials and validation failures.              |
+| Returned file path cannot be read                 | Server wrote a temp file on a remote/container filesystem   | Retry with `large_result_mode: "inline"` or set `OMNISEARCH_LARGE_RESULT_MODE=inline`.                                                        |
+| Research mode returned some but not all providers | A later search or extract failed, timed out, or was skipped | This is expected. Inspect `research.failed`, `research.skipped`, and `research.timed_out`. Tighten `research_time_budget` or disable extract. |
 
 ## GitHub token setup
 

--- a/src/server/tools/contract.test.ts
+++ b/src/server/tools/contract.test.ts
@@ -152,6 +152,31 @@ describe('MCP tool contract', () => {
 			v.safeParse(schema, { query: 'test', provider: 'kagi' })
 				.success,
 		).toBe(false);
+		expect(
+			v.safeParse(schema, {
+				query: 'sveltekit docs',
+				provider: 'brave',
+				mode: 'research',
+				research_time_budget: 20,
+				research_extract: false,
+				research_extract_count: 2,
+			}).success,
+		).toBe(true);
+		expect(
+			v.safeParse(schema, {
+				query: 'sveltekit docs',
+				provider: 'brave',
+				mode: 'deep',
+			}).success,
+		).toBe(false);
+		expect(
+			v.safeParse(schema, {
+				query: 'sveltekit docs',
+				provider: 'brave',
+				mode: 'research',
+				research_time_budget: 80,
+			}).success,
+		).toBe(false);
 	});
 
 	it('validates public web_extract payloads and unavailable modes at the MCP layer', async () => {
@@ -261,6 +286,111 @@ describe('MCP tool contract', () => {
 			provider: 'brave',
 			retryable: false,
 		});
+	});
+
+	it('keeps default web_search single-provider and supports research mode', async () => {
+		const { tools } = await load_contract({
+			BRAVE_API_KEY: 'brave-key',
+			TAVILY_API_KEY: 'tavily-key',
+		});
+		const tool = tools.find(
+			(entry) => entry.definition.name === 'web_search',
+		)!;
+
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockImplementation(async (url: string) => {
+				const href = String(url);
+				if (href.includes('api.search.brave.com')) {
+					return new Response(
+						JSON.stringify({
+							web: {
+								results: [
+									{
+										title: 'Brave Result',
+										url: 'https://brave.example/a',
+										description: 'From brave',
+									},
+								],
+							},
+						}),
+						{ status: 200 },
+					);
+				}
+				if (href.includes('/search')) {
+					return new Response(
+						JSON.stringify({
+							results: [
+								{
+									title: 'Tavily Result',
+									url: 'https://tavily.example/b',
+									content: 'From tavily',
+									score: 0.9,
+								},
+							],
+						}),
+						{ status: 200 },
+					);
+				}
+				if (href.includes('/extract')) {
+					return new Response(
+						JSON.stringify({
+							results: [
+								{
+									url: 'https://brave.example/a',
+									raw_content: 'Extracted page',
+								},
+							],
+							failed_results: [],
+							response_time: 0.1,
+						}),
+						{ status: 200 },
+					);
+				}
+				return new Response('missing mock', { status: 404 });
+			}),
+		);
+
+		const single = parse_tool_body(
+			await tool.handler({
+				query: 'example',
+				provider: 'brave',
+				large_result_mode: 'inline',
+			}),
+		);
+		expect(single).toEqual([
+			{
+				title: 'Brave Result',
+				url: 'https://brave.example/a',
+				snippet: 'From brave',
+				source_provider: 'brave',
+			},
+		]);
+
+		const research = parse_tool_body(
+			await tool.handler({
+				query: 'example',
+				provider: 'brave',
+				mode: 'research',
+				research_extract: true,
+				research_extract_count: 1,
+				large_result_mode: 'inline',
+			}),
+		);
+
+		expect(research.mode).toBe('research');
+		expect(
+			research.results.map((item: { url: string }) => item.url),
+		).toEqual([
+			'https://brave.example/a',
+			'https://tavily.example/b',
+		]);
+		expect(research.research.selected).toEqual(['brave', 'tavily']);
+		expect(research.research.succeeded).toEqual(
+			expect.arrayContaining(['brave', 'tavily']),
+		);
+		expect(research.research.extract.status).toBe('succeeded');
+		expect(research.extracts.content).toContain('Extracted page');
 	});
 
 	it('covers large-result inline/file modes and compact extraction at the MCP layer', async () => {

--- a/src/server/tools/research-helpers.ts
+++ b/src/server/tools/research-helpers.ts
@@ -1,0 +1,212 @@
+import {
+	ErrorType,
+	ProviderError,
+	type BaseSearchParams,
+	type ProcessingResult,
+	type SearchResult,
+} from '../../common/types.js';
+
+export const DEFAULT_RESEARCH_TIME_BUDGET_SECONDS = 55;
+export const DEFAULT_RESEARCH_EXTRACT_COUNT = 3;
+export const MAX_RESEARCH_SEARCH_PROVIDERS = 4;
+export const RESEARCH_EARLY_STOP_CONTRIBUTORS = 2;
+export const RESEARCH_SEARCH_CAPABILITY = 'web_search';
+
+export const RESEARCH_EXTRACT_PREFERENCE = [
+	'tavily:extract',
+	'firecrawl:scrape',
+	'exa:contents',
+	'kagi:summarize',
+] as const;
+
+export interface ResearchSearchProvider {
+	id: string;
+	capabilities?: readonly string[];
+	search(params: BaseSearchParams): Promise<SearchResult[]>;
+}
+
+export interface ResearchExtractProvider {
+	id: string;
+	name: string;
+	modes?: readonly string[];
+	process_content(
+		url: string | string[],
+		extract_depth?: 'basic' | 'advanced',
+	): Promise<ProcessingResult>;
+}
+
+export interface ResearchClock {
+	now(): number;
+	timeout<T>(
+		promise: Promise<T>,
+		timeout_ms: number,
+		error: Error,
+	): Promise<T>;
+}
+
+export interface ResearchModeParams extends BaseSearchParams {
+	preferred_provider?: string;
+	time_budget_seconds?: number;
+	extract?: boolean;
+	extract_count?: number;
+	clock?: ResearchClock;
+}
+
+export interface ResearchProviderFailure {
+	provider: string;
+	error: string;
+}
+
+export interface ResearchSkippedProvider {
+	provider: string;
+	reason: 'early_stop' | 'time_budget_exhausted';
+}
+
+export interface ResearchExtractReport {
+	provider?: string;
+	status: 'succeeded' | 'failed' | 'skipped' | 'timed_out';
+	urls: string[];
+	error?: string;
+	reason?:
+		| 'disabled'
+		| 'no_extract_provider'
+		| 'no_urls'
+		| 'time_budget_exhausted';
+}
+
+export interface ResearchModeResult {
+	mode: 'research';
+	results: SearchResult[];
+	extracts?: ProcessingResult;
+	research: {
+		time_budget_seconds: number;
+		elapsed_ms: number;
+		selected: string[];
+		succeeded: string[];
+		failed: ResearchProviderFailure[];
+		skipped: ResearchSkippedProvider[];
+		timed_out: string[];
+		extract: ResearchExtractReport;
+	};
+}
+
+export type SearchOutcome =
+	| { id: string; status: 'ok'; results: SearchResult[] }
+	| { id: string; status: 'error'; error: unknown }
+	| { id: string; status: 'timeout'; error: unknown };
+
+const with_timeout = async <T>(
+	promise: Promise<T>,
+	timeout_ms: number,
+	error: Error,
+): Promise<T> => {
+	const guarded = promise.then(
+		(value) => ({ ok: true as const, value }),
+		(cause) => ({ ok: false as const, cause }),
+	);
+	if (timeout_ms <= 0) throw error;
+
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	try {
+		const winner = await Promise.race([
+			guarded,
+			new Promise<never>((_, reject) => {
+				timer = setTimeout(() => reject(error), timeout_ms);
+			}),
+		]);
+		if (winner.ok) return winner.value;
+		throw winner.cause;
+	} finally {
+		if (timer) clearTimeout(timer);
+	}
+};
+
+export const default_research_clock: ResearchClock = {
+	now: () => Date.now(),
+	timeout: (promise, timeout_ms, error) =>
+		with_timeout(promise, timeout_ms, error),
+};
+
+export const normalize_result_url = (url: string): string => {
+	try {
+		const parsed = new URL(url);
+		parsed.hash = '';
+		parsed.hostname = parsed.hostname
+			.replace(/^www\./i, '')
+			.toLowerCase();
+		let normalized = parsed.toString();
+		if (parsed.pathname !== '/' && normalized.endsWith('/')) {
+			normalized = normalized.slice(0, -1);
+		}
+		return normalized;
+	} catch {
+		return url.trim();
+	}
+};
+
+export const dedupe_search_results = (
+	results: SearchResult[],
+	limit = 10,
+): SearchResult[] => {
+	const seen = new Set<string>();
+	const deduped: SearchResult[] = [];
+
+	for (const result of results) {
+		const key = normalize_result_url(result.url);
+		if (!key || seen.has(key)) continue;
+		seen.add(key);
+		deduped.push(result);
+		if (deduped.length >= limit) break;
+	}
+
+	return deduped;
+};
+
+export const select_research_search_providers = (
+	entries: readonly ResearchSearchProvider[],
+	preferred?: string,
+): ResearchSearchProvider[] => {
+	const by_id = new Map(entries.map((entry) => [entry.id, entry]));
+	const eligible = entries.filter((entry) =>
+		(entry.capabilities ?? []).includes(RESEARCH_SEARCH_CAPABILITY),
+	);
+	const pool = eligible.length > 0 ? eligible : [...entries];
+	const selected: ResearchSearchProvider[] = [];
+
+	const preferred_entry = preferred
+		? by_id.get(preferred)
+		: undefined;
+	if (preferred_entry) selected.push(preferred_entry);
+
+	for (const entry of pool) {
+		if (selected.length >= MAX_RESEARCH_SEARCH_PROVIDERS) break;
+		if (selected.some((item) => item.id === entry.id)) continue;
+		selected.push(entry);
+	}
+
+	return selected;
+};
+
+export const select_research_extract_provider = <
+	T extends { id: string },
+>(
+	entries: readonly T[],
+): T | undefined => {
+	const by_id = new Map(entries.map((entry) => [entry.id, entry]));
+	for (const id of RESEARCH_EXTRACT_PREFERENCE) {
+		const match = by_id.get(id);
+		if (match) return match;
+	}
+	return undefined;
+};
+
+export const research_error_message = (error: unknown): string =>
+	error instanceof Error ? error.message : String(error);
+
+export const research_timeout_error = (provider: string) =>
+	new ProviderError(
+		ErrorType.TIMEOUT,
+		`${provider} timed out: research time budget exhausted`,
+		provider,
+		{ retryable: true },
+	);

--- a/src/server/tools/research-mode.test.ts
+++ b/src/server/tools/research-mode.test.ts
@@ -1,0 +1,345 @@
+import { describe, expect, it } from 'vitest';
+import {
+	ErrorType,
+	ProviderError,
+	type SearchResult,
+} from '../../common/types.js';
+import {
+	DEFAULT_RESEARCH_TIME_BUDGET_SECONDS,
+	dedupe_search_results,
+	normalize_result_url,
+	run_research_mode,
+	select_research_extract_provider,
+	select_research_search_providers,
+	type ResearchClock,
+	type ResearchExtractProvider,
+	type ResearchSearchProvider,
+} from './research-mode.js';
+
+const result = (
+	provider: string,
+	path: string,
+	title = provider,
+): SearchResult => ({
+	title,
+	url: `https://example.com/${path}`,
+	snippet: `${title} snippet`,
+	source_provider: provider,
+});
+
+const search_provider = (
+	id: string,
+	search: ResearchSearchProvider['search'],
+	capabilities: readonly string[] = ['web_search'],
+): ResearchSearchProvider => ({
+	id,
+	capabilities,
+	search,
+});
+
+const extract_provider = (
+	id: string,
+	process_content: ResearchExtractProvider['process_content'],
+): ResearchExtractProvider => ({
+	id,
+	name: id.split(':')[0] ?? id,
+	modes: [id.split(':')[1] ?? 'extract'],
+	process_content,
+});
+
+const immediate_clock = (): ResearchClock => ({
+	now: () => 0,
+	timeout: async (promise) => promise,
+});
+
+describe('research mode helpers', () => {
+	it('normalizes URLs for cross-provider dedupe', () => {
+		expect(
+			normalize_result_url('https://www.Example.com/docs/#top'),
+		).toBe('https://example.com/docs');
+		expect(normalize_result_url('not a url')).toBe('not a url');
+	});
+
+	it('keeps first-seen URLs and honors the result limit', () => {
+		expect(
+			dedupe_search_results(
+				[
+					result('brave', 'a'),
+					result('tavily', 'a'),
+					result('kagi', 'b'),
+					result('exa', 'c'),
+				],
+				2,
+			),
+		).toEqual([result('brave', 'a'), result('kagi', 'b')]);
+	});
+
+	it('prefers the requested provider and web_search-capable peers', () => {
+		const selected = select_research_search_providers(
+			[
+				search_provider('tavily', async () => []),
+				search_provider('brave', async () => []),
+				search_provider('kagi', async () => []),
+				search_provider('exa', async () => []),
+				search_provider('kagi_enrichment', async () => [], [
+					'specialized_indexes',
+				]),
+			],
+			'brave',
+		).map((provider) => provider.id);
+
+		expect(selected).toEqual(['brave', 'tavily', 'kagi', 'exa']);
+	});
+
+	it('includes a specialized preferred provider without filling from it', () => {
+		const selected = select_research_search_providers(
+			[
+				search_provider('brave', async () => []),
+				search_provider('kagi_enrichment', async () => [], [
+					'specialized_indexes',
+				]),
+			],
+			'kagi_enrichment',
+		).map((provider) => provider.id);
+
+		expect(selected).toEqual(['kagi_enrichment', 'brave']);
+	});
+
+	it('picks extract providers in documented preference order', () => {
+		expect(
+			select_research_extract_provider([
+				{ id: 'kagi:summarize' },
+				{ id: 'firecrawl:scrape' },
+				{ id: 'tavily:extract' },
+			])?.id,
+		).toBe('tavily:extract');
+		expect(
+			select_research_extract_provider([{ id: 'exa:similar' }]),
+		).toBeUndefined();
+	});
+});
+
+describe('run_research_mode', () => {
+	it('fans out to several providers and returns partial results', async () => {
+		const payload = await run_research_mode(
+			{
+				query: 'sveltekit',
+				preferred_provider: 'brave',
+				extract: false,
+				clock: immediate_clock(),
+			},
+			[
+				search_provider('brave', async () => [result('brave', 'a')]),
+				search_provider('tavily', async () => {
+					throw new Error('tavily down');
+				}),
+			],
+		);
+
+		expect(payload.mode).toBe('research');
+		expect(payload.results).toEqual([result('brave', 'a')]);
+		expect(payload.research.selected).toEqual(['brave', 'tavily']);
+		expect(payload.research.succeeded).toEqual(['brave']);
+		expect(payload.research.failed).toEqual([
+			{ provider: 'tavily', error: 'tavily down' },
+		]);
+		expect(payload.research.extract.status).toBe('skipped');
+		expect(payload.research.extract.reason).toBe('disabled');
+		expect(payload.research.time_budget_seconds).toBe(
+			DEFAULT_RESEARCH_TIME_BUDGET_SECONDS,
+		);
+	});
+
+	it('stops waiting after two diverse contributors and labels the rest', async () => {
+		let slow_started = false;
+		const payload = await run_research_mode(
+			{
+				query: 'docs',
+				preferred_provider: 'brave',
+				extract: false,
+				clock: immediate_clock(),
+			},
+			[
+				search_provider('brave', async () => [result('brave', 'a')]),
+				search_provider('tavily', async () => [
+					result('tavily', 'b'),
+				]),
+				search_provider('kagi', async () => {
+					slow_started = true;
+					return new Promise(() => {});
+				}),
+			],
+		);
+
+		expect(slow_started).toBe(true);
+		expect(payload.research.succeeded).toEqual(['brave', 'tavily']);
+		expect(payload.research.skipped).toEqual([
+			{ provider: 'kagi', reason: 'early_stop' },
+		]);
+	});
+
+	it('skips later launches and extract when the budget is already exhausted', async () => {
+		let now = 2_000;
+		const clock: ResearchClock = {
+			now: () => now,
+			timeout: async (promise) => promise,
+		};
+		const payload = await run_research_mode(
+			{
+				query: 'budget',
+				preferred_provider: 'brave',
+				time_budget_seconds: 1,
+				clock,
+				extract: true,
+			},
+			[
+				search_provider('brave', async () => {
+					now = 3_000;
+					return [result('brave', 'a')];
+				}),
+				search_provider('tavily', async () => {
+					throw new Error('should not launch');
+				}),
+			],
+			extract_provider('tavily:extract', async () => {
+				throw new Error('should not extract');
+			}),
+		);
+
+		expect(payload.results).toEqual([result('brave', 'a')]);
+		expect(payload.research.skipped).toEqual([
+			{ provider: 'tavily', reason: 'time_budget_exhausted' },
+		]);
+		expect(payload.research.extract).toEqual(
+			expect.objectContaining({
+				status: 'skipped',
+				reason: 'time_budget_exhausted',
+				provider: 'tavily:extract',
+			}),
+		);
+	});
+
+	it('extracts top URLs and keeps search results when extract fails', async () => {
+		const extracted = await run_research_mode(
+			{
+				query: 'extract',
+				preferred_provider: 'brave',
+				extract_count: 1,
+				clock: immediate_clock(),
+			},
+			[
+				search_provider('brave', async () => [
+					result('brave', 'a'),
+					result('brave', 'b'),
+				]),
+			],
+			extract_provider('tavily:extract', async (urls) => ({
+				content: `extracted ${Array.isArray(urls) ? urls.join(',') : urls}`,
+				source_provider: 'tavily_extract',
+				metadata: { urls_processed: 1 },
+			})),
+		);
+
+		expect(extracted.extracts?.content).toBe(
+			'extracted https://example.com/a',
+		);
+		expect(extracted.research.extract.status).toBe('succeeded');
+		expect(extracted.research.extract.urls).toEqual([
+			'https://example.com/a',
+		]);
+
+		const failed = await run_research_mode(
+			{
+				query: 'extract',
+				preferred_provider: 'brave',
+				clock: immediate_clock(),
+			},
+			[search_provider('brave', async () => [result('brave', 'a')])],
+			extract_provider('tavily:extract', async () => {
+				throw new Error('extract exploded');
+			}),
+		);
+
+		expect(failed.results).toEqual([result('brave', 'a')]);
+		expect(failed.extracts).toBeUndefined();
+		expect(failed.research.extract).toEqual(
+			expect.objectContaining({
+				status: 'failed',
+				error: 'extract exploded',
+			}),
+		);
+	});
+
+	it('labels extract timeouts and missing extract providers', async () => {
+		let timeout_calls = 0;
+		const timed_out = await run_research_mode(
+			{
+				query: 'timeout',
+				preferred_provider: 'brave',
+				clock: {
+					now: () => 0,
+					timeout: async (promise, _ms, error) => {
+						timeout_calls += 1;
+						if (timeout_calls === 1) return promise;
+						throw error;
+					},
+				},
+			},
+			[search_provider('brave', async () => [result('brave', 'a')])],
+			extract_provider(
+				'tavily:extract',
+				async () => new Promise(() => {}),
+			),
+		);
+
+		expect(timed_out.results).toEqual([result('brave', 'a')]);
+		expect(timed_out.research.extract.status).toBe('timed_out');
+
+		const missing = await run_research_mode(
+			{
+				query: 'no-extract',
+				preferred_provider: 'brave',
+				clock: immediate_clock(),
+			},
+			[search_provider('brave', async () => [result('brave', 'a')])],
+		);
+
+		expect(missing.research.extract.reason).toBe(
+			'no_extract_provider',
+		);
+	});
+
+	it('keeps an empty research payload when every search provider fails', async () => {
+		const payload = await run_research_mode(
+			{
+				query: 'none',
+				preferred_provider: 'brave',
+				clock: immediate_clock(),
+			},
+			[
+				search_provider('brave', async () => {
+					throw new ProviderError(
+						ErrorType.API_ERROR,
+						'nope',
+						'brave',
+					);
+				}),
+			],
+		);
+
+		expect(payload.results).toEqual([]);
+		expect(payload.research.failed).toEqual([
+			{ provider: 'brave', error: 'nope' },
+		]);
+		expect(payload.research.extract.reason).toBe('no_urls');
+	});
+
+	it('throws when no search providers can be selected', async () => {
+		await expect(
+			run_research_mode({ query: 'empty' }, []),
+		).rejects.toMatchObject({
+			type: ErrorType.INVALID_INPUT,
+			provider: 'web_search',
+		});
+	});
+});

--- a/src/server/tools/research-mode.ts
+++ b/src/server/tools/research-mode.ts
@@ -1,0 +1,261 @@
+import {
+	ErrorType,
+	ProviderError,
+	type BaseSearchParams,
+	type ProcessingResult,
+	type SearchResult,
+} from '../../common/types.js';
+import {
+	DEFAULT_RESEARCH_EXTRACT_COUNT,
+	DEFAULT_RESEARCH_TIME_BUDGET_SECONDS,
+	RESEARCH_EARLY_STOP_CONTRIBUTORS,
+	dedupe_search_results,
+	default_research_clock,
+	normalize_result_url,
+	research_error_message,
+	research_timeout_error,
+	select_research_search_providers,
+	type ResearchClock,
+	type ResearchExtractProvider,
+	type ResearchExtractReport,
+	type ResearchModeParams,
+	type ResearchModeResult,
+	type ResearchProviderFailure,
+	type ResearchSearchProvider,
+	type ResearchSkippedProvider,
+	type SearchOutcome,
+} from './research-helpers.js';
+
+export {
+	DEFAULT_RESEARCH_EXTRACT_COUNT,
+	DEFAULT_RESEARCH_TIME_BUDGET_SECONDS,
+	MAX_RESEARCH_SEARCH_PROVIDERS,
+	RESEARCH_EARLY_STOP_CONTRIBUTORS,
+	RESEARCH_EXTRACT_PREFERENCE,
+	RESEARCH_SEARCH_CAPABILITY,
+	dedupe_search_results,
+	normalize_result_url,
+	select_research_extract_provider,
+	select_research_search_providers,
+} from './research-helpers.js';
+export type {
+	ResearchClock,
+	ResearchExtractProvider,
+	ResearchModeParams,
+	ResearchModeResult,
+	ResearchSearchProvider,
+} from './research-helpers.js';
+
+export const run_research_mode = async (
+	params: ResearchModeParams,
+	search_providers: readonly ResearchSearchProvider[],
+	extract_provider?: ResearchExtractProvider,
+): Promise<ResearchModeResult> => {
+	const clock = params.clock ?? default_research_clock;
+	const time_budget_seconds =
+		params.time_budget_seconds ??
+		DEFAULT_RESEARCH_TIME_BUDGET_SECONDS;
+	const extract_enabled = params.extract !== false;
+	const extract_count =
+		params.extract_count ?? DEFAULT_RESEARCH_EXTRACT_COUNT;
+	const start = clock.now();
+	const budget_ms = time_budget_seconds * 1000;
+	const remaining = () => budget_ms - (clock.now() - start);
+
+	const selected = select_research_search_providers(
+		search_providers,
+		params.preferred_provider,
+	);
+	if (selected.length === 0) {
+		throw new ProviderError(
+			ErrorType.INVALID_INPUT,
+			'No eligible search providers are available for research mode',
+			'web_search',
+		);
+	}
+
+	const succeeded: string[] = [];
+	const failed: ResearchProviderFailure[] = [];
+	const skipped: ResearchSkippedProvider[] = [];
+	const timed_out: string[] = [];
+	const results_by_provider = new Map<string, SearchResult[]>();
+	const contributors = new Set<string>();
+	const seen_urls = new Set<string>();
+	const pending = new Map<string, Promise<SearchOutcome>>();
+
+	for (const provider of selected) {
+		const timeout_ms = remaining();
+		if (timeout_ms <= 0) {
+			skipped.push({
+				provider: provider.id,
+				reason: 'time_budget_exhausted',
+			});
+			continue;
+		}
+
+		const search_params: BaseSearchParams = {
+			query: params.query,
+			limit: params.limit,
+			include_domains: params.include_domains,
+			exclude_domains: params.exclude_domains,
+		};
+
+		pending.set(
+			provider.id,
+			clock
+				.timeout(
+					provider.search(search_params).then(
+						(results) =>
+							({
+								id: provider.id,
+								status: 'ok',
+								results,
+							}) satisfies SearchOutcome,
+						(error) =>
+							({
+								id: provider.id,
+								status: 'error',
+								error,
+							}) satisfies SearchOutcome,
+					),
+					timeout_ms,
+					research_timeout_error(provider.id),
+				)
+				.catch(
+					(error) =>
+						({
+							id: provider.id,
+							status: 'timeout',
+							error,
+						}) satisfies SearchOutcome,
+				),
+		);
+	}
+
+	while (pending.size > 0) {
+		if (contributors.size >= RESEARCH_EARLY_STOP_CONTRIBUTORS) {
+			for (const id of pending.keys()) {
+				skipped.push({ provider: id, reason: 'early_stop' });
+			}
+			break;
+		}
+
+		const outcome = await Promise.race(pending.values());
+		pending.delete(outcome.id);
+
+		if (outcome.status === 'timeout') {
+			timed_out.push(outcome.id);
+			continue;
+		}
+		if (outcome.status === 'error') {
+			failed.push({
+				provider: outcome.id,
+				error: research_error_message(outcome.error),
+			});
+			continue;
+		}
+
+		succeeded.push(outcome.id);
+		results_by_provider.set(outcome.id, outcome.results);
+		for (const result of outcome.results) {
+			const key = normalize_result_url(result.url);
+			if (!key || seen_urls.has(key)) continue;
+			seen_urls.add(key);
+			contributors.add(outcome.id);
+		}
+	}
+
+	const merged: SearchResult[] = [];
+	for (const provider of selected) {
+		const rows = results_by_provider.get(provider.id);
+		if (rows) merged.push(...rows);
+	}
+	const results = dedupe_search_results(merged, params.limit ?? 10);
+	const extract_urls = results
+		.map((result) => result.url)
+		.filter(Boolean)
+		.slice(0, extract_count);
+
+	const extract = await run_research_extract({
+		clock,
+		extract_enabled,
+		extract_provider,
+		remaining_ms: remaining(),
+		urls: extract_urls,
+	});
+
+	return {
+		mode: 'research',
+		results,
+		extracts:
+			extract.status === 'succeeded' ? extract.result : undefined,
+		research: {
+			time_budget_seconds,
+			elapsed_ms: Math.max(0, clock.now() - start),
+			selected: selected.map((provider) => provider.id),
+			succeeded,
+			failed,
+			skipped,
+			timed_out,
+			extract: {
+				provider: extract_provider?.id,
+				status: extract.status,
+				urls: extract_urls,
+				error: extract.error,
+				reason: extract.reason,
+			},
+		},
+	};
+};
+
+const run_research_extract = async ({
+	clock,
+	extract_enabled,
+	extract_provider,
+	remaining_ms,
+	urls,
+}: {
+	clock: ResearchClock;
+	extract_enabled: boolean;
+	extract_provider?: ResearchExtractProvider;
+	remaining_ms: number;
+	urls: string[];
+}): Promise<{
+	status: ResearchExtractReport['status'];
+	reason?: ResearchExtractReport['reason'];
+	error?: string;
+	result?: ProcessingResult;
+}> => {
+	if (!extract_enabled) {
+		return { status: 'skipped', reason: 'disabled' };
+	}
+	if (urls.length === 0) {
+		return { status: 'skipped', reason: 'no_urls' };
+	}
+	if (!extract_provider) {
+		return { status: 'skipped', reason: 'no_extract_provider' };
+	}
+	if (remaining_ms <= 0) {
+		return { status: 'skipped', reason: 'time_budget_exhausted' };
+	}
+
+	try {
+		const result = await clock.timeout(
+			extract_provider.process_content(urls),
+			remaining_ms,
+			research_timeout_error(extract_provider.id),
+		);
+		return { status: 'succeeded', result };
+	} catch (error) {
+		if (
+			error instanceof ProviderError &&
+			error.type === ErrorType.TIMEOUT
+		) {
+			return { status: 'timed_out', error: error.message };
+		}
+		return {
+			status: 'failed',
+			error: research_error_message(error),
+		};
+	}
+};

--- a/src/server/tools/schemas.test.ts
+++ b/src/server/tools/schemas.test.ts
@@ -7,6 +7,10 @@ import {
 	large_result_mode_schema,
 	limit_schema,
 	query_schema,
+	research_extract_count_schema,
+	research_extract_schema,
+	research_time_budget_schema,
+	search_mode_schema,
 	url_or_urls_schema,
 } from './schemas.js';
 
@@ -75,6 +79,51 @@ describe('tool schemas', () => {
 		expect(v.safeParse(http_url_schema, 'not a url').success).toBe(
 			false,
 		);
+	});
+
+	it('validates opt-in research mode controls', () => {
+		expect(v.safeParse(search_mode_schema, undefined).success).toBe(
+			true,
+		);
+		expect(v.safeParse(search_mode_schema, 'normal').success).toBe(
+			true,
+		);
+		expect(v.safeParse(search_mode_schema, 'research').success).toBe(
+			true,
+		);
+		expect(v.safeParse(search_mode_schema, 'deep').success).toBe(
+			false,
+		);
+		expect(
+			v.safeParse(research_time_budget_schema, undefined).success,
+		).toBe(true);
+		expect(v.safeParse(research_time_budget_schema, 55).success).toBe(
+			true,
+		);
+		expect(v.safeParse(research_time_budget_schema, 1).success).toBe(
+			true,
+		);
+		expect(v.safeParse(research_time_budget_schema, 75).success).toBe(
+			true,
+		);
+		expect(v.safeParse(research_time_budget_schema, 0).success).toBe(
+			false,
+		);
+		expect(v.safeParse(research_time_budget_schema, 76).success).toBe(
+			false,
+		);
+		expect(v.safeParse(research_extract_schema, false).success).toBe(
+			true,
+		);
+		expect(
+			v.safeParse(research_extract_count_schema, 3).success,
+		).toBe(true);
+		expect(
+			v.safeParse(research_extract_count_schema, 0).success,
+		).toBe(false);
+		expect(
+			v.safeParse(research_extract_count_schema, 11).success,
+		).toBe(false);
 	});
 
 	it('bounds extraction URL arrays', () => {

--- a/src/server/tools/schemas.ts
+++ b/src/server/tools/schemas.ts
@@ -76,3 +76,44 @@ export const url_or_urls_schema = v.pipe(
 	]),
 	v.description('URL or array of URLs to process'),
 );
+
+export const search_mode_schema = v.optional(
+	v.pipe(
+		v.picklist(['normal', 'research']),
+		v.description(
+			'Search mode. normal is single-provider (default). research fans out to several eligible search providers and may extract top URLs under a time budget.',
+		),
+	),
+);
+
+export const research_time_budget_schema = v.optional(
+	v.pipe(
+		v.number(),
+		v.minValue(1, 'Research time budget must be at least 1 second'),
+		v.maxValue(75, 'Research time budget must be at most 75 seconds'),
+		v.description(
+			'Best-effort wall-clock budget in seconds for research mode (default: 55)',
+		),
+	),
+);
+
+export const research_extract_schema = v.optional(
+	v.pipe(
+		v.boolean(),
+		v.description(
+			'In research mode, extract a bounded set of top URLs with an available web_extract provider (default: true)',
+		),
+	),
+);
+
+export const research_extract_count_schema = v.optional(
+	v.pipe(
+		v.number(),
+		v.integer('Extract count must be an integer'),
+		v.minValue(1, 'Extract count must be at least 1'),
+		v.maxValue(10, 'Extract count must be at most 10'),
+		v.description(
+			'Maximum number of top URLs to extract in research mode (default: 3)',
+		),
+	),
+);

--- a/src/server/tools/web-extract.ts
+++ b/src/server/tools/web-extract.ts
@@ -36,6 +36,17 @@ export const get_available_providers = () => providers.names();
 export const get_provider_status_entries = () =>
 	providers.status_entries();
 
+export const get_registered_extract_providers = () =>
+	providers.entries().map((entry) => ({
+		id: entry.id,
+		name: entry.name,
+		modes: entry.modes,
+		process_content: (
+			url: string | string[],
+			extract_depth?: 'basic' | 'advanced',
+		) => entry.instance.process_content(url, extract_depth),
+	}));
+
 const web_extract_modes = Array.from(
 	new Set(
 		web_extract_provider_definitions.map(

--- a/src/server/tools/web-search.ts
+++ b/src/server/tools/web-search.ts
@@ -7,6 +7,10 @@ import {
 	type WebSearchProviderName,
 } from '../provider-definitions.js';
 import { ProviderRegistry } from '../provider-registry.js';
+import {
+	run_research_mode,
+	select_research_extract_provider,
+} from './research-mode.js';
 import { handle_tool_result } from './responses.js';
 import {
 	exclude_domains_schema,
@@ -14,7 +18,12 @@ import {
 	large_result_mode_schema,
 	limit_schema,
 	query_schema,
+	research_extract_count_schema,
+	research_extract_schema,
+	research_time_budget_schema,
+	search_mode_schema,
 } from './schemas.js';
+import { get_registered_extract_providers } from './web-extract.js';
 
 const providers = new ProviderRegistry<SearchProvider>();
 
@@ -41,7 +50,7 @@ export const register_web_search = (
 		{
 			name: 'web_search',
 			description:
-				'Search the web for information. Use when you need to find web pages, articles, or data. Providers: tavily (factual/citations), brave (privacy/operators), kagi (quality/operators), exa (AI-semantic), kagi_enrichment (specialized indexes). Brave/Kagi support query operators like site:, filetype:, lang:, before:, after:.',
+				'Search the web for information. Use when you need to find web pages, articles, or data. Providers: tavily (factual/citations), brave (privacy/operators), kagi (quality/operators), exa (AI-semantic), kagi_enrichment (specialized indexes). Brave/Kagi support query operators like site:, filetype:, lang:, before:, after:. Optional mode=research fans out to several configured search providers and may extract top URLs under research_time_budget (default 55s). Default remains single-provider.',
 			annotations: {
 				readOnlyHint: true,
 				destructiveHint: false,
@@ -58,6 +67,10 @@ export const register_web_search = (
 				include_domains: include_domains_schema,
 				exclude_domains: exclude_domains_schema,
 				large_result_mode: large_result_mode_schema,
+				mode: search_mode_schema,
+				research_time_budget: research_time_budget_schema,
+				research_extract: research_extract_schema,
+				research_extract_count: research_extract_count_schema,
 			}),
 		},
 		async ({
@@ -67,10 +80,37 @@ export const register_web_search = (
 			include_domains,
 			exclude_domains,
 			large_result_mode,
+			mode,
+			research_time_budget,
+			research_extract,
+			research_extract_count,
 		}) =>
 			handle_tool_result(
 				'web_search',
 				async () => {
+					if (mode === 'research') {
+						return run_research_mode(
+							{
+								query,
+								limit,
+								include_domains,
+								exclude_domains,
+								preferred_provider: provider,
+								time_budget_seconds: research_time_budget,
+								extract: research_extract,
+								extract_count: research_extract_count,
+							},
+							providers.entries().map((entry) => ({
+								id: entry.id,
+								capabilities: entry.capabilities,
+								search: (params) => entry.instance.search(params),
+							})),
+							select_research_extract_provider(
+								get_registered_extract_providers(),
+							),
+						);
+					}
+
 					const selected = providers.require(provider, 'web_search');
 
 					return selected.search({


### PR DESCRIPTION
## Summary

Adds an explicit `mode=research` path on `web_search` so one call can fan out to several eligible configured search providers and optionally extract a bounded set of top URLs under a best-effort time budget. Default single-provider `web_search` is unchanged.

Fixes #192.

## Scope

- `web_search` schema: optional `mode`, `research_time_budget` (default 55s, 1–75), `research_extract` (default true), `research_extract_count` (default 3).
- Research orchestration in `src/server/tools/research-mode.ts` plus helpers: concurrent fan-out, URL dedupe, early-stop after two diverse contributors, partial results on provider/extract failure.
- Reuses existing `web_extract` providers (Tavily extract, Firecrawl scrape, Exa contents, Kagi summarize).
- Docs: `docs/research-mode.md`, README, provider selection, troubleshooting.

No new providers, keys, or default-path behavior.

## Verification

- `pnpm test` — 122 tests, including research-mode unit tests and an MCP contract test that default `web_search` still returns a result array while `mode=research` returns the research object with fan-out + extract.
- `pnpm run check` — format, lint, types, architecture advisories.
- `pnpm run build`

Example research call:

```json
{
  "query": "turntable reviews under 1000",
  "provider": "brave",
  "mode": "research",
  "research_time_budget": 45
}
```

## Impact

- Non-breaking. Omitting `mode` (or `mode: "normal"`) keeps the current single-provider array response.
- Research mode is more expensive (several search APIs plus one extract) and returns an object with `results`, optional `extracts`, and `research` diagnostics (`selected` / `succeeded` / `failed` / `skipped` / `timed_out`).
- Budget exhaustion and extract failures keep whatever search hits already arrived.