### PR TITLE
feat: RRF merge, URL/title dedupe, and per-result provenance

### DIFF
--- a/.changeset/rrf-merge-provenance.md
+++ b/.changeset/rrf-merge-provenance.md
@@ -1,0 +1,6 @@
+---
+'mcp-omnisearch': patch
+---
+
+feat: fuse multi-provider search results with RRF, URL/title dedupe,
+and provenance

--- a/README.md
+++ b/README.md
@@ -132,6 +132,9 @@ Tavily, Kagi, Firecrawl, or Exa.
   and Firecrawl setup.
 - [Troubleshooting](docs/troubleshooting.md) — keys, access,
   validation, rate limits, and common failures.
+- [Result fusion](docs/result-fusion.md) — RRF merge, URL/title
+  identity, and per-result provenance when multiple provider lists are
+  present.
 
 ## Environment variables
 
@@ -144,6 +147,8 @@ Tavily, Kagi, Firecrawl, or Exa.
 - `FIRECRAWL_API_KEY`
 - `FIRECRAWL_BASE_URL` optional, for self-hosted Firecrawl
 - `OMNISEARCH_LARGE_RESULT_MODE` optional, `file` default or `inline`
+- `OMNISEARCH_RRF_K` optional, reciprocal-rank fusion constant
+  (default `60`)
 
 ## Development
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -127,6 +127,7 @@ Container variables:
 - `LINKUP_API_KEY`
 - `FIRECRAWL_API_KEY`
 - `FIRECRAWL_BASE_URL`
+- `OMNISEARCH_RRF_K` optional, default `60`
 - `PORT`, defaults to `8000`
 
 ## OpenAPI access

--- a/docs/result-fusion.md
+++ b/docs/result-fusion.md
@@ -1,0 +1,54 @@
+# Result fusion
+
+When more than one provider result list is present, Omnisearch
+canonicalizes identity and fuses ranks with reciprocal rank fusion
+(RRF). A single provider list is returned unchanged.
+
+This is the merge step for optional multi-provider fan-out. Current
+`web_search` still takes one `provider` and therefore still returns a
+plain list.
+
+## Identity
+
+Hits collapse when they share a canonical URL, or a canonical title
+when the URL is empty.
+
+URL canonicalization:
+
+- lowercase scheme and host
+- drop default ports and fragments
+- drop a trailing slash
+- drop tracking query keys (`utm_*`, `fbclid`, `gclid`)
+- sort remaining query parameters
+
+## Reciprocal rank fusion
+
+Each provider list contributes `1 / (k + rank)` with **1-based**
+ranks. The fused score is the sum of those contributions.
+
+`k` defaults to **60**, the usual RRF constant. Override it with
+`OMNISEARCH_RRF_K` (positive integer). Invalid values fall back to 60.
+
+The fused list is capped by the existing `limit` argument.
+
+## Provenance
+
+Fused hits include `sources[]`:
+
+```json
+{
+	"title": "Example",
+	"url": "https://example.com/docs",
+	"snippet": "…",
+	"score": 0.0325,
+	"source_provider": "brave",
+	"sources": [
+		{ "provider": "brave", "rank": 2, "score": 0.2 },
+		{ "provider": "tavily", "rank": 1, "score": 0.8 }
+	]
+}
+```
+
+`score` on the fused hit is the RRF score. `sources[].score` is the
+optional original provider score. Single-provider responses do not add
+`sources`.

