### PR TITLE
feat: add per-provider auto_allow cost gates

### DIFF
--- a/.changeset/auto-allow-cost-gates.md
+++ b/.changeset/auto-allow-cost-gates.md
@@ -1,0 +1,6 @@
+---
+'mcp-omnisearch': patch
+---
+
+feat: add per-provider auto_allow cost gates so expensive engines stay
+explicit-only

--- a/README.md
+++ b/README.md
@@ -117,6 +117,12 @@ Tavily, Kagi, Firecrawl, or Exa.
 - `FIRECRAWL_API_KEY`
 - `FIRECRAWL_BASE_URL` optional, for self-hosted Firecrawl
 - `OMNISEARCH_LARGE_RESULT_MODE` optional, `file` default or `inline`
+- `OMNISEARCH_AUTO_ALLOW` optional, comma-separated providers to opt
+  into automatic routing / fan-out / failover
+- `OMNISEARCH_AUTO_DENY` optional, comma-separated providers to keep
+  explicit-only
+- `OMNISEARCH_AUTO_ALLOW_<PROVIDER>` optional, `true`/`false` override
+  for one provider (for example `OMNISEARCH_AUTO_ALLOW_EXA=false`)
 
 ## Development
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -79,6 +79,10 @@ Container variables:
 - `LINKUP_API_KEY`
 - `FIRECRAWL_API_KEY`
 - `FIRECRAWL_BASE_URL`
+- `OMNISEARCH_AUTO_ALLOW` optional, opt gated providers into automatic
+  use
+- `OMNISEARCH_AUTO_DENY` optional, keep listed providers explicit-only
+- `OMNISEARCH_AUTO_ALLOW_<PROVIDER>` optional per-provider override
 - `PORT`, defaults to `8000`
 
 ## OpenAPI access

--- a/docs/provider-selection.md
+++ b/docs/provider-selection.md
@@ -42,6 +42,41 @@ search only. See
 | `firecrawl` | `FIRECRAWL_API_KEY` | `scrape`, `crawl`, `map`, `extract`, `actions` | Scraping, crawling, site maps, structured extraction, and browser actions. |
 | `exa`       | `EXA_API_KEY`       | `contents`, `similar`                          | Page content retrieval and semantically similar URLs.                      |
 
+## Cost gates (`auto_allow`)
+
+API keys enable **explicit** calls. They do not put a provider on
+every automatic query. Each provider has `auto_allow` (default `true`
+for current cheap/known engines). Set `auto_allow: false` on new
+expensive engines so `auto` routing, fan-out, and failover skip them.
+
+Explicit `provider: "parallel"` still works when that key exists.
+
+Opt a gated provider into automatic use:
+
+```bash
+OMNISEARCH_AUTO_ALLOW=parallel,querit
+```
+
+Or per provider:
+
+```bash
+OMNISEARCH_AUTO_ALLOW_PARALLEL=true
+```
+
+Keep a normally-allowed provider explicit-only:
+
+```bash
+OMNISEARCH_AUTO_DENY=exa
+# or
+OMNISEARCH_AUTO_ALLOW_EXA=false
+```
+
+`omnisearch://providers/status` lists gated-but-available providers
+under `auto_allow_excluded`. Automatic selection helpers
+(`select_for_automatic_use`, `ProviderRegistry.automatic_ids()`) honor
+the same gate. Call-site `opt_in` can include a gated provider for one
+request without changing the process-wide default.
+
 ## Provider choice cheatsheet
 
 - Need native operators like `filetype:pdf`, `intitle:`, or `before:`?

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -24,6 +24,7 @@ and configured providers remain available.
 | Query rejected before provider call       | Invalid input                                             | Check for empty queries, unsupported modes, malformed domains, or unsupported URL protocols.                                     |
 | Repeated transient errors                 | Rate limits, timeout, network failure, or provider 5xx    | Retry later or lower request volume. Retryable failures are handled separately from invalid credentials and validation failures. |
 | Returned file path cannot be read         | Server wrote a temp file on a remote/container filesystem | Retry with `large_result_mode: "inline"` or set `OMNISEARCH_LARGE_RESULT_MODE=inline`.                                           |
