### PR TITLE
feat: query-intent auto-routing when provider is omitted

### DIFF
--- a/.changeset/calm-auto-routing.md
+++ b/.changeset/calm-auto-routing.md
@@ -1,0 +1,5 @@
+---
+'mcp-omnisearch': patch
+---
+
+feat: auto-route omitted or auto provider from query signals

--- a/README.md
+++ b/README.md
@@ -74,7 +74,9 @@ working.
 
 ### `web_search`
 
-Search the web with Tavily, Brave, Kagi, Exa, or Kagi Enrichment.
+Search the web with Tavily, Brave, Kagi, Exa, or Kagi Enrichment. Omit
+`provider` or set it to `auto` to pick one configured engine from
+query signals. An explicit provider always wins.
 
 ```json
 {
@@ -87,6 +89,7 @@ Search the web with Tavily, Brave, Kagi, Exa, or Kagi Enrichment.
 ### `ai_search`
 
 Get sourced AI answers with Kagi FastGPT, Exa Answer, or Linkup.
+`provider` may be omitted or `auto`.
 
 ```json
 {
@@ -110,7 +113,8 @@ Search GitHub code, repositories, or users.
 ### `web_extract`
 
 Extract, crawl, scrape, summarize, or find similar content with
-Tavily, Kagi, Firecrawl, or Exa.
+Tavily, Kagi, Firecrawl, or Exa. Omit `provider` or set `auto` to pick
+one configured engine from the URL and mode.
 
 ```json
 {

--- a/docs/provider-selection.md
+++ b/docs/provider-selection.md
@@ -42,6 +42,47 @@ search only. See
 | `firecrawl` | `FIRECRAWL_API_KEY` | `scrape`, `crawl`, `map`, `extract`, `actions` | Scraping, crawling, site maps, structured extraction, and browser actions. |
 | `exa`       | `EXA_API_KEY`       | `contents`, `similar`                          | Page content retrieval and semantically similar URLs.                      |
 
+## Auto-routing
+
+When `provider` is omitted or set to `auto` on `web_search`,
+`ai_search`, or `web_extract`, Omnisearch scores **configured**
+providers from query (or URL) signals and picks **exactly one**
+winner. This is not multi-provider fan-out.
+
+An explicit `provider` value such as `tavily` always wins.
+
+If no configured provider is eligible — for example `web_extract` with
+`mode: "crawl"` when only Tavily is configured — the tool fails
+visibly instead of inventing results.
+
+### Signals
+
+| Signal                | Examples                        | Prefers             |
+| --------------------- | ------------------------------- | ------------------- |
+| Operators             | `site:`, `filetype:`, `before:` | Brave, Kagi, Tavily |
+| Freshness / news      | `today`, `latest news`          | Tavily, Brave       |
+| Docs / code           | `documentation`, `how to`       | Brave, Kagi, Tavily |
+| Semantic / academic   | `similar`, `arxiv`, papers      | Exa                 |
+| Specialized indexes   | `enrichment`, non-mainstream    | Kagi Enrichment     |
+| Deep AI questions     | `deep`, `comprehensive`         | Linkup              |
+| Semantic AI questions | `similar`, meaning              | Exa Answer          |
+| Default AI answers    | generic questions               | Kagi FastGPT        |
+| Video / podcast URLs  | YouTube, Vimeo                  | Kagi                |
+| Documentation URLs    | `docs.*`, `/docs`               | Firecrawl           |
+| Generic extraction    | other URLs                      | Tavily              |
+
+### Tie-break priority
+
+Equal scores use this documented order:
+
+- `web_search`: tavily > brave > kagi > exa > kagi_enrichment
+- `ai_search`: kagi_fastgpt > exa_answer > linkup
+- `web_extract`: tavily > firecrawl > kagi > exa
+
+The last routing decision (winner, reason, and scores) is available
+from `get_last_routing_decision()` for opt-in diagnostics. Default
+tool payloads stay unchanged.
+
 ## Provider choice cheatsheet
 
 - Need native operators like `filetype:pdf`, `intitle:`, or `before:`?

--- a/src/server/auto-routing.test.ts
+++ b/src/server/auto-routing.test.ts
@@ -1,0 +1,316 @@
+import { describe, expect, it } from 'vitest';
+import { ErrorType, ProviderError } from '../common/types.js';
+import {
+	AI_SEARCH_PRIORITY,
+	WEB_EXTRACT_PRIORITY,
+	WEB_SEARCH_PRIORITY,
+	detect_query_signals,
+	get_last_routing_decision,
+	is_auto_provider,
+	select_provider,
+} from './auto-routing.js';
+
+const web_search_candidates = WEB_SEARCH_PRIORITY.map((name) => ({
+	name,
+}));
+
+const ai_search_candidates = AI_SEARCH_PRIORITY.map((name) => ({
+	name,
+}));
+
+const web_extract_candidates = [
+	{ name: 'tavily', modes: ['extract'] },
+	{
+		name: 'firecrawl',
+		modes: ['scrape', 'crawl', 'map', 'extract', 'actions'],
+	},
+	{ name: 'kagi', modes: ['summarize'] },
+	{ name: 'exa', modes: ['contents', 'similar'] },
+];
+
+describe('is_auto_provider', () => {
+	it('treats omitted and auto as auto-routing', () => {
+		expect(is_auto_provider(undefined)).toBe(true);
+		expect(is_auto_provider('auto')).toBe(true);
+		expect(is_auto_provider('AUTO')).toBe(true);
+	});
+
+	it('treats an explicit provider name as an override', () => {
+		expect(is_auto_provider('tavily')).toBe(false);
+		expect(is_auto_provider('brave')).toBe(false);
+	});
+});
+
+describe('detect_query_signals', () => {
+	it('detects operator, freshness, news, and semantic signals', () => {
+		expect(
+			detect_query_signals('site:docs.svelte.dev svelte'),
+		).toEqual(expect.arrayContaining(['operators']));
+		expect(
+			detect_query_signals('latest news today about the fed'),
+		).toEqual(expect.arrayContaining(['freshness', 'news']));
+		expect(
+			detect_query_signals(
+				'similar research papers about transformers',
+			),
+		).toEqual(expect.arrayContaining(['semantic']));
+	});
+
+	it('detects docs, academic, and extract-oriented signals', () => {
+		expect(
+			detect_query_signals('sveltekit documentation how to'),
+		).toEqual(expect.arrayContaining(['docs_code']));
+		expect(
+			detect_query_signals('arxiv transformer architecture paper'),
+		).toEqual(expect.arrayContaining(['academic']));
+		expect(
+			detect_query_signals('https://www.youtube.com/watch?v=abc'),
+		).toEqual(expect.arrayContaining(['video']));
+		expect(
+			detect_query_signals(
+				'https://docs.python.org/3/library/os.html',
+			),
+		).toEqual(expect.arrayContaining(['docs_site']));
+	});
+});
+
+describe('select_provider', () => {
+	it('lets an explicit provider win without scoring', () => {
+		const decision = select_provider({
+			tool: 'web_search',
+			provider: 'tavily',
+			query: 'similar research papers about transformers',
+			candidates: web_search_candidates,
+		});
+
+		expect(decision).toEqual(
+			expect.objectContaining({
+				tool: 'web_search',
+				provider: 'tavily',
+				source: 'explicit',
+			}),
+		);
+		expect(decision.scores).toEqual([]);
+		expect(get_last_routing_decision()).toEqual(decision);
+	});
+
+	it('picks exactly one configured winner when provider is omitted', () => {
+		const decision = select_provider({
+			tool: 'web_search',
+			query: 'what is the capital of france',
+			candidates: web_search_candidates,
+		});
+
+		expect(decision.source).toBe('auto');
+		expect(decision.provider).toBe('tavily');
+		expect(decision.scores).toHaveLength(
+			web_search_candidates.length,
+		);
+		expect(decision.reason.length).toBeGreaterThan(0);
+	});
+
+	it('treats provider auto the same as an omitted provider', () => {
+		const omitted = select_provider({
+			tool: 'web_search',
+			query: 'sveltekit remote functions',
+			candidates: web_search_candidates,
+		});
+		const auto = select_provider({
+			tool: 'web_search',
+			provider: 'auto',
+			query: 'sveltekit remote functions',
+			candidates: web_search_candidates,
+		});
+
+		expect(auto.provider).toBe(omitted.provider);
+		expect(auto.source).toBe('auto');
+	});
+
+	it('prefers operator-capable search engines for operator queries', () => {
+		const decision = select_provider({
+			tool: 'web_search',
+			provider: 'auto',
+			query: 'sveltekit docs filetype:pdf site:docs.svelte.dev',
+			candidates: web_search_candidates,
+		});
+
+		expect(decision.provider).toBe('brave');
+		expect(decision.signals).toEqual(
+			expect.arrayContaining(['operators', 'docs_code']),
+		);
+	});
+
+	it('prefers exa for semantic discovery queries', () => {
+		const decision = select_provider({
+			tool: 'web_search',
+			query: 'similar research papers about transformers',
+			candidates: web_search_candidates,
+		});
+
+		expect(decision.provider).toBe('exa');
+	});
+
+	it('breaks equal scores with the documented priority list', () => {
+		const decision = select_provider({
+			tool: 'web_search',
+			query: 'latest news today about the fed',
+			candidates: [
+				{ name: 'tavily' },
+				{ name: 'brave' },
+				{ name: 'exa' },
+			],
+		});
+
+		expect(decision.provider).toBe('tavily');
+		expect(WEB_SEARCH_PRIORITY[0]).toBe('tavily');
+	});
+
+	it('only scores configured providers', () => {
+		const decision = select_provider({
+			tool: 'web_search',
+			query: 'similar research papers about transformers',
+			candidates: [{ name: 'tavily' }, { name: 'brave' }],
+		});
+
+		expect(decision.provider).toBe('tavily');
+		expect(decision.scores.map((score) => score.name)).toEqual([
+			'tavily',
+			'brave',
+		]);
+	});
+
+	it('does not pick kagi_enrichment for generic queries', () => {
+		const decision = select_provider({
+			tool: 'web_search',
+			query: 'weather in berlin',
+			candidates: web_search_candidates,
+		});
+
+		expect(decision.provider).not.toBe('kagi_enrichment');
+	});
+
+	it('selects kagi_enrichment when it is the only configured provider', () => {
+		const decision = select_provider({
+			tool: 'web_search',
+			query: 'weather in berlin',
+			candidates: [{ name: 'kagi_enrichment' }],
+		});
+
+		expect(decision.provider).toBe('kagi_enrichment');
+	});
+
+	it('fails visibly when no provider is eligible', () => {
+		expect(() =>
+			select_provider({
+				tool: 'web_search',
+				query: 'anything',
+				candidates: [],
+			}),
+		).toThrow(ProviderError);
+
+		try {
+			select_provider({
+				tool: 'web_search',
+				query: 'anything',
+				candidates: [],
+			});
+		} catch (error) {
+			expect(error).toMatchObject({
+				type: ErrorType.INVALID_INPUT,
+				provider: 'web_search',
+			});
+			expect((error as ProviderError).message).toMatch(
+				/no eligible provider/i,
+			);
+		}
+	});
+
+	it('fails visibly when extract mode has no configured provider', () => {
+		expect(() =>
+			select_provider({
+				tool: 'web_extract',
+				url: 'https://example.com',
+				mode: 'crawl',
+				candidates: [{ name: 'tavily', modes: ['extract'] }],
+			}),
+		).toThrow(
+			expect.objectContaining({
+				type: ErrorType.INVALID_INPUT,
+				provider: 'web_extract',
+			}),
+		);
+	});
+
+	it('routes youtube URLs to kagi when configured', () => {
+		const decision = select_provider({
+			tool: 'web_extract',
+			url: 'https://www.youtube.com/watch?v=abc',
+			candidates: web_extract_candidates,
+		});
+
+		expect(decision.provider).toBe('kagi');
+		expect(WEB_EXTRACT_PRIORITY).toContain('kagi');
+	});
+
+	it('routes documentation URLs to firecrawl when configured', () => {
+		const decision = select_provider({
+			tool: 'web_extract',
+			url: 'https://docs.python.org/3/library/os.html',
+			candidates: web_extract_candidates,
+		});
+
+		expect(decision.provider).toBe('firecrawl');
+	});
+
+	it('picks tavily for generic extraction by priority', () => {
+		const decision = select_provider({
+			tool: 'web_extract',
+			url: 'https://example.com/long-article',
+			candidates: web_extract_candidates,
+		});
+
+		expect(decision.provider).toBe('tavily');
+	});
+
+	it('routes deep AI queries to linkup and semantic ones to exa_answer', () => {
+		expect(
+			select_provider({
+				tool: 'ai_search',
+				query: 'deep comprehensive research on climate policy',
+				candidates: ai_search_candidates,
+			}).provider,
+		).toBe('linkup');
+
+		expect(
+			select_provider({
+				tool: 'ai_search',
+				query: 'similar concepts to attention mechanism',
+				candidates: ai_search_candidates,
+			}).provider,
+		).toBe('exa_answer');
+
+		expect(
+			select_provider({
+				tool: 'ai_search',
+				query: 'what is REST',
+				candidates: ai_search_candidates,
+			}).provider,
+		).toBe('kagi_fastgpt');
+	});
+
+	it('never fans out: one requested provider yields one winner', () => {
+		const decision = select_provider({
+			tool: 'web_search',
+			query: 'latest news and similar papers site:arxiv.org',
+			candidates: web_search_candidates,
+		});
+
+		expect(typeof decision.provider).toBe('string');
+		expect(decision.provider.includes(',')).toBe(false);
+		expect(
+			web_search_candidates.filter(
+				(candidate) => candidate.name === decision.provider,
+			),
+		).toHaveLength(1);
+	});
+});

--- a/src/server/auto-routing.ts
+++ b/src/server/auto-routing.ts
@@ -1,0 +1,390 @@
+import { parse_search_operators } from '../common/search-operators.js';
+import { ErrorType, ProviderError } from '../common/types.js';
+
+export const AUTO_PROVIDER = 'auto';
+
+export const WEB_SEARCH_PRIORITY = [
+	'tavily',
+	'brave',
+	'kagi',
+	'exa',
+	'kagi_enrichment',
+] as const;
+
+export const AI_SEARCH_PRIORITY = [
+	'kagi_fastgpt',
+	'exa_answer',
+	'linkup',
+] as const;
+
+export const WEB_EXTRACT_PRIORITY = [
+	'tavily',
+	'firecrawl',
+	'kagi',
+	'exa',
+] as const;
+
+export type AutoRoutingTool =
+	| 'web_search'
+	| 'ai_search'
+	| 'web_extract';
+
+export type QuerySignal =
+	| 'operators'
+	| 'freshness'
+	| 'news'
+	| 'semantic'
+	| 'docs_code'
+	| 'academic'
+	| 'enrichment'
+	| 'deep'
+	| 'video'
+	| 'summarize'
+	| 'docs_site'
+	| 'similar';
+
+export interface RoutingCandidate {
+	name: string;
+	modes?: readonly string[];
+}
+
+export interface RoutingScore {
+	name: string;
+	score: number;
+	matched_signals: QuerySignal[];
+}
+
+export interface RoutingDecision {
+	tool: AutoRoutingTool;
+	provider: string;
+	source: 'explicit' | 'auto';
+	reason: string;
+	signals: QuerySignal[];
+	scores: RoutingScore[];
+}
+
+export interface SelectProviderInput {
+	tool: AutoRoutingTool;
+	provider?: string;
+	query?: string;
+	url?: string | string[];
+	mode?: string;
+	include_domains?: string[];
+	exclude_domains?: string[];
+	candidates: readonly RoutingCandidate[];
+}
+
+type SignalOrGeneral = QuerySignal | 'general';
+type WeightTable = Record<
+	string,
+	Partial<Record<SignalOrGeneral, number>>
+>;
+
+const SIGNAL_ORDER: readonly QuerySignal[] = [
+	'operators',
+	'freshness',
+	'news',
+	'semantic',
+	'docs_code',
+	'academic',
+	'enrichment',
+	'deep',
+	'video',
+	'summarize',
+	'docs_site',
+	'similar',
+];
+
+const SIGNAL_PATTERNS: ReadonlyArray<readonly [QuerySignal, RegExp]> =
+	[
+		[
+			'freshness',
+			/\b(today|yesterday|latest|breaking|this week|this month|last 24|past week|past month|recent)\b/i,
+		],
+		[
+			'news',
+			/\b(news|headline|headlines|reuters|bloomberg|cnn|bbc|nytimes|new york times)\b/i,
+		],
+		[
+			'semantic',
+			/\b(similar|related to|like this|semantic|discover|research papers|find articles|meaning)\b/i,
+		],
+		[
+			'docs_code',
+			/\b(docs|documentation|api reference|github|stackoverflow|stack overflow|npm|pypi|how to|typescript|changelog)\b/i,
+		],
+		[
+			'academic',
+			/\b(arxiv|doi|research papers?|journal|pubmed|scholar|preprint|papers?)\b/i,
+		],
+		[
+			'enrichment',
+			/\b(specialized|non-mainstream|teclis|tinygem|enrichment)\b/i,
+		],
+		[
+			'deep',
+			/\b(deep|thorough|comprehensive|agentic|in-depth|in depth)\b/i,
+		],
+		['video', /\b(youtube\.com|youtu\.be|vimeo\.com|podcast)\b/i],
+		['summarize', /\b(summarize|summary|tldr|tl;dr)\b/i],
+		[
+			'docs_site',
+			/\bdocs\.|developer\.|\/docs(?:\/|$)|\/api(?:\/|$)|\/reference(?:\/|$)/i,
+		],
+		['similar', /\b(similar pages|find similar|pages like)\b/i],
+	];
+
+const WEB_SEARCH_WEIGHTS: WeightTable = {
+	tavily: {
+		general: 1,
+		freshness: 3,
+		news: 2,
+		docs_code: 2,
+		operators: 2,
+	},
+	brave: {
+		general: 1,
+		operators: 4,
+		news: 3,
+		freshness: 2,
+		docs_code: 3,
+	},
+	kagi: {
+		general: 1,
+		operators: 4,
+		docs_code: 3,
+		academic: 2,
+	},
+	exa: { general: 1, semantic: 5, academic: 4 },
+	kagi_enrichment: { news: 2, academic: 2, enrichment: 5 },
+};
+
+const AI_SEARCH_WEIGHTS: WeightTable = {
+	kagi_fastgpt: { general: 1 },
+	exa_answer: { general: 1, semantic: 4 },
+	linkup: { general: 1, deep: 4 },
+};
+
+const WEB_EXTRACT_WEIGHTS: WeightTable = {
+	tavily: { general: 1 },
+	firecrawl: { general: 1, docs_site: 3 },
+	kagi: { video: 5, summarize: 4 },
+	exa: { general: 1, similar: 5 },
+};
+
+const PRIORITY_BY_TOOL: Record<AutoRoutingTool, readonly string[]> = {
+	web_search: WEB_SEARCH_PRIORITY,
+	ai_search: AI_SEARCH_PRIORITY,
+	web_extract: WEB_EXTRACT_PRIORITY,
+};
+
+const WEIGHTS_BY_TOOL: Record<AutoRoutingTool, WeightTable> = {
+	web_search: WEB_SEARCH_WEIGHTS,
+	ai_search: AI_SEARCH_WEIGHTS,
+	web_extract: WEB_EXTRACT_WEIGHTS,
+};
+
+const FRESHNESS_OPERATORS = new Set(['before', 'after']);
+
+let last_routing_decision: RoutingDecision | undefined;
+
+/**
+ * True when the caller omitted provider or asked for auto-routing.
+ */
+export const is_auto_provider = (
+	provider: string | undefined,
+): boolean =>
+	provider === undefined ||
+	provider.trim().toLowerCase() === AUTO_PROVIDER;
+
+/**
+ * Return the last explicit or auto-routing decision for diagnostics.
+ */
+export const get_last_routing_decision = ():
+	| RoutingDecision
+	| undefined => last_routing_decision;
+
+const unique_signals = (signals: Iterable<QuerySignal>) => {
+	const found = new Set(signals);
+	return SIGNAL_ORDER.filter((signal) => found.has(signal));
+};
+
+/**
+ * Classify a query or URL into deterministic routing signals.
+ */
+export const detect_query_signals = (text: string): QuerySignal[] => {
+	const found = new Set<QuerySignal>();
+	const parsed = parse_search_operators(text);
+
+	if (parsed.operators.length > 0) {
+		found.add('operators');
+	}
+	if (
+		parsed.operators.some((operator) =>
+			FRESHNESS_OPERATORS.has(operator.type),
+		)
+	) {
+		found.add('freshness');
+	}
+
+	for (const [signal, pattern] of SIGNAL_PATTERNS) {
+		if (pattern.test(text)) {
+			found.add(signal);
+		}
+	}
+
+	return unique_signals(found);
+};
+
+const priority_index = (
+	priority: readonly string[],
+	name: string,
+) => {
+	const index = priority.indexOf(name);
+	return index === -1 ? priority.length : index;
+};
+
+const eligible_candidates = (
+	input: SelectProviderInput,
+): RoutingCandidate[] => {
+	const seen = new Set<string>();
+	const eligible: RoutingCandidate[] = [];
+
+	for (const candidate of input.candidates) {
+		if (seen.has(candidate.name)) continue;
+		if (
+			input.mode &&
+			candidate.modes &&
+			candidate.modes.length > 0 &&
+			!candidate.modes.includes(input.mode)
+		) {
+			continue;
+		}
+		seen.add(candidate.name);
+		eligible.push(candidate);
+	}
+
+	return eligible;
+};
+
+const routing_text = (input: SelectProviderInput) =>
+	[
+		input.query,
+		Array.isArray(input.url) ? input.url.join(' ') : input.url,
+	]
+		.filter((value): value is string => Boolean(value))
+		.join(' ');
+
+const score_candidates = (
+	tool: AutoRoutingTool,
+	candidates: readonly RoutingCandidate[],
+	signals: readonly QuerySignal[],
+): RoutingScore[] => {
+	const weights = WEIGHTS_BY_TOOL[tool];
+
+	return candidates.map((candidate) => {
+		const table = weights[candidate.name] ?? { general: 1 };
+		let score = table.general ?? 0;
+		const matched_signals: QuerySignal[] = [];
+
+		for (const signal of signals) {
+			const bump = table[signal] ?? 0;
+			if (bump > 0) {
+				score += bump;
+				matched_signals.push(signal);
+			}
+		}
+
+		return {
+			name: candidate.name,
+			score,
+			matched_signals,
+		};
+	});
+};
+
+const pick_winner = (
+	scores: readonly RoutingScore[],
+	priority: readonly string[],
+) =>
+	[...scores].sort((left, right) => {
+		if (right.score !== left.score) {
+			return right.score - left.score;
+		}
+		return (
+			priority_index(priority, left.name) -
+			priority_index(priority, right.name)
+		);
+	})[0];
+
+const auto_reason = (
+	winner: RoutingScore,
+	signals: readonly QuerySignal[],
+	priority: readonly string[],
+) => {
+	const signal_text =
+		signals.length > 0 ? signals.join(', ') : 'none';
+	return `auto-routed to ${winner.name} (score ${winner.score}) from signals: ${signal_text}; ties break by ${priority.join(' > ')}`;
+};
+
+const remember = (decision: RoutingDecision) => {
+	last_routing_decision = decision;
+	return decision;
+};
+
+/**
+ * Pick exactly one provider. Explicit names always win; omitted or
+ * "auto" scores configured candidates from query signals.
+ */
+export const select_provider = (
+	input: SelectProviderInput,
+): RoutingDecision => {
+	if (!is_auto_provider(input.provider)) {
+		return remember({
+			tool: input.tool,
+			provider: input.provider!.trim(),
+			source: 'explicit',
+			reason: `explicit provider override: ${input.provider!.trim()}`,
+			signals: [],
+			scores: [],
+		});
+	}
+
+	const eligible = eligible_candidates(input);
+	if (eligible.length === 0) {
+		const mode_text = input.mode ? ` mode "${input.mode}"` : '';
+		throw new ProviderError(
+			ErrorType.INVALID_INPUT,
+			`No eligible provider for ${input.tool}${mode_text}. Configure a matching API key or pass an explicit provider.`,
+			input.tool,
+		);
+	}
+
+	const signals = detect_query_signals(routing_text(input));
+	if (
+		(input.include_domains?.length ?? 0) > 0 ||
+		(input.exclude_domains?.length ?? 0) > 0
+	) {
+		if (!signals.includes('operators')) {
+			signals.push('operators');
+		}
+	}
+
+	const ordered_signals = unique_signals(signals);
+	const scores = score_candidates(
+		input.tool,
+		eligible,
+		ordered_signals,
+	);
+	const priority = PRIORITY_BY_TOOL[input.tool];
+	const winner = pick_winner(scores, priority);
+
+	return remember({
+		tool: input.tool,
+		provider: winner.name,
+		source: 'auto',
+		reason: auto_reason(winner, ordered_signals, priority),
+		signals: ordered_signals,
+		scores,
+	});
+};

--- a/src/server/tools/ai-search.ts
+++ b/src/server/tools/ai-search.ts
@@ -7,10 +7,12 @@ import {
 	type AISearchProviderName,
 } from '../provider-definitions.js';
 import { ProviderRegistry } from '../provider-registry.js';
+import { select_provider } from '../auto-routing.js';
 import { handle_tool_result } from './responses.js';
 import {
 	large_result_mode_schema,
 	limit_schema,
+	optional_provider_schema,
 	query_schema,
 } from './schemas.js';
 
@@ -39,7 +41,7 @@ export const register_ai_search = (
 		{
 			name: 'ai_search',
 			description:
-				'Get AI-powered answers with citations and reasoning. Use when you need synthesized answers rather than raw search results. Providers: kagi_fastgpt (fast ~900ms answers), exa_answer (semantic AI), linkup (deep agentic search with sources).',
+				'Get AI-powered answers with citations and reasoning. Use when you need synthesized answers rather than raw search results. Providers: kagi_fastgpt (fast ~900ms answers), exa_answer (semantic AI), linkup (deep agentic search with sources). Omit provider or set auto to pick exactly one configured engine from query signals.',
 			annotations: {
 				readOnlyHint: true,
 				destructiveHint: false,
@@ -48,9 +50,9 @@ export const register_ai_search = (
 			},
 			schema: v.object({
 				query: query_schema,
-				provider: v.pipe(
-					v.picklist(provider_names),
-					v.description('AI search provider to use'),
+				provider: optional_provider_schema(
+					provider_names,
+					'AI search provider to use. Omit or set to "auto" to pick one configured provider from query signals.',
 				),
 				limit: limit_schema,
 				large_result_mode: large_result_mode_schema,
@@ -60,7 +62,18 @@ export const register_ai_search = (
 			handle_tool_result(
 				'ai_search',
 				async () => {
-					const selected = providers.require(provider, 'ai_search');
+					const decision = select_provider({
+						tool: 'ai_search',
+						provider,
+						query,
+						candidates: providers.names().map((name) => ({
+							name,
+						})),
+					});
+					const selected = providers.require(
+						decision.provider,
+						'ai_search',
+					);
 
 					return selected.search({
 						query,

--- a/src/server/tools/contract.test.ts
+++ b/src/server/tools/contract.test.ts
@@ -152,6 +152,11 @@ describe('MCP tool contract', () => {
 			v.safeParse(schema, { query: 'test', provider: 'kagi' })
 				.success,
 		).toBe(false);
+		expect(v.safeParse(schema, { query: 'test' }).success).toBe(true);
+		expect(
+			v.safeParse(schema, { query: 'test', provider: 'auto' })
+				.success,
+		).toBe(true);
 	});
 
 	it('validates public web_extract payloads and unavailable modes at the MCP layer', async () => {
@@ -211,21 +216,22 @@ describe('MCP tool contract', () => {
 
 		vi.stubGlobal(
 			'fetch',
-			vi.fn().mockResolvedValueOnce(
-				new Response(
-					JSON.stringify({
-						web: {
-							results: [
-								{
-									title: 'Example',
-									url: 'https://example.com',
-									description: 'Example result',
-								},
-							],
-						},
-					}),
-					{ status: 200 },
-				),
+			vi.fn(
+				async () =>
+					new Response(
+						JSON.stringify({
+							web: {
+								results: [
+									{
+										title: 'Example',
+										url: 'https://example.com',
+										description: 'Example result',
+									},
+								],
+							},
+						}),
+						{ status: 200 },
+					),
 			),
 		);
 
@@ -242,6 +248,12 @@ describe('MCP tool contract', () => {
 				source_provider: 'brave',
 			},
 		]);
+
+		const omitted = await tool.handler({
+			query: 'example',
+			large_result_mode: 'inline',
+		});
+		expect(parse_tool_body(omitted)[0].source_provider).toBe('brave');
 
 		vi.stubGlobal(
 			'fetch',
@@ -312,5 +324,92 @@ describe('MCP tool contract', () => {
 				read_hint: expect.stringContaining('Use Read tool'),
 			}),
 		);
+	});
+
+	it('auto-routes omitted web_search to one configured provider', async () => {
+		const { tools } = await load_contract({
+			TAVILY_API_KEY: 'tavily-key',
+			EXA_API_KEY: 'exa-key',
+		});
+		const tool = tools.find(
+			(entry) => entry.definition.name === 'web_search',
+		)!;
+		const fetch = vi.fn(async (url: string) => {
+			if (url.includes('api.exa.ai')) {
+				return new Response(
+					JSON.stringify({
+						requestId: 'req-1',
+						results: [
+							{
+								id: 'id-1',
+								title: 'Exa result',
+								url: 'https://example.com',
+								text: 'Body',
+								score: 0.8,
+							},
+						],
+					}),
+					{ status: 200 },
+				);
+			}
+			return new Response(
+				JSON.stringify({
+					results: [
+						{
+							title: 'Tavily result',
+							url: 'https://example.com',
+							content: 'Body',
+							score: 0.9,
+						},
+					],
+				}),
+				{ status: 200 },
+			);
+		});
+		vi.stubGlobal('fetch', fetch);
+
+		const routed = parse_tool_body(
+			await tool.handler({
+				query: 'similar research papers about transformers',
+				large_result_mode: 'inline',
+			}),
+		);
+		expect(routed[0].source_provider).toBe('exa');
+		expect(fetch).toHaveBeenCalledTimes(1);
+		expect(fetch.mock.calls[0]?.[0]).toContain('api.exa.ai');
+
+		const explicit = parse_tool_body(
+			await tool.handler({
+				query: 'similar research papers about transformers',
+				provider: 'tavily',
+				large_result_mode: 'inline',
+			}),
+		);
+		expect(explicit[0].source_provider).toBe('tavily');
+		expect(fetch).toHaveBeenCalledTimes(2);
+		expect(fetch.mock.calls[1]?.[0]).toContain('api.tavily.com');
+	});
+
+	it('fails visibly when auto extract has no eligible provider', async () => {
+		const { tools } = await load_contract({
+			TAVILY_API_KEY: 'tavily-key',
+		});
+		const tool = tools.find(
+			(entry) => entry.definition.name === 'web_extract',
+		)!;
+		const response = await tool.handler({
+			url: 'https://example.com',
+			mode: 'crawl',
+		});
+		const body = parse_tool_body(response);
+
+		expect(response.isError).toBe(true);
+		expect(body).toEqual(
+			expect.objectContaining({
+				type: 'INVALID_INPUT',
+				provider: 'web_extract',
+			}),
+		);
+		expect(body.error).toMatch(/no eligible provider/i);
 	});
 });

--- a/src/server/tools/schemas.test.ts
+++ b/src/server/tools/schemas.test.ts
@@ -6,6 +6,7 @@ import {
 	include_raw_contents_schema,
 	large_result_mode_schema,
 	limit_schema,
+	optional_provider_schema,
 	query_schema,
 	url_or_urls_schema,
 } from './schemas.js';
@@ -15,6 +16,18 @@ describe('tool schemas', () => {
 		expect(v.parse(query_schema, 'sveltekit')).toBe('sveltekit');
 		expect(v.safeParse(query_schema, '').success).toBe(false);
 		expect(v.safeParse(query_schema, '   ').success).toBe(false);
+	});
+
+	it('accepts omitted or auto provider and rejects unknown names', () => {
+		const schema = optional_provider_schema(
+			['tavily', 'brave'],
+			'Search provider to use',
+		);
+
+		expect(v.safeParse(schema, undefined).success).toBe(true);
+		expect(v.parse(schema, 'auto')).toBe('auto');
+		expect(v.parse(schema, 'tavily')).toBe('tavily');
+		expect(v.safeParse(schema, 'kagi').success).toBe(false);
 	});
 
 	it('bounds result limits', () => {

--- a/src/server/tools/schemas.ts
+++ b/src/server/tools/schemas.ts
@@ -1,7 +1,19 @@
 import * as v from 'valibot';
+import { AUTO_PROVIDER } from '../auto-routing.js';
 
 const DOMAIN_PATTERN =
 	/^(?:\*\.)?(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,63}$/;
+
+export const optional_provider_schema = (
+	provider_names: string[],
+	description: string,
+) =>
+	v.optional(
+		v.pipe(
+			v.picklist([...provider_names, AUTO_PROVIDER]),
+			v.description(description),
+		),
+	);
 
 export const query_schema = v.pipe(
 	v.string(),

--- a/src/server/tools/web-extract.ts
+++ b/src/server/tools/web-extract.ts
@@ -15,10 +15,12 @@ import {
 	type WebExtractProvider,
 } from '../provider-definitions.js';
 import { ProviderRegistry } from '../provider-registry.js';
+import { select_provider } from '../auto-routing.js';
 import { handle_tool_result } from './responses.js';
 import {
 	include_raw_contents_schema,
 	large_result_mode_schema,
+	optional_provider_schema,
 	url_or_urls_schema,
 } from './schemas.js';
 
@@ -55,7 +57,7 @@ export const register_web_extract = (
 		{
 			name: 'web_extract',
 			description:
-				'Extract, process, or summarize web content from URLs. Use when you need to read page content, summarize articles, crawl sites, or extract structured data. Providers: tavily (content extraction), kagi (summarization of pages/videos/podcasts), firecrawl (scraping/crawling/mapping/structured extraction/interactive), exa (content retrieval/similar pages).',
+				'Extract, process, or summarize web content from URLs. Use when you need to read page content, summarize articles, crawl sites, or extract structured data. Providers: tavily (content extraction), kagi (summarization of pages/videos/podcasts), firecrawl (scraping/crawling/mapping/structured extraction/interactive), exa (content retrieval/similar pages). Omit provider or set auto to pick exactly one configured engine from the URL and mode.',
 			annotations: {
 				readOnlyHint: true,
 				destructiveHint: false,
@@ -64,9 +66,9 @@ export const register_web_extract = (
 			},
 			schema: v.object({
 				url: url_or_urls_schema,
-				provider: v.pipe(
-					v.picklist(available),
-					v.description('Processing provider to use'),
+				provider: optional_provider_schema(
+					available,
+					'Processing provider to use. Omit or set to "auto" to pick one configured provider from the URL and mode.',
 				),
 				mode: v.optional(
 					v.pipe(
@@ -97,7 +99,20 @@ export const register_web_extract = (
 			handle_tool_result(
 				'web_extract',
 				async () => {
-					const provider_name = provider as WebExtractProvider;
+					const decision = select_provider({
+						tool: 'web_extract',
+						provider,
+						url,
+						mode,
+						candidates: providers.names().map((name) => ({
+							name,
+							modes: get_valid_web_extract_modes(
+								name as WebExtractProvider,
+							),
+						})),
+					});
+					const provider_name =
+						decision.provider as WebExtractProvider;
 					const resolved_mode =
 						mode || get_default_web_extract_mode(provider_name);
 					const allowed = get_valid_web_extract_modes(provider_name);
@@ -105,19 +120,19 @@ export const register_web_extract = (
 					if (!resolved_mode || !allowed.includes(resolved_mode)) {
 						throw new ProviderError(
 							ErrorType.INVALID_INPUT,
-							`Mode "${resolved_mode}" is not valid for provider "${provider}". Valid modes: ${allowed.join(', ')}`,
+							`Mode "${resolved_mode}" is not valid for provider "${provider_name}". Valid modes: ${allowed.join(', ')}`,
 							'web_extract',
 						);
 					}
 
 					const key = make_processing_provider_key(
-						provider,
+						provider_name,
 						resolved_mode,
 					);
 					const selected = providers.require(
 						key,
 						'web_extract',
-						`Provider "${provider}" with mode "${resolved_mode}" is not available. Available modes for configured providers: ${allowed.join(', ') || 'none'}.`,
+						`Provider "${provider_name}" with mode "${resolved_mode}" is not available. Available modes for configured providers: ${allowed.join(', ') || 'none'}.`,
 					);
 
 					const result = await selected.process_content(

--- a/src/server/tools/web-search.ts
+++ b/src/server/tools/web-search.ts
@@ -7,12 +7,14 @@ import {
 	type WebSearchProviderName,
 } from '../provider-definitions.js';
 import { ProviderRegistry } from '../provider-registry.js';
+import { select_provider } from '../auto-routing.js';
 import { handle_tool_result } from './responses.js';
 import {
 	exclude_domains_schema,
 	include_domains_schema,
 	large_result_mode_schema,
 	limit_schema,
+	optional_provider_schema,
 	query_schema,
 } from './schemas.js';
 
@@ -41,7 +43,7 @@ export const register_web_search = (
 		{
 			name: 'web_search',
 			description:
-				'Search the web for information. Use when you need to find web pages, articles, or data. Providers: tavily (factual/citations), brave (privacy/operators), kagi (quality/operators), exa (AI-semantic), kagi_enrichment (specialized indexes). Brave/Kagi support query operators like site:, filetype:, lang:, before:, after:.',
+				'Search the web for information. Use when you need to find web pages, articles, or data. Providers: tavily (factual/citations), brave (privacy/operators), kagi (quality/operators), exa (AI-semantic), kagi_enrichment (specialized indexes). Brave/Kagi support query operators like site:, filetype:, lang:, before:, after:. Omit provider or set auto to pick exactly one configured engine from query signals.',
 			annotations: {
 				readOnlyHint: true,
 				destructiveHint: false,
@@ -50,9 +52,9 @@ export const register_web_search = (
 			},
 			schema: v.object({
 				query: query_schema,
-				provider: v.pipe(
-					v.picklist(provider_names),
-					v.description('Search provider to use'),
+				provider: optional_provider_schema(
+					provider_names,
+					'Search provider to use. Omit or set to "auto" to pick one configured provider from query signals.',
 				),
 				limit: limit_schema,
 				include_domains: include_domains_schema,
@@ -71,7 +73,20 @@ export const register_web_search = (
 			handle_tool_result(
 				'web_search',
 				async () => {
-					const selected = providers.require(provider, 'web_search');
+					const decision = select_provider({
+						tool: 'web_search',
+						provider,
+						query,
+						include_domains,
+						exclude_domains,
+						candidates: providers.names().map((name) => ({
+							name,
+						})),
+					});
+					const selected = providers.require(
+						decision.provider,
+						'web_search',
+					);
 
 					return selected.search({
 						query,


### PR DESCRIPTION
## Summary
- When `provider` is omitted or set to `auto`, score configured providers from query/URL signals and pick **exactly one** winner.
- An explicit `provider` such as `tavily` always wins.
- If no configured provider is eligible, fail visibly with `ProviderError` instead of inventing results. This is not fan-out.

## Scope
- `src/server/auto-routing.ts` — deterministic signal scoring and documented tie-break priority.
- `web_search`, `ai_search`, and `web_extract` now accept omitted/`auto` provider.
- Docs in README and `docs/provider-selection.md`. Routing reason/scores are stored for later diagnostics (`get_last_routing_decision`); default payloads stay unchanged.

## Verification
- `pnpm run check`
- `pnpm test` (131 passed)
- `pnpm run build`

## Impact
- `provider` is optional and also accepts `auto`.
- No new API keys. Unconfigured providers stay unregistered.
- No change to explicit single-provider calls.

Fixes #190