--- a/src/common/rrf-merge.test.ts
+++ b/src/common/rrf-merge.test.ts
@@ -1,0 +1,248 @@
+import { describe, expect, it } from 'vitest';
+import {
+	DEFAULT_RRF_K,
+	merge_search_result_lists,
+	result_identity_key,
+} from './rrf-merge.js';
+import type { SearchResult } from './types.js';
+
+const hit = (
+	overrides: Partial<SearchResult> &
+		Pick<SearchResult, 'source_provider'>,
+): SearchResult => ({
+	title: overrides.title ?? 'Example',
+	url: overrides.url ?? 'https://example.com/docs',
+	snippet: overrides.snippet ?? 'snippet',
+	source_provider: overrides.source_provider,
+	score: overrides.score,
+	metadata: overrides.metadata,
+});
+
+describe('result_identity_key', () => {
+	it('canonicalizes URL scheme, host, trailing slash, and tracking params', () => {
+		expect(
+			result_identity_key(
+				'HTTPS://Example.com/docs/?utm_source=beta&b=2&a=1',
+				'Ignored',
+			),
+		).toBe(
+			result_identity_key(
+				'https://example.com/docs?a=1&b=2',
+				'Other title',
+			),
+		);
+	});
+
+	it('drops default ports and fragments', () => {
+		expect(
+			result_identity_key(
+				'https://example.com:443/docs#section',
+				'Docs',
+			),
+		).toBe(result_identity_key('https://example.com/docs', 'Docs'));
+	});
+
+	it('falls back to a normalized title when URL is empty', () => {
+		expect(result_identity_key('', '  Title   Only  ')).toBe(
+			'title:title only',
+		);
+	});
+});
+
+describe('merge_search_result_lists', () => {
+	it('returns a single provider list unchanged without sources', () => {
+		const only = [
+			hit({
+				title: 'One',
+				url: 'https://example.com/one',
+				source_provider: 'brave',
+				score: 0.9,
+			}),
+		];
+
+		const merged = merge_search_result_lists([only], { limit: 1 });
+
+		expect(merged).toEqual(only);
+		expect(merged[0].sources).toBeUndefined();
+	});
+
+	it('ignores empty lists so a lone provider stays a plain list', () => {
+		const only = [
+			hit({
+				url: 'https://example.com/one',
+				source_provider: 'exa',
+			}),
+		];
+
+		expect(merge_search_result_lists([[], only, []])).toEqual(only);
+		expect(merge_search_result_lists([[], []])).toEqual([]);
+	});
+
+	it('fuses overlapping ranks with documented RRF k=60', () => {
+		expect(DEFAULT_RRF_K).toBe(60);
+
+		const tavily = [
+			hit({
+				title: 'Shared',
+				url: 'https://example.com/shared',
+				snippet: 'from tavily',
+				source_provider: 'tavily',
+				score: 0.8,
+			}),
+			hit({
+				title: 'Only Tavily',
+				url: 'https://example.com/tavily',
+				source_provider: 'tavily',
+				score: 0.4,
+			}),
+		];
+		const brave = [
+			hit({
+				title: 'Only Brave',
+				url: 'https://example.com/brave',
+				source_provider: 'brave',
+				score: 0.7,
+			}),
+			hit({
+				title: 'Shared again',
+				url: 'https://example.com/shared/',
+				snippet: '',
+				source_provider: 'brave',
+				score: 0.2,
+			}),
+		];
+
+		const fused = merge_search_result_lists([tavily, brave], {
+			k: 60,
+		});
+
+		expect(fused.map((result) => result.url)).toEqual([
+			'https://example.com/shared/',
+			'https://example.com/brave',
+			'https://example.com/tavily',
+		]);
+
+		// shared: 1/(60+1) + 1/(60+2)
+		// brave-only: 1/(60+1)
+		// tavily-only: 1/(60+2)
+		expect(fused[0].score).toBeCloseTo(1 / 61 + 1 / 62);
+		expect(fused[1].score).toBeCloseTo(1 / 61);
+		expect(fused[2].score).toBeCloseTo(1 / 62);
+		expect(fused[0].snippet).toBe('from tavily');
+		expect(fused[0].source_provider).toBe('brave');
+		expect(fused[0].sources).toEqual([
+			{ provider: 'brave', rank: 2, score: 0.2 },
+			{ provider: 'tavily', rank: 1, score: 0.8 },
+		]);
+	});
+
+	it('collapses duplicate URLs including tracking-query variants', () => {
+		const fused = merge_search_result_lists([
+			[
+				hit({
+					title: 'Same',
+					url: 'HTTPS://Example.com/docs/?utm_source=beta',
+					source_provider: 'beta',
+					score: 0.7,
+				}),
+			],
+			[
+				hit({
+					title: 'Same page',
+					url: 'https://example.com/docs',
+					snippet: 'preferred deterministic content',
+					source_provider: 'alpha',
+					score: 0.8,
+				}),
+				hit({
+					title: 'Duplicate from alpha',
+					url: 'https://example.com/docs/',
+					source_provider: 'alpha',
+					score: 0.1,
+				}),
+				hit({
+					title: 'Title only',
+					url: '',
+					source_provider: 'alpha',
+				}),
+			],
+		]);
+
+		expect(fused).toHaveLength(2);
+		expect(fused[0].snippet).toBe('preferred deterministic content');
+		expect(
+			fused[0].sources?.map((source) => source.provider),
+		).toEqual(['alpha', 'beta']);
+		expect(fused[0].score).toBeCloseTo(2 / 61);
+		expect(fused[1].title).toBe('Title only');
+	});
+
+	it('dedupes title-only hits after whitespace and case folding', () => {
+		const fused = merge_search_result_lists([
+			[
+				hit({
+					title: 'Title   Only',
+					url: '',
+					snippet: '',
+					source_provider: 'exa',
+				}),
+			],
+			[
+				hit({
+					title: 'title only',
+					url: '   ',
+					snippet: 'second',
+					source_provider: 'kagi',
+				}),
+			],
+		]);
+
+		expect(fused).toHaveLength(1);
+		expect(fused[0].sources).toHaveLength(2);
+		expect(fused[0].snippet).toBe('second');
+	});
+
+	it('caps the fused list with limit', () => {
+		const fused = merge_search_result_lists(
+			[
+				[
+					hit({
+						url: 'https://example.com/a',
+						source_provider: 'exa',
+					}),
+				],
+				[
+					hit({
+						url: 'https://example.com/b',
+						source_provider: 'brave',
+					}),
+				],
+			],
+			{ limit: 1 },
+		);
+
+		expect(fused).toHaveLength(1);
+	});
+
+	it('uses an explicit k in the RRF denominator', () => {
+		const fused = merge_search_result_lists(
+			[
+				[
+					hit({
+						url: 'https://example.com/a',
+						source_provider: 'exa',
+					}),
+				],
+				[
+					hit({
+						url: 'https://example.com/a',
+						source_provider: 'brave',
+					}),
+				],
+			],
+			{ k: 1 },
+		);
+
+		expect(fused[0].score).toBeCloseTo(1 / 2 + 1 / 2);
+	});
+});