+| Auto/fan-out skips a configured provider  | Provider is `auto_allow=false`                            | Call it with an explicit `provider`, or opt in via `OMNISEARCH_AUTO_ALLOW`. See `auto_allow_excluded` on provider status.        |
 
 ## GitHub token setup
 

--- a/src/config/auto-allow.test.ts
+++ b/src/config/auto-allow.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+import {
+	parse_bool_env,
+	parse_name_list,
+	provider_env_token,
+	resolve_auto_allow,
+} from './auto-allow.js';
+
+describe('auto-allow env parsing', () => {
+	it('parses comma-separated provider names', () => {
+		expect(parse_name_list('parallel, Querit, ')).toEqual([
+			'parallel',
+			'querit',
+		]);
+		expect(parse_name_list(undefined)).toEqual([]);
+	});
+
+	it('parses boolean env tokens', () => {
+		expect(parse_bool_env('true')).toBe(true);
+		expect(parse_bool_env('ON')).toBe(true);
+		expect(parse_bool_env('0')).toBe(false);
+		expect(parse_bool_env('off')).toBe(false);
+		expect(parse_bool_env('')).toBeUndefined();
+		expect(parse_bool_env('maybe')).toBeUndefined();
+	});
+
+	it('normalizes provider ids into env tokens', () => {
+		expect(provider_env_token('kagi_enrichment')).toBe(
+			'KAGI_ENRICHMENT',
+		);
+		expect(provider_env_token('firecrawl:crawl')).toBe(
+			'FIRECRAWL_CRAWL',
+		);
+	});
+});
+
+describe('resolve_auto_allow', () => {
+	it('defaults current cheap engines to allowed', () => {
+		expect(resolve_auto_allow('tavily', 'tavily', true, {})).toBe(
+			true,
+		);
+		expect(resolve_auto_allow('exa', 'exa', undefined, {})).toBe(
+			true,
+		);
+	});
+
+	it('keeps declared expensive engines gated', () => {
+		expect(
+			resolve_auto_allow('parallel', 'parallel', false, {}),
+		).toBe(false);
+	});
+
+	it('opts a gated provider in via OMNISEARCH_AUTO_ALLOW', () => {
+		expect(
+			resolve_auto_allow('parallel', 'parallel', false, {
+				OMNISEARCH_AUTO_ALLOW: 'parallel,querit',
+			}),
+		).toBe(true);
+	});
+
+	it('opts a cheap provider out via OMNISEARCH_AUTO_DENY', () => {
+		expect(
+			resolve_auto_allow('exa', 'exa', true, {
+				OMNISEARCH_AUTO_DENY: 'exa',
+			}),
+		).toBe(false);
+	});
+
+	it('lets allow-list win over deny-list', () => {
+		expect(
+			resolve_auto_allow('parallel', 'parallel', false, {
+				OMNISEARCH_AUTO_ALLOW: 'parallel',
+				OMNISEARCH_AUTO_DENY: 'parallel',
+			}),
+		).toBe(true);
+	});
+
+	it('lets per-provider env override lists and defaults', () => {
+		expect(
+			resolve_auto_allow('exa', 'exa', true, {
+				OMNISEARCH_AUTO_ALLOW_EXA: 'false',
+				OMNISEARCH_AUTO_ALLOW: 'exa',
+			}),
+		).toBe(false);
+		expect(
+			resolve_auto_allow('firecrawl:crawl', 'firecrawl', true, {
+				OMNISEARCH_AUTO_ALLOW_FIRECRAWL_CRAWL: 'false',
+			}),
+		).toBe(false);
+		expect(
+			resolve_auto_allow('firecrawl:scrape', 'firecrawl', true, {
+				OMNISEARCH_AUTO_ALLOW_FIRECRAWL: 'false',
+			}),
+		).toBe(false);
+	});
+});

