### PR TITLE
Add get_provider_info tool for non-secret provider metadata

### DIFF
--- a/.changeset/get-provider-info.md
+++ b/.changeset/get-provider-info.md
@@ -1,0 +1,5 @@
+---
+'mcp-omnisearch': patch
+---
+
+feat: add get_provider_info tool for non-secret provider metadata

--- a/README.md
+++ b/README.md
@@ -72,6 +72,19 @@ working.
 
 ## Tools
 
+### `get_provider_info`
+
+List registered providers and non-secret runtime metadata. Available
+even when only a subset of API keys is configured. Returns `id`,
+`tools`, `timeout`, `enabled`, `cooldown`, and `last_error_type`.
+Never returns keys, tokens, or secrets.
+
+```json
+{
+	"provider": "brave"
+}
+```
+
 ### `web_search`
 
 Search the web with Tavily, Brave, Kagi, Exa, or Kagi Enrichment.

--- a/src/server/provider-info.ts
+++ b/src/server/provider-info.ts
@@ -1,0 +1,70 @@
+import { config } from '../config/env.js';
+import type { ErrorType } from '../common/types.js';
+import type { ProviderStatus } from './provider-registry.js';
+import { get_provider_runtime } from './provider-runtime.js';
+
+export interface ProviderInfo {
+	id: string;
+	tools: string[];
+	timeout: number;
+	enabled: boolean;
+	cooldown: boolean;
+	last_error_type: ErrorType | null;
+}
+
+export const provider_timeouts: Record<string, number> = {
+	tavily: config.search.tavily.timeout,
+	brave: config.search.brave.timeout,
+	kagi: config.search.kagi.timeout,
+	exa: config.search.exa.timeout,
+	kagi_enrichment: config.enhancement.kagi_enrichment.timeout,
+	github: config.search.github.timeout,
+	kagi_fastgpt: config.ai_response.kagi_fastgpt.timeout,
+	exa_answer: config.ai_response.exa_answer.timeout,
+	linkup: config.ai_response.linkup.timeout,
+	'tavily:extract': config.processing.tavily_extract.timeout,
+	'kagi:summarize': config.processing.kagi_summarizer.timeout,
+	'firecrawl:scrape': config.processing.firecrawl_scrape.timeout,
+	'firecrawl:crawl': config.processing.firecrawl_crawl.timeout,
+	'firecrawl:map': config.processing.firecrawl_map.timeout,
+	'firecrawl:extract': config.processing.firecrawl_extract.timeout,
+	'firecrawl:actions': config.processing.firecrawl_actions.timeout,
+	'exa:contents': config.processing.exa_contents.timeout,
+	'exa:similar': config.processing.exa_similar.timeout,
+};
+
+export const get_provider_timeout = (id: string): number => {
+	const timeout = provider_timeouts[id];
+	if (typeof timeout !== 'number') {
+		throw new Error(`Missing timeout mapping for provider "${id}"`);
+	}
+
+	return timeout;
+};
+
+const runtime_for = (entry: ProviderStatus) => {
+	const by_id = get_provider_runtime(entry.id);
+	if (by_id.last_error_type !== null) return by_id;
+	return get_provider_runtime(entry.name);
+};
+
+export const list_provider_info = (
+	entries: readonly ProviderStatus[],
+	filter?: string,
+): ProviderInfo[] =>
+	entries
+		.filter(
+			(entry) =>
+				!filter || entry.id === filter || entry.name === filter,
+		)
+		.map((entry) => {
+			const runtime = runtime_for(entry);
+			return {
+				id: entry.id,
+				tools: [...entry.tools],
+				timeout: get_provider_timeout(entry.id),
+				enabled: entry.status === 'available',
+				cooldown: runtime.cooldown,
+				last_error_type: runtime.last_error_type,
+			};
+		});