--- a/src/common/rrf-merge.ts
+++ b/src/common/rrf-merge.ts
@@ -1,0 +1,183 @@
+import { DEFAULT_RRF_K, get_rrf_k } from '../config/env.js';
+import type { SearchResult, SearchResultSource } from './types.js';
+
+const TRACKING_QUERY_KEYS = new Set(['fbclid', 'gclid']);
+const TRACKING_QUERY_PREFIXES = ['utm_'];
+
+export interface MergeSearchResultOptions {
+	k?: number;
+	limit?: number;
+}
+
+const is_tracking_query_key = (key: string) => {
+	const normalized = key.toLowerCase();
+	return (
+		TRACKING_QUERY_KEYS.has(normalized) ||
+		TRACKING_QUERY_PREFIXES.some((prefix) =>
+			normalized.startsWith(prefix),
+		)
+	);
+};
+
+const canonicalize_url = (url: string): string | undefined => {
+	const trimmed = url.trim();
+	if (!trimmed) return undefined;
+
+	try {
+		const parsed = new URL(trimmed);
+		const hostname = parsed.hostname.toLowerCase();
+		if (!hostname) {
+			return `url:${trimmed.toLowerCase()}`;
+		}
+
+		const params = [...parsed.searchParams.entries()]
+			.filter(([key]) => !is_tracking_query_key(key))
+			.sort(
+				([left_key, left_value], [right_key, right_value]) =>
+					left_key.localeCompare(right_key) ||
+					left_value.localeCompare(right_value),
+			);
+
+		const path = parsed.pathname.replace(/\/+$/, '') || '/';
+		const search = params.length
+			? `?${new URLSearchParams(params).toString()}`
+			: '';
+
+		return `url:${parsed.protocol}//${parsed.host.toLowerCase()}${path}${search}`;
+	} catch {
+		return `url:${trimmed.toLowerCase()}`;
+	}
+};
+
+const canonicalize_title = (title: string): string | undefined => {
+	const normalized = title.replace(/\s+/g, ' ').trim().toLowerCase();
+	return normalized ? `title:${normalized}` : undefined;
+};
+
+export const result_identity_key = (
+	url: string,
+	title: string,
+): string => canonicalize_url(url) ?? canonicalize_title(title) ?? '';
+
+const resolve_rrf_k = (k?: number): number => {
+	if (k !== undefined && Number.isInteger(k) && k >= 1) {
+		return k;
+	}
+
+	return get_rrf_k();
+};
+
+const to_source = (
+	result: SearchResult,
+	rank: number,
+): SearchResultSource => {
+	const source: SearchResultSource = {
+		provider: result.source_provider,
+		rank,
+	};
+
+	if (result.score !== undefined) {
+		source.score = result.score;
+	}
+
+	return source;
+};
+
+const fuse_result_lists = (
+	lists: readonly SearchResult[][],
+	k: number,
+	limit?: number,
+): SearchResult[] => {
+	const fused = new Map<
+		string,
+		SearchResult & { score: number; sources: SearchResultSource[] }
+	>();
+
+	const named_lists = lists
+		.filter((list) => list.length > 0)
+		.map((results) => ({
+			provider: results[0].source_provider,
+			results,
+		}))
+		.sort((left, right) =>
+			left.provider.localeCompare(right.provider),
+		);
+
+	for (const { results } of named_lists) {
+		const seen_keys = new Set<string>();
+
+		for (const [index, result] of results.entries()) {
+			const key = result_identity_key(result.url, result.title);
+			if (!key || seen_keys.has(key)) continue;
+			seen_keys.add(key);
+
+			const rank = index + 1;
+			const contribution = 1 / (k + rank);
+			const source = to_source(result, rank);
+			const existing = fused.get(key);
+
+			if (!existing) {
+				fused.set(key, {
+					title: result.title,
+					url: result.url,
+					snippet: result.snippet,
+					score: contribution,
+					source_provider: result.source_provider,
+					sources: [source],
+					metadata: result.metadata,
+				});
+				continue;
+			}
+
+			existing.score += contribution;
+			existing.sources.push(source);
+			existing.title = existing.title || result.title;
+			existing.url = existing.url || result.url;
+			existing.snippet = existing.snippet || result.snippet;
+			existing.metadata = existing.metadata ?? result.metadata;
+		}
+	}
+
+	for (const result of fused.values()) {
+		result.sources.sort(
+			(left, right) =>
+				left.provider.localeCompare(right.provider) ||
+				left.rank - right.rank,
+		);
+	}
+
+	const ranked = [...fused.values()].sort((left, right) => {
+		if (right.score !== left.score) return right.score - left.score;
+
+		const left_key = result_identity_key(left.url, left.title);
+		const right_key = result_identity_key(right.url, right.title);
+		return (
+			left_key.localeCompare(right_key) ||
+			left.title
+				.toLowerCase()
+				.localeCompare(right.title.toLowerCase())
+		);
+	});
+
+	return limit === undefined ? ranked : ranked.slice(0, limit);
+};
+
+// Single-provider calls stay a plain list. Multi-provider lists are
+// fused with RRF: sum(1 / (k + rank)), default k = 60.
+export const merge_search_result_lists = (
+	lists: readonly SearchResult[][],
+	options: MergeSearchResultOptions = {},
+): SearchResult[] => {
+	const non_empty = lists.filter((list) => list.length > 0);
+	if (non_empty.length <= 1) {
+		return non_empty[0] ? [...non_empty[0]] : [];
+	}
+
+	return fuse_result_lists(
+		non_empty,
+		resolve_rrf_k(options.k),
+		options.limit,
+	);
+};
+
+export { DEFAULT_RRF_K };

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -2,12 +2,19 @@
 
 export type ProviderMetadata = Record<string, unknown>;
 