--- a/src/config/auto-allow.ts
+++ b/src/config/auto-allow.ts
@@ -1,0 +1,74 @@
+const TRUE_VALUES = new Set(['1', 'true', 'yes', 'on']);
+const FALSE_VALUES = new Set(['0', 'false', 'no', 'off']);
+
+export const parse_name_list = (
+	value: string | undefined,
+): string[] =>
+	(value ?? '')
+		.split(',')
+		.map((item) => item.trim().toLowerCase())
+		.filter(Boolean);
+
+export const parse_bool_env = (
+	value: string | undefined,
+): boolean | undefined => {
+	if (value === undefined || value.trim() === '') return undefined;
+
+	const normalized = value.trim().toLowerCase();
+	if (TRUE_VALUES.has(normalized)) return true;
+	if (FALSE_VALUES.has(normalized)) return false;
+
+	return undefined;
+};
+
+export const provider_env_token = (value: string): string =>
+	value
+		.replace(/[^a-zA-Z0-9]+/g, '_')
+		.replace(/^_|_$/g, '')
+		.toUpperCase();
+
+const list_includes = (list: string[], id: string, name: string) =>
+	list.includes(id.toLowerCase()) ||
+	list.includes(name.toLowerCase());
+
+/**
+ * Resolve whether a provider may be chosen by automatic routing,
+ * fan-out, or failover. Explicit `provider` calls ignore this gate.
+ *
+ * Override order: per-id env, per-name env, OMNISEARCH_AUTO_ALLOW,
+ * OMNISEARCH_AUTO_DENY, then the declared default (true when omitted).
+ */
+export const resolve_auto_allow = (
+	id: string,
+	name: string,
+	declared = true,
+	env: NodeJS.ProcessEnv = process.env,
+): boolean => {
+	const per_id = parse_bool_env(
+		env[`OMNISEARCH_AUTO_ALLOW_${provider_env_token(id)}`],
+	);
+	if (per_id !== undefined) return per_id;
+
+	const per_name = parse_bool_env(
+		env[`OMNISEARCH_AUTO_ALLOW_${provider_env_token(name)}`],
+	);
+	if (per_name !== undefined) return per_name;
+
+	if (
+		list_includes(
+			parse_name_list(env.OMNISEARCH_AUTO_ALLOW),
+			id,
+			name,
+		)
+	) {
+		return true;
+	}
+
+	if (
+		list_includes(parse_name_list(env.OMNISEARCH_AUTO_DENY), id, name)
+	) {
+		return false;
+	}
+
+	return declared;
+};

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -12,6 +12,11 @@ export const LINKUP_API_KEY = process.env.LINKUP_API_KEY;
 export const FIRECRAWL_API_KEY = process.env.FIRECRAWL_API_KEY;
 export const FIRECRAWL_BASE_URL = process.env.FIRECRAWL_BASE_URL;
 
