### PR TITLE
feat: HTTP bearer auth and per-token rate limits

### DIFF
--- a/.changeset/http-auth-ratelimit.md
+++ b/.changeset/http-auth-ratelimit.md
@@ -1,0 +1,5 @@
+---
+'mcp-omnisearch': patch
+---
+
+feat: add HTTP bearer auth and per-token rate limits

--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ Tavily, Kagi, Firecrawl, or Exa.
   behavior and remote deployment caveats.
 - [Deployment](docs/deployment.md) — MCP client, WSL, Docker, cloud,
   and Firecrawl setup.
+- [HTTP auth](docs/http-auth.md) — bearer tokens, fail-closed remote
+  binds, and per-token rate limits.
 - [Troubleshooting](docs/troubleshooting.md) — keys, access,
   validation, rate limits, and common failures.
 
@@ -117,6 +119,14 @@ Tavily, Kagi, Firecrawl, or Exa.
 - `FIRECRAWL_API_KEY`
 - `FIRECRAWL_BASE_URL` optional, for self-hosted Firecrawl
 - `OMNISEARCH_LARGE_RESULT_MODE` optional, `file` default or `inline`
+- `TRANSPORT` optional, `stdio` default or `http`
+- `HOST` optional HTTP bind, defaults to `127.0.0.1`
+- `PORT` optional HTTP port, defaults to `8080`
+- `HTTP_PATH` optional MCP path, defaults to `/mcp`
+- `AUTH_TOKENS` required for non-loopback HTTP binds
+- `RATE_LIMIT_REQUESTS` optional, defaults to `120` per token
+- `RATE_LIMIT_WINDOW_MINUTES` optional, defaults to `1`
+- `UNAUTH_RATE_LIMIT_REQUESTS` optional, defaults to `20`
 
 ## Development
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -89,6 +89,13 @@ Once deployed through the container, the MCP server is accessible at:
 - OpenAPI endpoint: `/omnisearch`
 - Compatible with OpenWebUI and other tools expecting OpenAPI
 
+## Native HTTP / Streamable HTTP
+
+Set `TRANSPORT=http` to serve MCP over HTTP instead of stdio. Remote
+or wildcard binds require `AUTH_TOKENS`. See [HTTP auth](http-auth.md)
+for bearer tokens, `/health`, and per-token sliding-window rate
+limits.
+
 For HTTP, hosted, or containerized deployments, prefer
 `OMNISEARCH_LARGE_RESULT_MODE=inline`. See
 [large results](large-results.md).

--- a/docs/http-auth.md
+++ b/docs/http-auth.md
@@ -1,0 +1,48 @@
+# HTTP bearer auth and rate limits
+
+stdio remains the default transport and does not use these settings.
+
+When `TRANSPORT=http`, Omnisearch serves Streamable HTTP MCP on
+`HTTP_PATH` (default `/mcp`) and a liveness endpoint at `/health`.
+
+## Fail closed
+
+Non-loopback binds (`0.0.0.0`, `::`, or any routable address) refuse
+to start unless `AUTH_TOKENS` contains at least one unique, nonblank
+bearer token. Loopback binds (`127.0.0.1`, `::1`, `localhost`) may
+start without tokens for local development.
+
+Tokens must be unique and nonblank. JSON array values may not include
+surrounding whitespace. Comma, semicolon, or newline lists trim
+delimiter padding.
+
+```bash
+TRANSPORT=http
+HOST=0.0.0.0
+PORT=8080
+AUTH_TOKENS=replace-me,another-token
+```
+
+Clients send `Authorization: Bearer <token>`.
+
+## Rate limits
+
+Authenticated MCP requests use a per-token sliding window. The default
+is 120 requests per token per 60 seconds (`RATE_LIMIT_REQUESTS=120`,
+`RATE_LIMIT_WINDOW_MINUTES=1`).
+
+Unauthenticated MCP traffic shares one tight bucket
+(`UNAUTH_RATE_LIMIT_REQUESTS=20` over the same window) and is rejected
+with 401 when tokens are configured. Exceeding a window returns 429
+with `Retry-After`.
+
+`GET` and `HEAD` `/health` stay outside auth and rate limits so
+orchestrators can probe the process.
+
+## Example
+
+```bash
+TRANSPORT=http HOST=127.0.0.1 PORT=8080 node ./dist/index.js
+curl -s http://127.0.0.1:8080/health
+# {"status":"ok"}
+```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -23,6 +23,9 @@ and configured providers remain available.
 | Request fails with unauthorized/forbidden | Invalid key or plan mismatch                              | Verify the key belongs to the provider and has access to the endpoint or plan tier.                                              |
 | Query rejected before provider call       | Invalid input                                             | Check for empty queries, unsupported modes, malformed domains, or unsupported URL protocols.                                     |
 | Repeated transient errors                 | Rate limits, timeout, network failure, or provider 5xx    | Retry later or lower request volume. Retryable failures are handled separately from invalid credentials and validation failures. |