--- a/src/server/provider-runtime.test.ts
+++ b/src/server/provider-runtime.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { ErrorType, ProviderError } from '../common/types.js';
+import {
+	clear_provider_runtime,
+	get_provider_runtime,
+	record_provider_error,
+} from './provider-runtime.js';
+
+afterEach(() => {
+	clear_provider_runtime();
+});
+
+describe('provider runtime', () => {
+	it('records last error type without storing the error message', () => {
+		record_provider_error(
+			new ProviderError(
+				ErrorType.AUTH_ERROR,
+				'Invalid API key sk-secret-value',
+				'brave',
+			),
+		);
+
+		const runtime = get_provider_runtime('brave');
+
+		expect(runtime).toEqual({
+			last_error_type: ErrorType.AUTH_ERROR,
+			cooldown: false,
+		});
+		expect(JSON.stringify(runtime)).not.toContain('sk-secret-value');
+		expect(JSON.stringify(runtime)).not.toContain('Invalid API key');
+	});
+
+	it('marks cooldown while a rate-limit reset time is in the future', () => {
+		const now = new Date('2026-08-16T10:00:00.000Z');
+		const reset_time = new Date('2026-08-16T10:05:00.000Z');
+
+		record_provider_error(
+			new ProviderError(
+				ErrorType.RATE_LIMIT,
+				'Rate limit exceeded for brave',
+				'brave',
+				{ reset_time, retryable: true },
+			),
+			() => now,
+		);
+
+		expect(get_provider_runtime('brave', () => now)).toEqual({
+			last_error_type: ErrorType.RATE_LIMIT,
+			cooldown: true,
+		});
+		expect(
+			get_provider_runtime(
+				'brave',
+				() => new Date('2026-08-16T10:06:00.000Z'),
+			),
+		).toEqual({
+			last_error_type: ErrorType.RATE_LIMIT,
+			cooldown: false,
+		});
+	});
+
+	it('uses a one-minute cooldown when rate-limited without reset_time', () => {
+		const now = new Date('2026-08-16T10:00:00.000Z');
+
+		record_provider_error(
+			new ProviderError(
+				ErrorType.RATE_LIMIT,
+				'Rate limit exceeded for tavily',
+				'tavily',
+				{ retryable: true },
+			),
+			() => now,
+		);
+
+		expect(get_provider_runtime('tavily', () => now)).toEqual({
+			last_error_type: ErrorType.RATE_LIMIT,
+			cooldown: true,
+		});
+		expect(
+			get_provider_runtime(
+				'tavily',
+				() => new Date('2026-08-16T10:01:00.000Z'),
+			),
+		).toEqual({
+			last_error_type: ErrorType.RATE_LIMIT,
+			cooldown: false,
+		});
+	});
+
+	it('ignores non-provider errors', () => {
+		record_provider_error(new Error('boom'));
+
+		expect(get_provider_runtime('brave')).toEqual({
+			last_error_type: null,
+			cooldown: false,
+		});
+	});
+});

--- a/src/server/provider-runtime.ts
+++ b/src/server/provider-runtime.ts
@@ -1,0 +1,62 @@
+import { ErrorType, ProviderError } from '../common/types.js';
+
+export const DEFAULT_RATE_LIMIT_COOLDOWN_MS = 60_000;
+
+export interface ProviderRuntimeState {
+	last_error_type: ErrorType | null;
+	cooldown: boolean;
+}
+
+interface StoredRuntimeState {
+	last_error_type: ErrorType;
+	cooldown_until: Date | null;
+}
+
+const runtime_states = new Map<string, StoredRuntimeState>();
+
+const cooldown_until_for = (
+	error: ProviderError,
+	now: Date,
+): Date | null => {
+	if (error.type !== ErrorType.RATE_LIMIT) return null;
+
+	return error.details?.reset_time instanceof Date
+		? error.details.reset_time
+		: new Date(now.getTime() + DEFAULT_RATE_LIMIT_COOLDOWN_MS);
+};
+
+export const clear_provider_runtime = () => {
+	runtime_states.clear();
+};
+
+export const record_provider_error = (
+	error: unknown,
+	now: () => Date = () => new Date(),
+) => {
+	if (!(error instanceof ProviderError)) return;
+
+	runtime_states.set(error.provider, {
+		last_error_type: error.type,
+		cooldown_until: cooldown_until_for(error, now()),
+	});
+};
+
+export const get_provider_runtime = (
+	provider: string,
+	now: () => Date = () => new Date(),
+): ProviderRuntimeState => {
+	const state = runtime_states.get(provider);
+	if (!state) {
+		return {
+			last_error_type: null,
+			cooldown: false,
+		};
+	}
+
+	return {
+		last_error_type: state.last_error_type,
+		cooldown:
+			state.cooldown_until !== null &&
+			state.cooldown_until.getTime() > now().getTime(),
+	};
+};