+// Automatic-use cost gates (explicit provider calls ignore these):
+// OMNISEARCH_AUTO_ALLOW, OMNISEARCH_AUTO_DENY,
+// OMNISEARCH_AUTO_ALLOW_<PROVIDER>
+export { resolve_auto_allow, parse_name_list } from './auto-allow.js';
+
 // Provider configuration
 export const config = {
 	search: {

--- a/src/server/auto-allow.test.ts
+++ b/src/server/auto-allow.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+import {
+	build_auto_allow_quality_report,
+	select_for_automatic_use,
+	type AutoAllowCandidate,
+} from './auto-allow.js';
+
+const candidate = (
+	id: string,
+	auto_allow: boolean,
+	name = id,
+): AutoAllowCandidate => ({ id, name, auto_allow });
+
+const cheap = [
+	candidate('tavily', true),
+	candidate('brave', true),
+	candidate('kagi', true),
+];
+
+const mixed = [
+	...cheap,
+	candidate('parallel', false),
+	candidate('querit', false),
+];
+
+describe('select_for_automatic_use', () => {
+	it('keeps current cheap engines in the automatic pool', () => {
+		expect(select_for_automatic_use(cheap)).toEqual({
+			selected: cheap,
+			auto_allow_excluded: [],
+		});
+	});
+
+	it('skips gated providers for auto routing', () => {
+		const { selected, auto_allow_excluded } =
+			select_for_automatic_use(mixed);
+
+		expect(selected.map((entry) => entry.id)).toEqual([
+			'tavily',
+			'brave',
+			'kagi',
+		]);
+		expect(auto_allow_excluded).toEqual(['parallel', 'querit']);
+	});
+
+	it('skips gated providers for fan-out', () => {
+		const fan_out = select_for_automatic_use(mixed);
+
+		expect(fan_out.selected.map((entry) => entry.id)).not.toContain(
+			'parallel',
+		);
+		expect(fan_out.auto_allow_excluded).toContain('parallel');
+	});
+
+	it('skips gated providers for failover', () => {
+		const remaining = mixed.filter((entry) => entry.id !== 'tavily');
+		const failover = select_for_automatic_use(remaining);
+
+		expect(failover.selected.map((entry) => entry.id)).toEqual([
+			'brave',
+			'kagi',
+		]);
+		expect(failover.auto_allow_excluded).toEqual([
+			'parallel',
+			'querit',
+		]);
+	});
+
+	it('includes a gated provider when the call opts in', () => {
+		const opted = select_for_automatic_use(mixed, {
+			opt_in: ['parallel'],
+		});
+
+		expect(opted.selected.map((entry) => entry.id)).toEqual([
+			'tavily',
+			'brave',
+			'kagi',
+			'parallel',
+		]);
+		expect(opted.auto_allow_excluded).toEqual(['querit']);
+	});
+});
+
+describe('build_auto_allow_quality_report', () => {
+	it('lists auto_allow_excluded names', () => {
+		expect(build_auto_allow_quality_report(mixed)).toEqual({
+			auto_allow_excluded: ['parallel', 'querit'],
+		});
+	});
+});

--- a/src/server/auto-allow.ts
+++ b/src/server/auto-allow.ts
@@ -1,0 +1,67 @@
+export interface AutoAllowCandidate {
+	id: string;
+	name: string;
+	auto_allow: boolean;
+}
+
+export interface AutomaticSelection<T extends AutoAllowCandidate> {
+	selected: T[];
+	auto_allow_excluded: string[];
+}
+
+export type AutomaticUse = 'auto' | 'fan-out' | 'failover';
+
+const unique_names = (names: readonly string[]): string[] =>
+	Array.from(new Set(names));
+
+const opted_in = (
+	candidate: AutoAllowCandidate,
+	opt_in: readonly string[],
+) => {
+	const tokens = opt_in.map((token) => token.toLowerCase());
+	return (
+		tokens.includes(candidate.id.toLowerCase()) ||
+		tokens.includes(candidate.name.toLowerCase())
+	);
+};
+
+export const is_allowed_for_automatic_use = (
+	candidate: AutoAllowCandidate,
+	opt_in: readonly string[] = [],
+): boolean => candidate.auto_allow || opted_in(candidate, opt_in);
+
+/**
+ * Filter candidates for auto routing, fan-out, and failover.
+ * Explicit provider selection must not use this helper.
+ */
+export const select_for_automatic_use = <
+	T extends AutoAllowCandidate,
+>(
+	candidates: readonly T[],
+	options: { opt_in?: readonly string[] } = {},
+): AutomaticSelection<T> => {
+	const selected: T[] = [];
+	const excluded: string[] = [];
+
+	for (const candidate of candidates) {
+		if (is_allowed_for_automatic_use(candidate, options.opt_in)) {
+			selected.push(candidate);
+			continue;
+		}
+
+		excluded.push(candidate.name);
+	}
+
+	return {
+		selected,
+		auto_allow_excluded: unique_names(excluded),
+	};
+};
+
+export const build_auto_allow_quality_report = (
+	candidates: readonly AutoAllowCandidate[],
+	options: { opt_in?: readonly string[] } = {},
+) => ({
+	auto_allow_excluded: select_for_automatic_use(candidates, options)
+		.auto_allow_excluded,
+});

--- a/src/server/handlers.test.ts
+++ b/src/server/handlers.test.ts
@@ -45,6 +45,7 @@ const provider_status = (
 	tools: ['web_search'],
 	modes: [],
 	capabilities: ['web_search'],
+	auto_allow: true,
 	...overrides,
 });
 
@@ -128,6 +129,51 @@ describe('setup_handlers', () => {
 			processing: 1,
 			total: 1,
 		});
+		expect(status_body.auto_allow_excluded).toEqual([]);
+	});
+
+	it('lists available gated providers in auto_allow_excluded', async () => {
+		reset_available_providers();
+		provider_status_entries.push(
+			provider_status({
+				id: 'tavily',
+				name: 'tavily',
+				api_key_name: 'TAVILY_API_KEY',
+			}),
+			provider_status({
+				id: 'parallel',
+				name: 'parallel',
+				api_key_name: 'PARALLEL_API_KEY',
+				auto_allow: false,
+			}),
+			provider_status({
+				id: 'querit',
+				name: 'querit',
+				status: 'unavailable',
+				api_key_name: 'QUERIT_API_KEY',
+				auto_allow: false,
+				unavailable_reason: 'missing_api_key',
+			}),
+		);
+
+		const { resources, server } = create_mock_server();
+		setup_handlers(server as any);
+
+		const provider_status_resource = resources.find(
+			(resource) => resource.definition.name === 'provider-status',
+		)!;
+		const status_response = await provider_status_resource.handler();
+		const status_body = JSON.parse(status_response.contents[0].text);
+
+		expect(status_body.auto_allow_excluded).toEqual(['parallel']);
+		expect(status_body.providers.search).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					name: 'parallel',
+					auto_allow: false,
+				}),
+			]),
+		);
 	});
 
 	it('returns provider information for available providers', async () => {
@@ -175,6 +221,7 @@ describe('setup_handlers', () => {
 					category: 'search',
 					status: 'available',
 					api_key_name: 'KAGI_API_KEY',
+					auto_allow: true,
 				}),
 			],
 		});