+| HTTP process exits at startup             | Non-loopback bind without `AUTH_TOKENS`                   | Set unique `AUTH_TOKENS` or bind `127.0.0.1` / `::1`. See [HTTP auth](http-auth.md).                                             |
+| HTTP 401 on `/mcp`                        | Missing or invalid bearer token                           | Send `Authorization: Bearer <token>` from `AUTH_TOKENS`. `/health` does not require a token.                                     |
+| HTTP 429 on `/mcp`                        | Per-token or unauthenticated sliding window exceeded      | Wait for `Retry-After` or raise `RATE_LIMIT_REQUESTS` / `UNAUTH_RATE_LIMIT_REQUESTS`.                                            |
 | Returned file path cannot be read         | Server wrote a temp file on a remote/container filesystem | Retry with `large_result_mode: "inline"` or set `OMNISEARCH_LARGE_RESULT_MODE=inline`.                                           |
 
 ## GitHub token setup

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
 	},
 	"dependencies": {
 		"@tmcp/adapter-valibot": "^0.1.6",
+		"@tmcp/transport-http": "^0.8.6",
 		"@tmcp/transport-stdio": "^0.4.3",
 		"octokit": "^5.0.5",
 		"tmcp": "^1.19.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@tmcp/adapter-valibot':
         specifier: ^0.1.6
         version: 0.1.6(tmcp@1.19.4)(valibot@1.4.2)
+      '@tmcp/transport-http':
+        specifier: ^0.8.6
+        version: 0.8.6(tmcp@1.19.4)
       '@tmcp/transport-stdio':
         specifier: ^0.4.3
         version: 0.4.3(tmcp@1.19.4)
@@ -699,6 +702,20 @@ packages:
       tmcp: ^1.17.0
       valibot: ^1.1.0
 
+  '@tmcp/session-manager@0.2.2':
+    resolution: {integrity: sha512-UrCRpTsxh5XnMbplspvftEYboiZWgAiXqqAUbyFTHoHMJ0LoNDy8bQd0+7qtxtT4S5Qsnv650gvs/Nbec5NTCQ==}
+    peerDependencies:
+      tmcp: ^1.16.3
+
+  '@tmcp/transport-http@0.8.6':
+    resolution: {integrity: sha512-iLcxu+tEMbkVHbhFfyXQhxfPDDTfm+F0kEw8Xg/a1rm29s4cBg1vwcpbtk02XTxsdDh8RJ1AZkQwF9WDGeb/IA==}
+    peerDependencies:
+      '@tmcp/auth': ^0.3.3 || ^0.4.0
+      tmcp: ^1.18.0
+    peerDependenciesMeta:
+      '@tmcp/auth':
+        optional: true
+
   '@tmcp/transport-stdio@0.4.3':
     resolution: {integrity: sha512-chdmSwk7PSXjkaQId2OAY8ZMFrTFWwckfCyXJuw6b6WFK9IMK95EoU2VDFioybcmawuQox0MNPM5R2DVxlptoA==}
     peerDependencies:
@@ -1060,6 +1077,9 @@ packages:
 
   es-module-lexer@2.3.1:
     resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
+
+  esm-env@1.2.2:
+    resolution: {integrity: sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==}
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
@@ -2088,6 +2108,16 @@ snapshots:
       tmcp: 1.19.4
       valibot: 1.4.2
 
+  '@tmcp/session-manager@0.2.2(tmcp@1.19.4)':
+    dependencies:
+      tmcp: 1.19.4
+
+  '@tmcp/transport-http@0.8.6(tmcp@1.19.4)':
+    dependencies:
+      '@tmcp/session-manager': 0.2.2(tmcp@1.19.4)
+      esm-env: 1.2.2
+      tmcp: 1.19.4
+
   '@tmcp/transport-stdio@0.4.3(tmcp@1.19.4)':
     dependencies:
       tmcp: 1.19.4
@@ -2350,6 +2380,8 @@ snapshots:
   dom-accessibility-api@0.5.16: {}
 
   es-module-lexer@2.3.1: {}
+
+  esm-env@1.2.2: {}
 
   estree-walker@3.0.3:
     dependencies:

--- a/src/config/http.test.ts
+++ b/src/config/http.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from 'vitest';
+import {
+	assert_http_can_start,
+	is_loopback_host,
+	load_http_config,
+	parse_auth_tokens,
+} from './http.js';
+
+describe('parse_auth_tokens', () => {
+	it('returns an empty list when unset or blank', () => {
+		expect(parse_auth_tokens(undefined)).toEqual([]);
+		expect(parse_auth_tokens('')).toEqual([]);
+		expect(parse_auth_tokens('   ')).toEqual([]);
+		expect(parse_auth_tokens('[]')).toEqual([]);
+	});
+
+	it('parses a JSON array of unique nonblank tokens', () => {
+		expect(parse_auth_tokens('["alpha","beta"]')).toEqual([
+			'alpha',
+			'beta',
+		]);
+	});
+
+	it('parses comma, semicolon, and newline separated tokens', () => {
+		expect(parse_auth_tokens('alpha, beta')).toEqual([
+			'alpha',
+			'beta',
+		]);
+		expect(parse_auth_tokens('alpha;beta')).toEqual([
+			'alpha',
+			'beta',
+		]);
+		expect(parse_auth_tokens('alpha\nbeta')).toEqual([
+			'alpha',
+			'beta',
+		]);
+	});
+
+	it('rejects blank, padded, or duplicate JSON tokens', () => {
+		expect(() => parse_auth_tokens('["alpha",""]')).toThrow(
+			/nonblank/i,
+		);
+		expect(() => parse_auth_tokens('[" token"]')).toThrow(
+			/whitespace/i,
+		);
+		expect(() => parse_auth_tokens('["token "]')).toThrow(
+			/whitespace/i,
+		);
+		expect(() => parse_auth_tokens('["alpha","alpha"]')).toThrow(
+			/unique/i,
+		);
+	});
+});
+
+describe('is_loopback_host', () => {
+	it('treats loopback names and addresses as local', () => {
+		expect(is_loopback_host('127.0.0.1')).toBe(true);
+		expect(is_loopback_host('127.1.2.3')).toBe(true);
+		expect(is_loopback_host('localhost')).toBe(true);
+		expect(is_loopback_host('::1')).toBe(true);
+		expect(is_loopback_host('[::1]')).toBe(true);
+		expect(is_loopback_host('::ffff:127.0.0.1')).toBe(true);
+	});
+
+	it('treats wildcard and routable binds as non-loopback', () => {
+		expect(is_loopback_host('0.0.0.0')).toBe(false);
+		expect(is_loopback_host('::')).toBe(false);
+		expect(is_loopback_host('[::]')).toBe(false);
+		expect(is_loopback_host('192.168.1.10')).toBe(false);
+		expect(is_loopback_host('::ffff:10.0.0.1')).toBe(false);
+	});
+});
+
+describe('load_http_config', () => {
+	it('defaults to stdio with loopback HTTP settings unused', () => {
+		const config = load_http_config({});
+
+		expect(config.transport).toBe('stdio');
+		expect(config.host).toBe('127.0.0.1');
+		expect(config.port).toBe(8080);
+		expect(config.path).toBe('/mcp');
+		expect(config.auth_tokens).toEqual([]);
+		expect(config.rate_limit_requests).toBe(120);
+		expect(config.rate_limit_window_ms).toBe(60_000);
+		expect(config.unauth_rate_limit_requests).toBe(20);
+	});
+
+	it('reads HTTP bind, tokens, and rate-limit settings', () => {
+		const config = load_http_config({
+			TRANSPORT: 'http',
+			HOST: '0.0.0.0',
+			PORT: '9000',
+			HTTP_PATH: '/mcp',
+			AUTH_TOKENS: 'alpha,beta',
+			RATE_LIMIT_REQUESTS: '60',
+			RATE_LIMIT_WINDOW_MINUTES: '2',
+			UNAUTH_RATE_LIMIT_REQUESTS: '5',
+		});
+
+		expect(config).toMatchObject({
+			transport: 'http',
+			host: '0.0.0.0',
+			port: 9000,
+			path: '/mcp',
+			auth_tokens: ['alpha', 'beta'],
+			rate_limit_requests: 60,
+			rate_limit_window_ms: 120_000,
+			unauth_rate_limit_requests: 5,
+		});
+	});
+
+	it('rejects invalid numeric HTTP settings', () => {
+		expect(() => load_http_config({ PORT: '-1' })).toThrow(/port/i);
+		expect(() =>
+			load_http_config({ RATE_LIMIT_REQUESTS: '0' }),
+		).toThrow(/rate/i);
+		expect(() =>
+			load_http_config({ RATE_LIMIT_WINDOW_MINUTES: '-1' }),
+		).toThrow(/window/i);
+	});
+
+	it('allows ephemeral PORT=0 and reserves /health', () => {
+		expect(load_http_config({ PORT: '0' }).port).toBe(0);
+		expect(() => load_http_config({ HTTP_PATH: '/health' })).toThrow(
+			/health/,
+		);
+	});
+});
+
+describe('assert_http_can_start', () => {
+	it('refuses non-loopback HTTP without tokens', () => {
+		expect(() =>
+			assert_http_can_start(
+				load_http_config({
+					TRANSPORT: 'http',
+					HOST: '0.0.0.0',
+				}),
+			),
+		).toThrow(/AUTH_TOKENS/);
+	});
+
+	it('allows loopback HTTP without tokens and remote HTTP with tokens', () => {
+		expect(() =>
+			assert_http_can_start(
+				load_http_config({
+					TRANSPORT: 'http',
+					HOST: '127.0.0.1',
+				}),
+			),
+		).not.toThrow();
+
+		expect(() =>
+			assert_http_can_start(
+				load_http_config({
+					TRANSPORT: 'http',
+					HOST: '0.0.0.0',
+					AUTH_TOKENS: 'secret-token',
+				}),
+			),
+		).not.toThrow();
+	});
+
+	it('does not require tokens for stdio', () => {
+		expect(() =>
+			assert_http_can_start(
+				load_http_config({
+					HOST: '0.0.0.0',
+				}),
+			),
+		).not.toThrow();
+	});
+});

--- a/src/config/http.ts
+++ b/src/config/http.ts
@@ -1,0 +1,244 @@
+export type TransportMode = 'stdio' | 'http';
+
+export type HttpConfig = {
+	transport: TransportMode;
+	host: string;
+	port: number;
+	path: string;
+	auth_tokens: string[];
+	rate_limit_requests: number;
+	rate_limit_window_ms: number;
+	unauth_rate_limit_requests: number;
+};
+
+const DEFAULT_HOST = '127.0.0.1';
+const DEFAULT_PORT = 8080;
+const DEFAULT_PATH = '/mcp';
+const DEFAULT_RATE_LIMIT_REQUESTS = 120;
+const DEFAULT_RATE_LIMIT_WINDOW_MINUTES = 1;
+const DEFAULT_UNAUTH_RATE_LIMIT_REQUESTS = 20;
+
+const IPV4_MAPPED_PREFIX = '::ffff:';
+
+export const parse_auth_tokens = (
+	raw: string | undefined,
+): string[] => {
+	if (raw === undefined) return [];
+
+	const trimmed = raw.trim();
+	if (trimmed === '' || trimmed === '[]') return [];
+
+	if (trimmed.startsWith('[')) {
+		let parsed: unknown;
+		try {
+			parsed = JSON.parse(trimmed);
+		} catch {
+			throw new Error(
+				'AUTH_TOKENS must be a JSON array or a comma-separated list of unique, nonblank tokens.',
+			);
+		}
+
+		if (!Array.isArray(parsed)) {
+			throw new Error(
+				'AUTH_TOKENS JSON value must be an array of unique, nonblank tokens.',
+			);
+		}
+
+		return normalize_json_tokens(parsed);
+	}
+
+	return normalize_delimited_tokens(trimmed);
+};
+
+const normalize_json_tokens = (values: unknown[]): string[] => {
+	const tokens: string[] = [];
+	const seen = new Set<string>();
+
+	for (const value of values) {
+		if (typeof value !== 'string') {
+			throw new Error('AUTH_TOKENS must contain only string tokens.');
+		}
+
+		if (value.trim() === '') {
+			throw new Error(
+				'AUTH_TOKENS must contain unique, nonblank tokens.',
+			);
+		}
+
+		if (value !== value.trim()) {
+			throw new Error(
+				'AUTH_TOKENS must not include surrounding whitespace.',
+			);
+		}
+
+		if (seen.has(value)) {
+			throw new Error('AUTH_TOKENS must be unique.');
+		}
+
+		seen.add(value);
+		tokens.push(value);
+	}
+
+	return tokens;
+};
+
+const normalize_delimited_tokens = (raw: string): string[] => {
+	const tokens: string[] = [];
+	const seen = new Set<string>();
+
+	for (const part of raw.split(/[,;\n]/)) {
+		const token = part.trim();
+		if (token === '') continue;
+
+		if (seen.has(token)) {
+			throw new Error('AUTH_TOKENS must be unique.');
+		}
+
+		seen.add(token);
+		tokens.push(token);
+	}
+
+	return tokens;
+};
+
+export const is_loopback_host = (host: string): boolean => {
+	const normalized = unwrap_host(host).toLowerCase();
+
+	if (normalized === 'localhost' || normalized === '::1') {
+		return true;
+	}
+
+	if (normalized.startsWith(IPV4_MAPPED_PREFIX)) {
+		return is_loopback_ipv4(
+			normalized.slice(IPV4_MAPPED_PREFIX.length),
+		);
+	}
+
+	return is_loopback_ipv4(normalized);
+};
+
+const unwrap_host = (host: string): string => {
+	if (host.startsWith('[') && host.endsWith(']')) {
+		return host.slice(1, -1);
+	}
+	return host;
+};
+
+const is_loopback_ipv4 = (host: string): boolean => {
+	const parts = host.split('.');
+	if (parts.length !== 4) return false;
+
+	const octets = parts.map((part) => Number(part));
+	if (octets.some((octet) => !Number.isInteger(octet))) {
+		return false;
+	}
+
+	return (
+		octets[0] === 127 &&
+		octets.every((octet) => octet >= 0 && octet <= 255)
+	);
+};
+
+export const load_http_config = (
+	env: NodeJS.ProcessEnv = process.env,
+): HttpConfig => {
+	const transport = parse_transport(env.TRANSPORT);
+	const host = env.HOST?.trim() || DEFAULT_HOST;
+	const path = normalize_http_path(env.HTTP_PATH);
+
+	return {
+		transport,
+		host,
+		port: parse_port(env.PORT),
+		path,
+		auth_tokens: parse_auth_tokens(env.AUTH_TOKENS),
+		rate_limit_requests: parse_positive_int(
+			env.RATE_LIMIT_REQUESTS,
+			DEFAULT_RATE_LIMIT_REQUESTS,
+			'RATE_LIMIT_REQUESTS',
+		),
+		rate_limit_window_ms:
+			parse_positive_int(
+				env.RATE_LIMIT_WINDOW_MINUTES,
+				DEFAULT_RATE_LIMIT_WINDOW_MINUTES,
+				'RATE_LIMIT_WINDOW_MINUTES',
+			) * 60_000,
+		unauth_rate_limit_requests: parse_positive_int(
+			env.UNAUTH_RATE_LIMIT_REQUESTS,
+			DEFAULT_UNAUTH_RATE_LIMIT_REQUESTS,
+			'UNAUTH_RATE_LIMIT_REQUESTS',
+		),
+	};
+};
+
+const parse_transport = (raw: string | undefined): TransportMode => {
+	const value = raw?.trim().toLowerCase();
+	if (!value || value === 'stdio') return 'stdio';
+	if (value === 'http') return 'http';
+
+	throw new Error(
+		`TRANSPORT must be "stdio" or "http", received "${raw}".`,
+	);
+};
+
+const normalize_http_path = (raw: string | undefined): string => {
+	const value = raw?.trim() || DEFAULT_PATH;
+	if (!value.startsWith('/')) {
+		throw new Error('HTTP_PATH must be an absolute path.');
+	}
+	if (value.includes('?') || value.includes('#')) {
+		throw new Error(
+			'HTTP_PATH must be a literal path without query or fragment.',
+		);
+	}
+	if (value !== '/' && value.endsWith('/')) {
+		return value.slice(0, -1);
+	}
+	if (value === '/health') {
+		throw new Error(
+			'HTTP_PATH cannot be /health because that path is reserved.',
+		);
+	}
+	return value;
+};
+
+const parse_port = (raw: string | undefined): number => {
+	if (raw === undefined || raw.trim() === '') return DEFAULT_PORT;
+
+	const value = Number(raw);
+	if (!Number.isInteger(value) || value < 0 || value > 65535) {
+		throw new Error('PORT must be an integer between 0 and 65535.');
+	}
+	return value;
+};
+
+const parse_positive_int = (
+	raw: string | undefined,
+	fallback: number,
+	name: string,
+	options: { max?: number } = {},
+): number => {
+	if (raw === undefined || raw.trim() === '') return fallback;
+
+	const value = Number(raw);
+	if (!Number.isInteger(value) || value <= 0) {
+		throw new Error(`${name} must be a positive integer.`);
+	}
+	if (options.max !== undefined && value > options.max) {
+		throw new Error(`${name} must be between 1 and ${options.max}.`);
+	}
+	return value;
+};
+
+export const assert_http_can_start = (config: HttpConfig): void => {
+	if (config.transport !== 'http') return;
+
+	if (
+		!is_loopback_host(config.host) &&
+		config.auth_tokens.length === 0
+	) {
+		throw new Error(
+			`Refusing to start HTTP on non-loopback bind ${config.host}:${config.port} without AUTH_TOKENS. Set unique bearer tokens or bind a loopback address.`,
+		);
+	}
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,10 @@ import { StdioTransport } from '@tmcp/transport-stdio';
 import { McpServer } from 'tmcp';
 import type { GenericSchema } from 'valibot';
 import { validate_config } from './config/env.js';
+import {
+	assert_http_can_start,
+	load_http_config,
+} from './config/http.js';
 import { setup_handlers } from './server/handlers.js';
 import {
 	initialize_providers,
@@ -59,6 +63,15 @@ class OmnisearchServer {
 	}
 
 	async run() {
+		const http_config = load_http_config();
+		if (http_config.transport === 'http') {
+			assert_http_can_start(http_config);
+			const { start_http_server } =
+				await import('./server/http-listen.js');
+			await start_http_server(this.server, http_config);
+			return;
+		}
+
 		const transport = new StdioTransport(this.server);
 		transport.listen();
 		console.error('Omnisearch MCP server running on stdio');

--- a/src/server/http-auth.test.ts
+++ b/src/server/http-auth.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import {
+	extract_bearer_token,
+	match_auth_token,
+} from './http-auth.js';
+
+describe('extract_bearer_token', () => {
+	it('reads a Bearer token from Authorization', () => {
+		expect(extract_bearer_token('Bearer secret-token')).toBe(
+			'secret-token',
+		);
+		expect(extract_bearer_token('bearer secret-token')).toBe(
+			'secret-token',
+		);
+	});
+
+	it('returns undefined for missing or non-bearer credentials', () => {
+		expect(extract_bearer_token(undefined)).toBeUndefined();
+		expect(extract_bearer_token('Basic abc')).toBeUndefined();
+		expect(extract_bearer_token('Bearer')).toBeUndefined();
+		expect(extract_bearer_token('Bearer ')).toBeUndefined();
+	});
+});
+
+describe('match_auth_token', () => {
+	it('returns the configured token on a match', () => {
+		expect(match_auth_token('beta', ['alpha', 'beta'])).toBe('beta');
+	});
+
+	it('returns undefined when the presented token is unknown', () => {
+		expect(
+			match_auth_token('nope', ['alpha', 'beta']),
+		).toBeUndefined();
+		expect(match_auth_token('alpha', [])).toBeUndefined();
+	});
+});

--- a/src/server/http-auth.ts
+++ b/src/server/http-auth.ts
@@ -1,0 +1,33 @@
+import { createHash, timingSafeEqual } from 'node:crypto';
+
+const BEARER_PREFIX = /^bearer\s+(\S+)$/i;
+
+export const extract_bearer_token = (
+	authorization: string | undefined,
+): string | undefined => {
+	if (!authorization) return undefined;
+
+	const match = authorization.match(BEARER_PREFIX);
+	return match?.[1];
+};
+
+export const match_auth_token = (
+	presented: string,
+	tokens: readonly string[],
+): string | undefined => {
+	let matched: string | undefined;
+
+	for (const token of tokens) {
+		if (tokens_equal(presented, token)) {
+			matched = token;
+		}
+	}
+
+	return matched;
+};
+
+const tokens_equal = (left: string, right: string): boolean => {
+	const left_hash = createHash('sha256').update(left).digest();
+	const right_hash = createHash('sha256').update(right).digest();
+	return timingSafeEqual(left_hash, right_hash);
+};

--- a/src/server/http-listen.test.ts
+++ b/src/server/http-listen.test.ts
@@ -1,0 +1,49 @@
+import { ValibotJsonSchemaAdapter } from '@tmcp/adapter-valibot';
+import { McpServer } from 'tmcp';
+import type { GenericSchema } from 'valibot';
+import { describe, expect, it } from 'vitest';
+import { load_http_config } from '../config/http.js';
+import { start_http_server } from './http-listen.js';
+
+const create_server = () => {
+	const adapter = new ValibotJsonSchemaAdapter();
+	return new McpServer<GenericSchema>(
+		{
+			name: 'omnisearch-http-test',
+			version: '0.0.0',
+			description: 'HTTP auth test server',
+		},
+		{
+			adapter,
+			capabilities: {
+				tools: { listChanged: true },
+			},
+		},
+	);
+};
+
+describe('start_http_server', () => {
+	it('wraps the MCP HTTP transport and leaves /health open', async () => {
+		const handle = await start_http_server(
+			create_server(),
+			load_http_config({
+				TRANSPORT: 'http',
+				HOST: '127.0.0.1',
+				PORT: '0',
+				AUTH_TOKENS: 'secret-token',
+			}),
+		);
+
+		try {
+			const health = await fetch(
+				`http://127.0.0.1:${handle.port}/health`,
+			);
+			expect(health.status).toBe(200);
+			await expect(health.json()).resolves.toEqual({
+				status: 'ok',
+			});
+		} finally {
+			await handle.close();
+		}
+	});
+});

--- a/src/server/http-listen.ts
+++ b/src/server/http-listen.ts
@@ -1,0 +1,22 @@
+import { HttpTransport } from '@tmcp/transport-http';
+import type { McpServer } from 'tmcp';
+import type { GenericSchema } from 'valibot';
+import type { HttpConfig } from '../config/http.js';
+import {
+	start_http_listener,
+	type HttpServerHandle,
+} from './http-server.js';
+
+export const start_http_server = async (
+	mcp_server: McpServer<GenericSchema>,
+	config: HttpConfig,
+): Promise<HttpServerHandle> => {
+	const transport = new HttpTransport(mcp_server, {
+		path: config.path,
+	});
+	const handle = await start_http_listener(config, (request) =>
+		transport.respond(request),
+	);
+
+	return handle;
+};

--- a/src/server/http-rate-limit.test.ts
+++ b/src/server/http-rate-limit.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { create_sliding_window_limiter } from './http-rate-limit.js';
+
+describe('create_sliding_window_limiter', () => {
+	it('allows requests until the window is full', () => {
+		let now = 1_000;
+		const limiter = create_sliding_window_limiter({
+			max_requests: 2,
+			window_ms: 60_000,
+			now: () => now,
+		});
+
+		expect(limiter.consume('token-a').allowed).toBe(true);
+		const second = limiter.consume('token-a');
+		expect(second.allowed).toBe(true);
+		expect(second.remaining).toBe(0);
+
+		const blocked = limiter.consume('token-a');
+		expect(blocked.allowed).toBe(false);
+		expect(blocked.retry_after_seconds).toBeGreaterThan(0);
+	});
+
+	it('uses an independent sliding window per key', () => {
+		const limiter = create_sliding_window_limiter({
+			max_requests: 1,
+			window_ms: 60_000,
+			now: () => 1_000,
+		});
+
+		expect(limiter.consume('alpha').allowed).toBe(true);
+		expect(limiter.consume('beta').allowed).toBe(true);
+		expect(limiter.consume('alpha').allowed).toBe(false);
+	});
+
+	it('expires timestamps that fall outside the window', () => {
+		let now = 10_000;
+		const limiter = create_sliding_window_limiter({
+			max_requests: 1,
+			window_ms: 1_000,
+			now: () => now,
+		});
+
+		expect(limiter.consume('token-a').allowed).toBe(true);
+		now = 11_001;
+		expect(limiter.consume('token-a').allowed).toBe(true);
+	});
+});

--- a/src/server/http-rate-limit.ts
+++ b/src/server/http-rate-limit.ts
@@ -1,0 +1,53 @@
+export type RateLimitDecision = {
+	allowed: boolean;
+	remaining: number;
+	limit: number;
+	retry_after_seconds: number;
+};
+
+export type SlidingWindowLimiter = {
+	consume: (key: string) => RateLimitDecision;
+};
+
+export const create_sliding_window_limiter = (options: {
+	max_requests: number;
+	window_ms: number;
+	now?: () => number;
+}): SlidingWindowLimiter => {
+	const windows = new Map<string, number[]>();
+	const now = options.now ?? Date.now;
+
+	return {
+		consume(key: string): RateLimitDecision {
+			const current = now();
+			const cutoff = current - options.window_ms;
+			const stamps = (windows.get(key) ?? []).filter(
+				(stamp) => stamp > cutoff,
+			);
+
+			if (stamps.length >= options.max_requests) {
+				windows.set(key, stamps);
+				const retry_after_ms =
+					stamps[0] + options.window_ms - current;
+				return {
+					allowed: false,
+					remaining: 0,
+					limit: options.max_requests,
+					retry_after_seconds: Math.max(
+						1,
+						Math.ceil(retry_after_ms / 1000),
+					),
+				};
+			}
+
+			stamps.push(current);
+			windows.set(key, stamps);
+			return {
+				allowed: true,
+				remaining: options.max_requests - stamps.length,
+				limit: options.max_requests,
+				retry_after_seconds: 0,
+			};
+		},
+	};
+};

--- a/src/server/http-server.test.ts
+++ b/src/server/http-server.test.ts
@@ -1,0 +1,177 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { load_http_config } from '../config/http.js';
+import { create_sliding_window_limiter } from './http-rate-limit.js';
+import {
+	handle_http_request,
+	start_http_listener,
+} from './http-server.js';
+
+const mcp_ok = vi.fn(async () => new Response('ok', { status: 200 }));
+
+const request = (path: string, init: RequestInit = {}): Request =>
+	new Request(`http://127.0.0.1:8080${path}`, init);
+
+const handle = (
+	req: Request,
+	env: NodeJS.ProcessEnv,
+	respond_mcp = mcp_ok,
+	limiter = create_sliding_window_limiter({
+		max_requests: 120,
+		window_ms: 60_000,
+	}),
+) =>
+	handle_http_request(req, {
+		config: load_http_config(env),
+		limiter,
+		respond_mcp,
+	});
+
+describe('handle_http_request', () => {
+	afterEach(() => {
+		mcp_ok.mockClear();
+	});
+
+	it('keeps /health free of auth and rate limits', async () => {
+		const limiter = create_sliding_window_limiter({
+			max_requests: 1,
+			window_ms: 60_000,
+		});
+		const env = { AUTH_TOKENS: 'secret-token' };
+
+		const health = await handle(
+			request('/health'),
+			env,
+			mcp_ok,
+			limiter,
+		);
+		expect(health.status).toBe(200);
+		await expect(health.json()).resolves.toEqual({ status: 'ok' });
+
+		const again = await handle(
+			request('/health'),
+			env,
+			mcp_ok,
+			limiter,
+		);
+		expect(again.status).toBe(200);
+		expect(mcp_ok).not.toHaveBeenCalled();
+	});
+
+	it('rejects MCP traffic without a valid bearer token when tokens are configured', async () => {
+		const env = { AUTH_TOKENS: 'secret-token' };
+
+		const missing = await handle(
+			request('/mcp', { method: 'POST' }),
+			env,
+		);
+		expect(missing.status).toBe(401);
+		expect(missing.headers.get('WWW-Authenticate')).toMatch(
+			/Bearer/i,
+		);
+
+		const invalid = await handle(
+			request('/mcp', {
+				method: 'POST',
+				headers: { Authorization: 'Bearer wrong' },
+			}),
+			env,
+		);
+		expect(invalid.status).toBe(401);
+		expect(mcp_ok).not.toHaveBeenCalled();
+	});
+
+	it('forwards authenticated MCP requests and rate-limits per token', async () => {
+		const env = { AUTH_TOKENS: 'secret-token' };
+		const limiter = create_sliding_window_limiter({
+			max_requests: 1,
+			window_ms: 60_000,
+		});
+		const headers = { Authorization: 'Bearer secret-token' };
+
+		const allowed = await handle(
+			request('/mcp', { method: 'POST', headers }),
+			env,
+			mcp_ok,
+			limiter,
+		);
+		expect(allowed.status).toBe(200);
+		expect(mcp_ok).toHaveBeenCalledOnce();
+
+		const blocked = await handle(
+			request('/mcp', { method: 'POST', headers }),
+			env,
+			mcp_ok,
+			limiter,
+		);
+		expect(blocked.status).toBe(429);
+		expect(blocked.headers.get('Retry-After')).toBeTruthy();
+		expect(mcp_ok).toHaveBeenCalledOnce();
+	});
+
+	it('shares one tight unauthenticated bucket when tokens are not required', async () => {
+		const env = { TRANSPORT: 'http', HOST: '127.0.0.1' };
+		const tight = create_sliding_window_limiter({
+			max_requests: 1,
+			window_ms: 60_000,
+		});
+
+		const first = await handle(
+			request('/mcp', { method: 'POST' }),
+			env,
+			mcp_ok,
+			tight,
+		);
+		expect(first.status).toBe(200);
+
+		const second = await handle(
+			request('/mcp', { method: 'POST' }),
+			env,
+			mcp_ok,
+			tight,
+		);
+		expect(second.status).toBe(429);
+	});
+
+	it('listens on loopback and keeps /health unauthenticated', async () => {
+		const handle = await start_http_listener(
+			load_http_config({
+				TRANSPORT: 'http',
+				HOST: '127.0.0.1',
+				PORT: '0',
+				AUTH_TOKENS: 'secret-token',
+			}),
+			mcp_ok,
+		);
+
+		try {
+			const health = await fetch(
+				`http://127.0.0.1:${handle.port}/health`,
+			);
+			expect(health.status).toBe(200);
+			await expect(health.json()).resolves.toEqual({
+				status: 'ok',
+			});
+
+			const denied = await fetch(
+				`http://127.0.0.1:${handle.port}/mcp`,
+				{ method: 'POST' },
+			);
+			expect(denied.status).toBe(401);
+		} finally {
+			await handle.close();
+		}
+	});
+
+	it('refuses to listen on a non-loopback bind without tokens', async () => {
+		await expect(
+			start_http_listener(
+				load_http_config({
+					TRANSPORT: 'http',
+					HOST: '0.0.0.0',
+					PORT: '0',
+				}),
+				mcp_ok,
+			),
+		).rejects.toThrow(/AUTH_TOKENS/);
+	});
+});

--- a/src/server/http-server.ts
+++ b/src/server/http-server.ts
@@ -1,0 +1,262 @@
+import {
+	createServer,
+	type IncomingMessage,
+	type Server,
+} from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { Readable } from 'node:stream';
+import {
+	assert_http_can_start,
+	type HttpConfig,
+} from '../config/http.js';
+import {
+	extract_bearer_token,
+	match_auth_token,
+} from './http-auth.js';
+import {
+	create_sliding_window_limiter,
+	type RateLimitDecision,
+	type SlidingWindowLimiter,
+} from './http-rate-limit.js';
+
+const UNAUTHENTICATED_KEY = 'unauthenticated';
+const HEALTH_PATH = '/health';
+
+export type HttpRequestHandlers = {
+	config: HttpConfig;
+	limiter: SlidingWindowLimiter;
+	unauth_limiter?: SlidingWindowLimiter;
+	respond_mcp: (request: Request) => Promise<Response | null>;
+};
+
+export type HttpServerHandle = {
+	port: number;
+	close: () => Promise<void>;
+};
+
+export const handle_http_request = async (
+	request: Request,
+	handlers: HttpRequestHandlers,
+): Promise<Response> => {
+	const url = new URL(request.url);
+	if (is_health_path(url.pathname)) {
+		return health_response(request.method);
+	}
+
+	const authorization =
+		request.headers.get('authorization') ?? undefined;
+	const presented = extract_bearer_token(authorization);
+	const matched = presented
+		? match_auth_token(presented, handlers.config.auth_tokens)
+		: undefined;
+	const tokens_configured = handlers.config.auth_tokens.length > 0;
+
+	if (tokens_configured && !matched) {
+		const unauth = consume_unauth(handlers);
+		if (!unauth.allowed) {
+			return rate_limit_response(unauth);
+		}
+		return unauthorized_response();
+	}
+
+	const decision = matched
+		? handlers.limiter.consume(matched)
+		: consume_unauth(handlers);
+	if (!decision.allowed) {
+		return rate_limit_response(decision);
+	}
+
+	const mcp_response = await handlers.respond_mcp(request);
+	return mcp_response ?? new Response(null, { status: 404 });
+};
+
+const consume_unauth = (
+	handlers: HttpRequestHandlers,
+): RateLimitDecision => {
+	const limiter = handlers.unauth_limiter ?? handlers.limiter;
+	return limiter.consume(UNAUTHENTICATED_KEY);
+};
+
+const is_health_path = (pathname: string): boolean => {
+	if (pathname === HEALTH_PATH) return true;
+	return pathname === `${HEALTH_PATH}/`;
+};
+
+const health_response = (method: string): Response => {
+	if (method !== 'GET' && method !== 'HEAD') {
+		return new Response(null, {
+			status: 405,
+			headers: { Allow: 'GET, HEAD' },
+		});
+	}
+
+	return new Response(
+		method === 'HEAD' ? null : JSON.stringify({ status: 'ok' }),
+		{
+			status: 200,
+			headers: { 'Content-Type': 'application/json' },
+		},
+	);
+};
+
+const unauthorized_response = (): Response =>
+	new Response(JSON.stringify({ error: 'unauthorized' }), {
+		status: 401,
+		headers: {
+			'Content-Type': 'application/json',
+			'WWW-Authenticate': 'Bearer realm="mcp-omnisearch"',
+		},
+	});
+
+const rate_limit_response = (decision: RateLimitDecision): Response =>
+	new Response(JSON.stringify({ error: 'rate_limit_exceeded' }), {
+		status: 429,
+		headers: {
+			'Content-Type': 'application/json',
+			'Retry-After': String(decision.retry_after_seconds),
+			'RateLimit-Limit': String(decision.limit),
+			'RateLimit-Remaining': '0',
+			'RateLimit-Reset': String(decision.retry_after_seconds),
+		},
+	});
+
+export const start_http_listener = async (
+	config: HttpConfig,
+	respond_mcp: (request: Request) => Promise<Response | null>,
+	limiters?: {
+		limiter?: SlidingWindowLimiter;
+		unauth_limiter?: SlidingWindowLimiter;
+	},
+): Promise<HttpServerHandle> => {
+	assert_http_can_start(config);
+
+	const limiter =
+		limiters?.limiter ??
+		create_sliding_window_limiter({
+			max_requests: config.rate_limit_requests,
+			window_ms: config.rate_limit_window_ms,
+		});
+	const unauth_limiter =
+		limiters?.unauth_limiter ??
+		create_sliding_window_limiter({
+			max_requests: config.unauth_rate_limit_requests,
+			window_ms: config.rate_limit_window_ms,
+		});
+
+	const server = createServer((req, res) => {
+		void handle_node_request(req, res, {
+			config,
+			limiter,
+			unauth_limiter,
+			respond_mcp,
+		});
+	});
+
+	await listen(server, config.port, config.host);
+	const address = server.address() as AddressInfo;
+
+	console.error(
+		`Omnisearch MCP server running on http://${config.host}:${address.port}${config.path} (${config.auth_tokens.length} auth token(s), ${config.rate_limit_requests} req / ${config.rate_limit_window_ms / 1000}s per token)`,
+	);
+
+	return {
+		port: address.port,
+		close: () =>
+			new Promise((resolve, reject) => {
+				server.close((error) => {
+					if (error) reject(error);
+					else resolve();
+				});
+			}),
+	};
+};
+
+const handle_node_request = async (
+	req: IncomingMessage,
+	res: import('node:http').ServerResponse,
+	handlers: HttpRequestHandlers,
+): Promise<void> => {
+	try {
+		const request = await incoming_to_request(req);
+		const response = await handle_http_request(request, handlers);
+		await write_node_response(res, response);
+	} catch (error) {
+		console.error(
+			`HTTP request failed: ${
+				error instanceof Error ? error.message : 'unknown error'
+			}`,
+		);
+		if (!res.headersSent) {
+			res.statusCode = 500;
+			res.setHeader('Content-Type', 'application/json');
+			res.end(JSON.stringify({ error: 'internal_error' }));
+			return;
+		}
+		res.end();
+	}
+};
+
+const incoming_to_request = async (
+	req: IncomingMessage,
+): Promise<Request> => {
+	const host = req.headers.host ?? '127.0.0.1';
+	const url = `http://${host}${req.url ?? '/'}`;
+	const method = req.method ?? 'GET';
+	const headers = new Headers();
+
+	for (const [key, value] of Object.entries(req.headers)) {
+		if (value === undefined) continue;
+		if (Array.isArray(value)) {
+			for (const item of value) headers.append(key, item);
+		} else {
+			headers.set(key, value);
+		}
+	}
+
+	const can_have_body = method !== 'GET' && method !== 'HEAD';
+	return new Request(url, {
+		method,
+		headers,
+		body: can_have_body ? Readable.toWeb(req) : undefined,
+		duplex: 'half',
+	} as RequestInit);
+};
+
+const write_node_response = async (
+	res: import('node:http').ServerResponse,
+	response: Response,
+): Promise<void> => {
+	res.statusCode = response.status;
+	response.headers.forEach((value, key) => {
+		res.setHeader(key, value);
+	});
+
+	if (!response.body) {
+		res.end();
+		return;
+	}
+
+	const reader = response.body.getReader();
+	try {
+		while (true) {
+			const { done, value } = await reader.read();
+			if (done) break;
+			res.write(value);
+		}
+	} finally {
+		res.end();
+	}
+};
+
+const listen = (
+	server: Server,
+	port: number,
+	host: string,
+): Promise<void> =>
+	new Promise((resolve, reject) => {
+		server.once('error', reject);
+		server.listen(port, host, () => {
+			server.off('error', reject);
+			resolve();
+		});
+	});


### PR DESCRIPTION
## Summary

- Add optional `TRANSPORT=http` Streamable HTTP serving while leaving stdio as the unchanged default.
- Require unique, nonblank `AUTH_TOKENS` on non-loopback binds (fail closed); apply a per-token sliding window (default 120 req / minute).
- Keep `GET`/`HEAD` `/health` outside auth and rate limits. Unauthenticated MCP traffic shares one tight bucket and is rejected when tokens are configured.

Fixes #206

## Scope

- `src/config/http.ts` — transport/bind/token/rate-limit config
- `src/server/http-*.ts` — bearer auth, sliding window, HTTP listener
- `docs/http-auth.md` plus README/deployment/troubleshooting links
- `@tmcp/transport-http` for the MCP HTTP path

## Verification

- `pnpm run format`
- `pnpm run test` — 137 passed
- `pnpm run check`
- `pnpm run build`

Rebased/merged onto current `main` (tmcp 1.20 / MCP 2026-07-28 server factory).

## Impact

- stdio default is unchanged.
- Remote HTTP (`HOST=0.0.0.0` / `::`) will not start without `AUTH_TOKENS`.
- Loopback HTTP may start without tokens; unauthenticated MCP requests share `UNAUTH_RATE_LIMIT_REQUESTS` (default 20 / window).
- Rate-limit behavior is documented in `docs/http-auth.md`.