+export interface SearchResultSource {
+	provider: string;
+	rank: number;
+	score?: number;
+}
+
 export interface SearchResult {
 	title: string;
 	url: string;
 	snippet: string;
 	score?: number;
 	source_provider: string;
+	sources?: SearchResultSource[];
 	metadata?: ProviderMetadata;
 }
 

--- a/src/config/env.test.ts
+++ b/src/config/env.test.ts
@@ -1,8 +1,29 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
+	DEFAULT_RRF_K,
+	get_rrf_k,
 	should_warn_for_local_file_offload,
 	warn_for_local_file_offload,
 } from './env.js';
+
+describe('get_rrf_k', () => {
+	it('defaults to the documented RRF constant of 60', () => {
+		expect(DEFAULT_RRF_K).toBe(60);
+		expect(get_rrf_k({})).toBe(60);
+		expect(get_rrf_k({ OMNISEARCH_RRF_K: '   ' })).toBe(60);
+	});
+
+	it('reads a positive integer from OMNISEARCH_RRF_K', () => {
+		expect(get_rrf_k({ OMNISEARCH_RRF_K: '40' })).toBe(40);
+	});
+
+	it('falls back to 60 for invalid OMNISEARCH_RRF_K values', () => {
+		expect(get_rrf_k({ OMNISEARCH_RRF_K: '0' })).toBe(60);
+		expect(get_rrf_k({ OMNISEARCH_RRF_K: '-1' })).toBe(60);
+		expect(get_rrf_k({ OMNISEARCH_RRF_K: '60.5' })).toBe(60);
+		expect(get_rrf_k({ OMNISEARCH_RRF_K: 'abc' })).toBe(60);
+	});
+});
 
 describe('large-result local file offload warnings', () => {
 	it('warns when file mode is configured in likely remote deployments', () => {

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -134,6 +134,24 @@ const remote_deployment_markers = [
 	'VERCEL',
 ];
 
+// Reciprocal rank fusion constant. Standard RRF uses
+// sum(1 / (k + rank)) with 1-based ranks. Hub default is 60.
+export const DEFAULT_RRF_K = 60;
+
+export const get_rrf_k = (
+	env: NodeJS.ProcessEnv = process.env,
+): number => {
+	const raw = env.OMNISEARCH_RRF_K?.trim();
+	if (!raw) return DEFAULT_RRF_K;
+
+	const parsed = Number(raw);
+	if (!Number.isInteger(parsed) || parsed < 1) {
+		return DEFAULT_RRF_K;
+	}
+
+	return parsed;
+};
+
 export const should_warn_for_local_file_offload = (
 	env: NodeJS.ProcessEnv = process.env,
 ) =>

--- a/src/server/tools/contract.test.ts
+++ b/src/server/tools/contract.test.ts
@@ -82,7 +82,7 @@ afterEach(() => {
 	vi.restoreAllMocks();
 });
 
-describe('MCP tool contract', () => {
+describe('MCP tool contract', { timeout: 15_000 }, () => {
 	it('registers no public tools when no providers are configured', async () => {
 		const { tools, tools_module } = await load_contract({});
 

--- a/src/server/tools/web-search.test.ts
+++ b/src/server/tools/web-search.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import type { SearchResult } from '../../common/types.js';
+import { merge_web_search_results } from './web-search.js';
+
+const hit = (
+	overrides: Partial<SearchResult> &
+		Pick<SearchResult, 'source_provider' | 'url'>,
+): SearchResult => ({
+	title: overrides.title ?? overrides.url,
+	url: overrides.url,
+	snippet: overrides.snippet ?? '',
+	source_provider: overrides.source_provider,
+	score: overrides.score,
+});
+
+afterEach(() => {
+	delete process.env.OMNISEARCH_RRF_K;
+});
+
+describe('merge_web_search_results', () => {
+	it('keeps a single provider response as a plain list', () => {
+		const results = [
+			hit({
+				url: 'https://example.com/a',
+				source_provider: 'brave',
+				score: 0.5,
+			}),
+		];
+
+		expect(merge_web_search_results([results], { limit: 5 })).toEqual(
+			results,
+		);
+	});
+
+	it('fuses multiple provider lists with provenance and limit', () => {
+		const fused = merge_web_search_results(
+			[
+				[
+					hit({
+						url: 'https://example.com/shared',
+						source_provider: 'tavily',
+						score: 0.9,
+					}),
+				],
+				[
+					hit({
+						url: 'https://example.com/shared',
+						source_provider: 'exa',
+						score: 0.4,
+					}),
+					hit({
+						url: 'https://example.com/other',
+						source_provider: 'exa',
+					}),
+				],
+			],
+			{ limit: 1 },
+		);
+
+		expect(fused).toHaveLength(1);
+		expect(fused[0].sources).toEqual([
+			{ provider: 'exa', rank: 1, score: 0.4 },
+			{ provider: 'tavily', rank: 1, score: 0.9 },
+		]);
+	});
+
+	it('honors OMNISEARCH_RRF_K when fusing lists', () => {
+		process.env.OMNISEARCH_RRF_K = '1';
+
+		const fused = merge_web_search_results([
+			[
+				hit({
+					url: 'https://example.com/a',
+					source_provider: 'brave',
+				}),
+			],
+			[
+				hit({
+					url: 'https://example.com/a',
+					source_provider: 'exa',
+				}),
+			],
+		]);
+
+		expect(fused[0].score).toBeCloseTo(1);
+	});
+});

--- a/src/server/tools/web-search.ts
+++ b/src/server/tools/web-search.ts
@@ -1,7 +1,12 @@
 import { McpServer } from 'tmcp';
 import type { GenericSchema } from 'valibot';
 import * as v from 'valibot';
-import { SearchProvider } from '../../common/types.js';
+import { merge_search_result_lists } from '../../common/rrf-merge.js';
+import {
+	SearchProvider,
+	type SearchResult,
+} from '../../common/types.js';
+import { get_rrf_k } from '../../config/env.js';
 import {
 	web_search_provider_definitions,
 	type WebSearchProviderName,
@@ -29,6 +34,18 @@ export const get_available_providers = () => providers.names();
 
 export const get_provider_status_entries = () =>
 	providers.status_entries();
+
+// Thin hook for current single-list calls and future fan-out
+// (#188). One list stays a plain SearchResult[]; several lists
+// are fused with RRF, URL/title identity, and sources[].
+export const merge_web_search_results = (
+	lists: readonly SearchResult[][],
+	options: { limit?: number } = {},
+) =>
+	merge_search_result_lists(lists, {
+		k: get_rrf_k(),
+		limit: options.limit,
+	});
 
 export const register_web_search = (
 	server: McpServer<GenericSchema>,
@@ -73,12 +90,17 @@ export const register_web_search = (
 				async () => {
 					const selected = providers.require(provider, 'web_search');
 
-					return selected.search({
-						query,
-						limit,
-						include_domains,
-						exclude_domains,
-					});
+					return merge_web_search_results(
+						[
+							await selected.search({
+								query,
+								limit,
+								include_domains,
+								exclude_domains,
+							}),
+						],
+						{ limit },
+					);
 				},
 				{ large_result_mode },
 			),


### PR DESCRIPTION
## Summary

- When more than one provider result list is present, canonicalize identity on URL (and title when URL is empty), fuse ranks with reciprocal rank fusion (`sum(1 / (k + rank))`, documented `k`, default **60**), and attach `sources[]` (`provider`, original `rank`, optional original `score`).
- Single-provider `web_search` stays a plain list with no `sources` noise. Fan-out (#188) is not on main, so this PR adds a pure merge module plus a thin `merge_web_search_results` hook instead of a full multi-provider product.
- `OMNISEARCH_RRF_K` overrides `k`. Invalid values fall back to 60. The fused list is capped by the existing `limit`.

Fixes #189.

## Scope

- `src/common/rrf-merge.ts` — identity + RRF + provenance
- `src/server/tools/web-search.ts` — thin hook around current single-list calls
- `src/common/types.ts` — optional `sources[]`
- `src/config/env.ts` — `OMNISEARCH_RRF_K` / `DEFAULT_RRF_K`
- Docs: `docs/result-fusion.md`, README, deployment env list
- Tests for RRF math, URL/title dedupe, single-list passthrough, and the web_search hook

## Verification

```bash
pnpm test
pnpm run check
pnpm run build
```

Local result: 124 tests passed, format/lint/typecheck clean, build succeeded.

## Impact

- No breaking change for current single-`provider` calls.
- No new API keys or HTTP paths.
- Ready for #188 to pass multiple lists into `merge_web_search_results`.

## Test plan

- [x] RRF scores match `1/(k+rank)` with 1-based ranks (`k=60` and `k=1`)
- [x] Duplicate URLs collapse (trailing slash, case, `utm_*` / `fbclid` / `gclid`)
- [x] Title-only identity after whitespace/case folding
- [x] Single-provider list is unchanged and has no `sources`
- [x] Fused hits include sorted `sources[]` with original rank/score
- [x] `limit` caps the fused list
- [x] `OMNISEARCH_RRF_K` is honored by the web_search hook