--- a/src/server/handlers.ts
+++ b/src/server/handlers.ts
@@ -1,5 +1,6 @@
 import { McpServer } from 'tmcp';
 import type { GenericSchema } from 'valibot';
+import { build_auto_allow_quality_report } from './auto-allow.js';
 import type {
 	ProviderCategory,
 	ProviderStatus,
@@ -67,6 +68,7 @@ const aggregate_provider_info = (
 			tools: provider.tools,
 			modes: provider.modes,
 			capabilities: provider.capabilities,
+			auto_allow: provider.auto_allow,
 			unavailable_reason: provider.unavailable_reason,
 		})),
 	};
@@ -126,6 +128,11 @@ export const setup_handlers = (server: McpServer<GenericSchema>) => {
 									...unavailable_count,
 									total: total - available_total,
 								},
+								...build_auto_allow_quality_report(
+									provider_status_entries.filter(
+										(provider) => provider.status === 'available',
+									),
+								),
 							},
 							null,
 							2,

--- a/src/server/provider-definitions.test.ts
+++ b/src/server/provider-definitions.test.ts
@@ -140,4 +140,19 @@ describe('provider definitions', () => {
 			'exa:contents',
 		);
 	});
+
+	it('defaults current known engines to automatic use', () => {
+		const definitions = [
+			...web_search_provider_definitions,
+			...ai_search_provider_definitions,
+			...github_provider_definitions,
+			...web_extract_provider_definitions,
+		];
+
+		expect(
+			definitions.filter((definition) =>
+				Object.hasOwn(definition, 'auto_allow'),
+			),
+		).toEqual([]);
+	});
 });

--- a/src/server/provider-registry.test.ts
+++ b/src/server/provider-registry.test.ts
@@ -25,6 +25,7 @@ describe('ProviderRegistry', () => {
 				category: 'search',
 				status: 'available',
 				api_key_name: 'brave',
+				auto_allow: true,
 			}),
 		]);
 	});