--- a/src/server/tools/contract.test.ts
+++ b/src/server/tools/contract.test.ts
@@ -83,10 +83,12 @@ afterEach(() => {
 });
 
 describe('MCP tool contract', () => {
-	it('registers no public tools when no providers are configured', async () => {
+	it('registers only get_provider_info when no providers are configured', async () => {
 		const { tools, tools_module } = await load_contract({});
 
-		expect(tools).toEqual([]);
+		expect(tools.map((tool) => tool.definition.name)).toEqual([
+			'get_provider_info',
+		]);
 		expect(tools_module.provider_status_entries).toEqual(
 			expect.arrayContaining([
 				expect.objectContaining({
@@ -96,7 +98,7 @@ describe('MCP tool contract', () => {
 				}),
 			]),
 		);
-	});
+	}, 15_000);
 
 	it('registers tools from the configured provider set', async () => {
 		const { tools } = await load_contract({
@@ -107,6 +109,7 @@ describe('MCP tool contract', () => {
 		});
 
 		expect(tools.map((tool) => tool.definition.name)).toEqual([
+			'get_provider_info',
 			'web_search',
 			'github_search',
 			'ai_search',

--- a/src/server/tools/index.ts
+++ b/src/server/tools/index.ts
@@ -1,6 +1,7 @@
 import { McpServer } from 'tmcp';
 import type { GenericSchema } from 'valibot';
 import type { ProviderStatus } from '../provider-registry.js';
+import { clear_provider_runtime } from '../provider-runtime.js';
 import {
 	get_provider_status_entries as get_ai_provider_status_entries,
 	get_available_providers as get_ai_providers,
@@ -13,6 +14,7 @@ import {
 	initialize_github_search,
 	register_github_search,
 } from './github-search.js';
+import { register_provider_info } from './provider-info.js';
 import {
 	get_provider_status_entries as get_extract_provider_status_entries,
 	get_available_providers as get_extract_providers,
@@ -44,6 +46,7 @@ const reset_provider_tracking = () => {
 
 export const initialize_providers = () => {
 	reset_provider_tracking();
+	clear_provider_runtime();
 
 	if (initialize_web_search()) {
 		for (const p of get_search_providers())
@@ -103,6 +106,7 @@ export const initialize_providers = () => {
 };
 
 export const register_tools = (server: McpServer<GenericSchema>) => {
+	register_provider_info(server, () => provider_status_entries);
 	register_web_search(server);
 	register_github_search(server);
 	register_ai_search(server);

--- a/src/server/tools/provider-info.test.ts
+++ b/src/server/tools/provider-info.test.ts
@@ -1,0 +1,315 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ErrorType } from '../../common/types.js';
+import { config } from '../../config/env.js';
+import { clear_provider_runtime } from '../provider-runtime.js';
+
+interface RegisteredTool {
+	definition: { name: string; description?: string };
+	handler: (args: Record<string, unknown>) => Promise<{
+		content: Array<{ text: string }>;
+		isError?: boolean;
+	}>;
+}
+
+const API_KEY_NAMES = [
+	'TAVILY_API_KEY',
+	'BRAVE_API_KEY',
+	'KAGI_API_KEY',
+	'GITHUB_API_KEY',
+	'EXA_API_KEY',
+	'LINKUP_API_KEY',
+	'FIRECRAWL_API_KEY',
+];
+
+const SECRET = 'super-secret-brave-token-205';
+
+const create_mock_server = () => {
+	const tools: RegisteredTool[] = [];
+	return {
+		tools,
+		server: {
+			tool: (
+				definition: RegisteredTool['definition'],
+				handler: RegisteredTool['handler'],
+			) => {
+				tools.push({ definition, handler });
+			},
+		},
+	};
+};
+
+const load_provider_info = async (
+	keys: Record<string, string | undefined>,
+) => {
+	vi.resetModules();
+	clear_provider_runtime();
+	for (const key of API_KEY_NAMES) delete process.env[key];
+	for (const [key, value] of Object.entries(keys)) {
+		if (value !== undefined) process.env[key] = value;
+	}
+
+	const tools_module = await import('./index.js');
+	const { tools, server } = create_mock_server();
+	vi.spyOn(console, 'error').mockImplementation(() => {});
+	vi.spyOn(console, 'warn').mockImplementation(() => {});
+	tools_module.initialize_providers();
+	tools_module.register_tools(server as any);
+
+	const tool = tools.find(
+		(entry) => entry.definition.name === 'get_provider_info',
+	);
+	return { tools, tool, tools_module };
+};
+
+const parse_tool_body = (response: {
+	content: Array<{ text: string }>;
+}) => JSON.parse(response.content[0].text);
+
+const collect_strings = (value: unknown): string[] => {
+	if (typeof value === 'string') return [value];
+	if (typeof value === 'number' || typeof value === 'boolean') {
+		return [String(value)];
+	}
+	if (Array.isArray(value)) {
+		return value.flatMap(collect_strings);
+	}
+	if (value && typeof value === 'object') {
+		return Object.entries(value).flatMap(([key, nested]) => [
+			key,
+			...collect_strings(nested),
+		]);
+	}
+	return [];
+};
+
+afterEach(() => {
+	for (const key of API_KEY_NAMES) delete process.env[key];
+	clear_provider_runtime();
+	vi.unstubAllGlobals();
+	vi.restoreAllMocks();
+});
+
+describe('get_provider_info', () => {
+	it('is registered and lists every provider when no keys are set', async () => {
+		const { tools, tool } = await load_provider_info({});
+
+		expect(tools.map((entry) => entry.definition.name)).toEqual([
+			'get_provider_info',
+		]);
+		expect(tool).toBeDefined();
+
+		const body = parse_tool_body(await tool!.handler({}));
+
+		expect(
+			body.providers.map((provider: { id: string }) => provider.id),
+		).toEqual([
+			'tavily',
+			'brave',
+			'kagi',
+			'exa',
+			'kagi_enrichment',
+			'github',
+			'kagi_fastgpt',
+			'exa_answer',
+			'linkup',
+			'tavily:extract',
+			'kagi:summarize',
+			'firecrawl:scrape',
+			'firecrawl:crawl',
+			'firecrawl:map',
+			'firecrawl:extract',
+			'firecrawl:actions',
+			'exa:contents',
+			'exa:similar',
+		]);
+		expect(
+			body.providers.every(
+				(provider: { enabled: boolean }) =>
+					provider.enabled === false,
+			),
+		).toBe(true);
+	}, 15_000);
+
+	it('enables only configured providers and reports timeouts and tools', async () => {
+		const { tool } = await load_provider_info({
+			BRAVE_API_KEY: SECRET,
+		});
+
+		const body = parse_tool_body(await tool!.handler({}));
+		const by_id = Object.fromEntries(
+			body.providers.map((provider: { id: string }) => [
+				provider.id,
+				provider,
+			]),
+		);
+
+		expect(by_id.brave).toEqual({
+			id: 'brave',
+			tools: ['web_search'],
+			timeout: config.search.brave.timeout,
+			enabled: true,
+			cooldown: false,
+			last_error_type: null,
+		});
+		expect(by_id.tavily).toEqual({
+			id: 'tavily',
+			tools: ['web_search'],
+			timeout: config.search.tavily.timeout,
+			enabled: false,
+			cooldown: false,
+			last_error_type: null,
+		});
+		expect(by_id.github).toEqual({
+			id: 'github',
+			tools: ['github_search'],
+			timeout: config.search.github.timeout,
+			enabled: false,
+			cooldown: false,
+			last_error_type: null,
+		});
+		expect(by_id['firecrawl:scrape']).toEqual({
+			id: 'firecrawl:scrape',
+			tools: ['web_extract'],
+			timeout: config.processing.firecrawl_scrape.timeout,
+			enabled: false,
+			cooldown: false,
+			last_error_type: null,
+		});
+		expect(by_id.kagi_fastgpt).toEqual({
+			id: 'kagi_fastgpt',
+			tools: ['ai_search'],
+			timeout: config.ai_response.kagi_fastgpt.timeout,
+			enabled: false,
+			cooldown: false,
+			last_error_type: null,
+		});
+	});
+
+	it('never returns keys, tokens, or secrets', async () => {
+		const { tool } = await load_provider_info({
+			BRAVE_API_KEY: SECRET,
+			TAVILY_API_KEY: 'tavily-secret-205',
+		});
+
+		const response = await tool!.handler({});
+		const body = parse_tool_body(response);
+		const strings = collect_strings(body);
+
+		expect(response.content[0].text).not.toContain(SECRET);
+		expect(response.content[0].text).not.toContain(
+			'tavily-secret-205',
+		);
+		expect(strings).not.toEqual(
+			expect.arrayContaining([
+				expect.stringMatching(
+					/api[_-]?key|token|secret|authorization|password|bearer/i,
+				),
+			]),
+		);
+	});
+
+	it('filters by provider id or name', async () => {
+		const { tool } = await load_provider_info({
+			FIRECRAWL_API_KEY: 'firecrawl-key',
+		});
+
+		const by_id = parse_tool_body(
+			await tool!.handler({ provider: 'firecrawl:scrape' }),
+		);
+		expect(by_id.providers).toEqual([
+			expect.objectContaining({
+				id: 'firecrawl:scrape',
+				tools: ['web_extract'],
+				enabled: true,
+			}),
+		]);
+
+		const by_name = parse_tool_body(
+			await tool!.handler({ provider: 'firecrawl' }),
+		);
+		expect(
+			by_name.providers.map(
+				(provider: { id: string }) => provider.id,
+			),
+		).toEqual([
+			'firecrawl:scrape',
+			'firecrawl:crawl',
+			'firecrawl:map',
+			'firecrawl:extract',
+			'firecrawl:actions',
+		]);
+	});
+
+	it('surfaces last error type from a real provider failure', async () => {
+		const { tools, tool } = await load_provider_info({
+			BRAVE_API_KEY: SECRET,
+		});
+		const web_search = tools.find(
+			(entry) => entry.definition.name === 'web_search',
+		)!;
+
+		vi.stubGlobal(
+			'fetch',
+			vi
+				.fn()
+				.mockImplementation(() =>
+					Promise.resolve(new Response('nope', { status: 401 })),
+				),
+		);
+		await web_search.handler({
+			query: 'example',
+			provider: 'brave',
+		});
+
+		const body = parse_tool_body(await tool!.handler({}));
+		const brave = body.providers.find(
+			(provider: { id: string }) => provider.id === 'brave',
+		);
+
+		expect(brave).toEqual({
+			id: 'brave',
+			tools: ['web_search'],
+			timeout: config.search.brave.timeout,
+			enabled: true,
+			cooldown: false,
+			last_error_type: ErrorType.AUTH_ERROR,
+		});
+		expect(JSON.stringify(body)).not.toContain(SECRET);
+	});
+
+	it('exposes cooldown when the last error is a rate limit', async () => {
+		const { tool } = await load_provider_info({
+			BRAVE_API_KEY: SECRET,
+		});
+		const { record_provider_error } =
+			await import('../provider-runtime.js');
+		const { ProviderError } = await import('../../common/types.js');
+
+		record_provider_error(
+			new ProviderError(
+				ErrorType.RATE_LIMIT,
+				`Rate limit exceeded for brave using ${SECRET}`,
+				'brave',
+				{
+					reset_time: new Date(Date.now() + 60_000),
+					retryable: true,
+				},
+			),
+		);
+
+		const body = parse_tool_body(await tool!.handler({}));
+		const brave = body.providers.find(
+			(provider: { id: string }) => provider.id === 'brave',
+		);
+
+		expect(brave).toEqual({
+			id: 'brave',
+			tools: ['web_search'],
+			timeout: config.search.brave.timeout,
+			enabled: true,
+			cooldown: true,
+			last_error_type: ErrorType.RATE_LIMIT,
+		});
+		expect(JSON.stringify(body)).not.toContain(SECRET);
+	});
+});

--- a/src/server/tools/provider-info.ts
+++ b/src/server/tools/provider-info.ts
@@ -1,0 +1,40 @@
+import { McpServer } from 'tmcp';
+import type { GenericSchema } from 'valibot';
+import * as v from 'valibot';
+import { list_provider_info } from '../provider-info.js';
+import type { ProviderStatus } from '../provider-registry.js';
+import { create_json_tool_response } from './responses.js';
+
+export const register_provider_info = (
+	server: McpServer<GenericSchema>,
+	get_entries: () => readonly ProviderStatus[],
+) => {
+	server.tool(
+		{
+			name: 'get_provider_info',
+			description:
+				'List registered providers with non-secret runtime metadata: id, tools, timeout, enabled, cooldown, and last error type. Works with a subset of API keys. Does not return keys, tokens, or secrets.',
+			annotations: {
+				readOnlyHint: true,
+				destructiveHint: false,
+				idempotentHint: true,
+				openWorldHint: false,
+			},
+			schema: v.object({
+				provider: v.optional(
+					v.pipe(
+						v.string(),
+						v.minLength(1, 'Provider cannot be empty'),
+						v.description(
+							'Optional provider id or name to filter the listing',
+						),
+					),
+				),
+			}),
+		},
+		async ({ provider }) =>
+			create_json_tool_response({
+				providers: list_provider_info(get_entries(), provider),
+			}),
+	);
+};

--- a/src/server/tools/responses.test.ts
+++ b/src/server/tools/responses.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import { ErrorType, ProviderError } from '../../common/types.js';
 import {
+	clear_provider_runtime,
+	get_provider_runtime,
+} from '../provider-runtime.js';
+import {
 	create_error_tool_response,
 	create_json_tool_response,
 	handle_tool_result,
@@ -16,6 +20,7 @@ afterEach(() => {
 		process.env.OMNISEARCH_LARGE_RESULT_MODE =
 			original_large_result_mode;
 	}
+	clear_provider_runtime();
 });
 
 describe('tool responses', () => {
@@ -93,6 +98,24 @@ describe('tool responses', () => {
 				},
 			],
 		});
+	});
+
+	it('records last provider error type without the message', async () => {
+		await handle_tool_result('web_search', async () => {
+			throw new ProviderError(
+				ErrorType.RATE_LIMIT,
+				'Rate limit exceeded for brave using sk-secret',
+				'brave',
+				{ retryable: true },
+			);
+		});
+
+		const runtime = get_provider_runtime('brave');
+		expect(runtime).toEqual({
+			last_error_type: ErrorType.RATE_LIMIT,
+			cooldown: true,
+		});
+		expect(JSON.stringify(runtime)).not.toContain('sk-secret');
 	});
 
 	it('wraps thrown errors as MCP error responses', async () => {

--- a/src/server/tools/responses.ts
+++ b/src/server/tools/responses.ts
@@ -3,6 +3,7 @@ import {
 	handle_large_result,
 	type LargeResultMode,
 } from '../../common/results.js';
+import { record_provider_error } from '../provider-runtime.js';
 
 export const create_json_tool_response = (payload: unknown) => ({
 	content: [
@@ -34,6 +35,7 @@ export const handle_tool_result = async <T>(
 			}),
 		);
 	} catch (error) {
+		record_provider_error(error);
 		return create_error_tool_response(error as Error);
 	}
 };


### PR DESCRIPTION
## Summary
- Add `get_provider_info` so agents can see which registered providers this deploy can actually call before they fan out.
- Each entry includes `id`, `tools`, `timeout`, `enabled`, `cooldown`, and `last_error_type` only.
- Keys, tokens, and secrets are never returned. The tool works when only a subset of API keys is present, including when none are set.

## Scope
- New always-registered MCP tool plus in-memory last-error/cooldown tracking from provider failures.
- Timeout values come from existing `config` entries.
- README and changeset only. Existing provider tools and status resources are unchanged aside from registering this meta tool.

## Verification
- `pnpm run check` — pass, 0 warnings
- `pnpm run test` — 119 passed
- `pnpm run build` — pass
- Example: with only `BRAVE_API_KEY` set, `get_provider_info` lists `brave` as `enabled: true` and other providers as `enabled: false`. A 401 from `web_search` records `last_error_type: AUTH_ERROR` without leaking the key.

## Impact
- Additive. `get_provider_info` is registered even when no provider keys are configured.
- No breaking changes and no new API key requirements.

Fixes #205