@@ -87,5 +88,78 @@ describe('ProviderRegistry', () => {
 		expect(() => registry.require('missing', 'web_search')).toThrow(
 			ProviderError,
 		);
+	});
+
+	it('keeps gated providers callable by explicit id', () => {
+		const registry = new ProviderRegistry<{ name: string }>();
+
+		registry.register({
+			id: 'parallel',
+			name: 'parallel',
+			category: 'search',
+			api_key: 'key',
+			auto_allow: false,
+			create: () => ({ name: 'parallel' }),
+		});
+
+		expect(registry.require('parallel', 'web_search')).toEqual({
+			name: 'parallel',
+		});
+		expect(registry.automatic_ids()).toEqual([]);
+		expect(registry.auto_allow_quality_report()).toEqual({
+			auto_allow_excluded: ['parallel'],
+		});
+	});
+
+	it('excludes env-denied providers from automatic selection', () => {
+		const registry = new ProviderRegistry<{ name: string }>();
+
+		registry.register(
+			{
+				id: 'exa',
+				name: 'exa',
+				category: 'search',
+				api_key: 'key',
+				create: () => ({ name: 'exa' }),
+			},
+			{ OMNISEARCH_AUTO_DENY: 'exa' },
+		);
+		registry.register(
+			{
+				id: 'tavily',
+				name: 'tavily',
+				category: 'search',
+				api_key: 'key',
+				create: () => ({ name: 'tavily' }),
+			},
+			{ OMNISEARCH_AUTO_DENY: 'exa' },
+		);
+
+		expect(registry.automatic_ids()).toEqual(['tavily']);
+		expect(registry.ids()).toEqual(['exa', 'tavily']);
+		expect(registry.auto_allow_quality_report()).toEqual({
+			auto_allow_excluded: ['exa'],
+		});
+	});
+
+	it('opts a declared-gated provider into automatic use', () => {
+		const registry = new ProviderRegistry<{ name: string }>();
+
+		registry.register(
+			{
+				id: 'parallel',
+				name: 'parallel',
+				category: 'search',
+				api_key: 'key',
+				auto_allow: false,
+				create: () => ({ name: 'parallel' }),
+			},
+			{ OMNISEARCH_AUTO_ALLOW: 'parallel' },
+		);
+
+		expect(registry.automatic_ids()).toEqual(['parallel']);
+		expect(registry.auto_allow_quality_report()).toEqual({
+			auto_allow_excluded: [],
+		});
 	});
 });

--- a/src/server/provider-registry.ts
+++ b/src/server/provider-registry.ts
@@ -1,5 +1,10 @@
 import { ErrorType, ProviderError } from '../common/types.js';
 import { is_api_key_valid } from '../common/validation.js';
+import { resolve_auto_allow } from '../config/auto-allow.js';
+import {
+	build_auto_allow_quality_report,
+	select_for_automatic_use,
+} from './auto-allow.js';
 
 export type ProviderCategory =
 	| 'search'
@@ -17,6 +22,7 @@ export interface ProviderDefinition<T> {
 	tools?: readonly string[];
 	modes?: readonly string[];
 	capabilities?: readonly string[];
+	auto_allow?: boolean;
 }
 
 export interface ProviderStatus {
@@ -29,6 +35,7 @@ export interface ProviderStatus {
 	tools: readonly string[];
 	modes: readonly string[];
 	capabilities: readonly string[];
+	auto_allow: boolean;
 	unavailable_reason?: 'missing_api_key';
 }
 
@@ -41,6 +48,7 @@ export interface RegisteredProvider<T> {
 	tools: readonly string[];
 	modes: readonly string[];
 	capabilities: readonly string[];
+	auto_allow: boolean;
 }
 
 export class ProviderRegistry<T> {
@@ -57,8 +65,17 @@ export class ProviderRegistry<T> {
 		this.missing_api_key_names.clear();
 	}
 
-	register(definition: ProviderDefinition<T>) {
+	register(
+		definition: ProviderDefinition<T>,
+		env: NodeJS.ProcessEnv = process.env,
+	) {
 		const api_key_name = definition.api_key_name ?? definition.name;
+		const auto_allow = resolve_auto_allow(
+			definition.id,
+			definition.name,
+			definition.auto_allow ?? true,
+			env,
+		);
 		const base_status = {
 			id: definition.id,
 			name: definition.name,
@@ -68,6 +85,7 @@ export class ProviderRegistry<T> {
 			tools: definition.tools ?? [],
 			modes: definition.modes ?? [],
 			capabilities: definition.capabilities ?? [],
+			auto_allow,
 		};
 
 		if (!definition.api_key || definition.api_key.trim() === '') {
@@ -109,9 +127,12 @@ export class ProviderRegistry<T> {
 		});
 	}
 
-	register_all(definitions: readonly ProviderDefinition<T>[]) {
+	register_all(
+		definitions: readonly ProviderDefinition<T>[],
+		env: NodeJS.ProcessEnv = process.env,
+	) {
 		for (const definition of definitions) {
-			this.register(definition);
+			this.register(definition, env);
 		}
 	}
 
@@ -156,6 +177,26 @@ export class ProviderRegistry<T> {
 
 	status_entries(): ProviderStatus[] {
 		return Array.from(this.statuses.values());
+	}
+
+	automatic_entries(): RegisteredProvider<T>[] {
+		return select_for_automatic_use(this.entries()).selected;
+	}
+
+	automatic_ids(): string[] {
+		return this.automatic_entries().map((provider) => provider.id);
+	}
+
+	automatic_names(): string[] {
+		return Array.from(
+			new Set(
+				this.automatic_entries().map((provider) => provider.name),
+			),
+		);
+	}
+
+	auto_allow_quality_report() {
+		return build_auto_allow_quality_report(this.entries());
 	}
 
 	get size() {

--- a/src/server/tools/ai-search.ts
+++ b/src/server/tools/ai-search.ts
@@ -25,8 +25,14 @@ export const initialize_ai_search = (): boolean => {
 
 export const get_available_providers = () => providers.names();
 
+export const get_automatic_providers = () =>
+	providers.automatic_names();
+
 export const get_provider_status_entries = () =>
 	providers.status_entries();
+
+export const get_auto_allow_quality_report = () =>
+	providers.auto_allow_quality_report();
 
 export const register_ai_search = (
 	server: McpServer<GenericSchema>,

--- a/src/server/tools/contract.test.ts
+++ b/src/server/tools/contract.test.ts
@@ -19,6 +19,13 @@ const API_KEY_NAMES = [
 	'FIRECRAWL_API_KEY',
 ];
 
+const AUTO_ALLOW_ENV_NAMES = [
+	'OMNISEARCH_AUTO_ALLOW',
+	'OMNISEARCH_AUTO_DENY',
+	'OMNISEARCH_AUTO_ALLOW_BRAVE',
+	'OMNISEARCH_AUTO_ALLOW_EXA',
+];
+
 const create_mock_server = () => {
 	const tools: RegisteredTool[] = [];
 	return {
@@ -78,11 +85,12 @@ const mock_tavily_extract_response = (content: string) => {
 
 afterEach(() => {
 	for (const key of API_KEY_NAMES) delete process.env[key];
+	for (const key of AUTO_ALLOW_ENV_NAMES) delete process.env[key];
 	vi.unstubAllGlobals();
 	vi.restoreAllMocks();
 });
 
-describe('MCP tool contract', () => {
+describe('MCP tool contract', { timeout: 15_000 }, () => {
 	it('registers no public tools when no providers are configured', async () => {
 		const { tools, tools_module } = await load_contract({});
 
@@ -261,6 +269,61 @@ describe('MCP tool contract', () => {
 			provider: 'brave',
 			retryable: false,
 		});
+	});
+
+	it('keeps explicit providers callable when auto_allow is denied', async () => {
+		process.env.OMNISEARCH_AUTO_DENY = 'brave';
+		const { tools, tools_module } = await load_contract({
+			BRAVE_API_KEY: 'brave-key',
+			TAVILY_API_KEY: 'tavily-key',
+		});
+		const tool = tools.find(
+			(entry) => entry.definition.name === 'web_search',
+		)!;
+
+		expect(
+			v.safeParse(tool.definition.schema, {
+				query: 'example',
+				provider: 'brave',
+			}).success,
+		).toBe(true);
+		expect(tools_module.get_auto_allow_quality_report()).toEqual({
+			auto_allow_excluded: ['brave'],
+		});
+
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue(
+				new Response(
+					JSON.stringify({
+						web: {
+							results: [
+								{
+									title: 'Example',
+									url: 'https://example.com',
+									description: 'Example result',
+								},
+							],
+						},
+					}),
+					{ status: 200 },
+				),
+			),
+		);
+
+		const success = await tool.handler({
+			query: 'example',
+			provider: 'brave',
+			large_result_mode: 'inline',
+		});
+		expect(parse_tool_body(success)).toEqual([
+			{
+				title: 'Example',
+				url: 'https://example.com',
+				snippet: 'Example result',
+				source_provider: 'brave',
+			},
+		]);
 	});
 
 	it('covers large-result inline/file modes and compact extraction at the MCP layer', async () => {

--- a/src/server/tools/github-search.ts
+++ b/src/server/tools/github-search.ts
@@ -22,8 +22,14 @@ export const initialize_github_search = (): boolean => {
 
 export const get_available = () => providers.names();
 
+export const get_automatic_providers = () =>
+	providers.automatic_names();
+
 export const get_provider_status_entries = () =>
 	providers.status_entries();
+
+export const get_auto_allow_quality_report = () =>
+	providers.auto_allow_quality_report();
 
 export const register_github_search = (
 	server: McpServer<GenericSchema>,

--- a/src/server/tools/index.ts
+++ b/src/server/tools/index.ts
@@ -1,5 +1,6 @@
 import { McpServer } from 'tmcp';
 import type { GenericSchema } from 'valibot';
+import { build_auto_allow_quality_report } from '../auto-allow.js';
 import type { ProviderStatus } from '../provider-registry.js';
 import {
 	get_provider_status_entries as get_ai_provider_status_entries,
@@ -108,3 +109,10 @@ export const register_tools = (server: McpServer<GenericSchema>) => {
 	register_ai_search(server);
 	register_web_extract(server);
 };
+
+export const get_auto_allow_quality_report = () =>
+	build_auto_allow_quality_report(
+		provider_status_entries.filter(
+			(provider) => provider.status === 'available',
+		),
+	);

--- a/src/server/tools/web-extract.ts
+++ b/src/server/tools/web-extract.ts
@@ -33,8 +33,14 @@ export const initialize_web_extract = (): boolean => {
 
 export const get_available_providers = () => providers.names();
 
+export const get_automatic_providers = () =>
+	providers.automatic_names();
+
 export const get_provider_status_entries = () =>
 	providers.status_entries();
+
+export const get_auto_allow_quality_report = () =>
+	providers.auto_allow_quality_report();
 
 const web_extract_modes = Array.from(
 	new Set(

--- a/src/server/tools/web-search.ts
+++ b/src/server/tools/web-search.ts
@@ -27,8 +27,14 @@ export const initialize_web_search = (): boolean => {
 
 export const get_available_providers = () => providers.names();
 
+export const get_automatic_providers = () =>
+	providers.automatic_names();
+
 export const get_provider_status_entries = () =>
 	providers.status_entries();
+
+export const get_auto_allow_quality_report = () =>
+	providers.auto_allow_quality_report();
 
 export const register_web_search = (
 	server: McpServer<GenericSchema>,


### PR DESCRIPTION
## Summary

API keys should not put an expensive provider on every automatic query. This adds per-provider `auto_allow` cost gates so explicit `provider` calls still work, while `auto` routing, fan-out, and failover skip `auto_allow=false` unless the operator opts in.

Fixes #207.

## Approach

- Current cheap/known engines default to `auto_allow=true` (field omitted).
- New expensive engines should set `auto_allow: false` on their definition.
- Env opt-in / opt-out: `OMNISEARCH_AUTO_ALLOW`, `OMNISEARCH_AUTO_DENY`, and `OMNISEARCH_AUTO_ALLOW_<NAME>`.
- `select_for_automatic_use()` and `ProviderRegistry.automatic_ids()` are the shared gate for auto / fan-out / failover. `require()` stays ungated so explicit providers always win.
- `omnisearch://providers/status` includes `auto_allow` per provider and `auto_allow_excluded` on the quality report.

## Scope

- `src/config/auto-allow.ts` — env resolution
- `src/server/auto-allow.ts` — automatic-use filter + quality report
- `src/server/provider-registry.ts` — store `auto_allow`, expose automatic helpers
- Provider status resource + docs (README, provider-selection, deployment, troubleshooting)
- Tests for explicit-always-works, auto/fan-out/failover skip, and opt-in

No new providers and no change to explicit single-provider tool calls.

## Verification

```bash
pnpm install
pnpm run check
pnpm test
pnpm run build
```

Locally after syncing `upstream/main`: 131 tests passed, lint/format clean, build succeeded.

Example: `OMNISEARCH_AUTO_DENY=brave` still accepts `web_search` with `provider: "brave"`, and `auto_allow_excluded` lists `brave`.

## Impact

- Non-breaking for current engines (all remain auto-allowed).
- Operators can keep a configured key explicit-only without unregistering the provider.
- Follow-up orchestration (#188 / #190 / #191) should use `select_for_automatic_use` / `automatic_ids()` so they honor the gate.