### PR TITLE
Add news search vertical to web_search

### DIFF
--- a/.changeset/news-search-vertical.md
+++ b/.changeset/news-search-vertical.md
@@ -1,0 +1,5 @@
+---
+'mcp-omnisearch': patch
+---
+
+feat: add web_search news vertical with per-provider applied metadata

--- a/README.md
+++ b/README.md
@@ -84,6 +84,20 @@ Search the web with Tavily, Brave, Kagi, Exa, or Kagi Enrichment.
 }
 ```
 
+Optional `search_type` is `search` (default) or `news`. News uses a
+native news path for Brave (`/news/search`), Tavily (`topic=news`),
+Exa (`category=news`), and Kagi Enrichment (`/enrich/news`). Kagi
+general search stays on `/search` and reports
+`search_type.applied=false` in result metadata.
+
+```json
+{
+	"query": "what happened today in svelte",
+	"provider": "brave",
+	"search_type": "news"
+}
+```
+
 ### `ai_search`
 
 Get sourced AI answers with Kagi FastGPT, Exa Answer, or Linkup.

--- a/docs/provider-selection.md
+++ b/docs/provider-selection.md
@@ -53,3 +53,6 @@ search only. See
   `kagi_fastgpt`, `exa_answer`, or `linkup`.
 - Need to crawl/scrape/map a site? Use `web_extract` with `firecrawl`.
 - Need public code/repository/user discovery? Use `github_search`.
+- Need a news vertical? Set `search_type: "news"` on `web_search`.
+  Brave, Tavily, Exa, and Kagi Enrichment use a native news path; Kagi
+  runs general search and sets `search_type.applied=false`.

--- a/src/common/search-type.test.ts
+++ b/src/common/search-type.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import {
+	search_type_metadata,
+	with_search_type_metadata,
+} from './search-type.js';
+import type { SearchResult } from './types.js';
+
+const result = (
+	overrides: Partial<SearchResult> = {},
+): SearchResult => ({
+	title: 'Example',
+	url: 'https://example.com',
+	snippet: 'Summary',
+	source_provider: 'brave',
+	...overrides,
+});
+
+describe('search_type_metadata', () => {
+	it('marks news as applied for providers with a native news path', () => {
+		expect(search_type_metadata('brave', 'news')).toEqual({
+			requested: 'news',
+			applied: true,
+			provider: 'brave',
+			native_value: 'news',
+		});
+		expect(search_type_metadata('tavily', 'news').applied).toBe(true);
+		expect(search_type_metadata('exa', 'news').applied).toBe(true);
+		expect(search_type_metadata('kagi_enrichment', 'news')).toEqual({
+			requested: 'news',
+			applied: true,
+			provider: 'kagi_enrichment',
+			native_value: 'news',
+		});
+	});
+
+	it('marks news as not applied for providers without a native news path', () => {
+		expect(search_type_metadata('kagi', 'news')).toEqual({
+			requested: 'news',
+			applied: false,
+			provider: 'kagi',
+			reason: 'provider kagi does not support search_type news',
+		});
+	});
+
+	it('treats general search as applied for every provider', () => {
+		expect(search_type_metadata('kagi', 'search')).toEqual({
+			requested: 'search',
+			applied: true,
+			provider: 'kagi',
+			native_value: 'search',
+		});
+		expect(search_type_metadata('brave', 'search').applied).toBe(
+			true,
+		);
+	});
+});
+
+describe('with_search_type_metadata', () => {
+	it('leaves results unchanged when search_type is omitted', () => {
+		const results = [result()];
+
+		expect(with_search_type_metadata(results, 'brave')).toEqual(
+			results,
+		);
+	});
+
+	it('attaches search_type metadata without dropping existing fields', () => {
+		const results = [
+			result({
+				metadata: { age: '2 hours ago' },
+			}),
+		];
+
+		expect(
+			with_search_type_metadata(results, 'brave', 'news'),
+		).toEqual([
+			{
+				...results[0],
+				metadata: {
+					age: '2 hours ago',
+					search_type: {
+						requested: 'news',
+						applied: true,
+						provider: 'brave',
+						native_value: 'news',
+					},
+				},
+			},
+		]);
+	});
+});

--- a/src/common/search-type.ts
+++ b/src/common/search-type.ts
@@ -1,0 +1,64 @@
+import type { SearchResult, SearchType } from './types.js';
+
+export const NATIVE_NEWS_VALUES: Record<string, string> = {
+	brave: 'news',
+	tavily: 'news',
+	exa: 'news',
+	kagi_enrichment: 'news',
+};
+
+export interface SearchTypeMetadata {
+	requested: SearchType;
+	applied: boolean;
+	provider: string;
+	native_value?: string;
+	reason?: string;
+}
+
+export const search_type_metadata = (
+	provider: string,
+	requested: SearchType,
+): SearchTypeMetadata => {
+	if (requested === 'search') {
+		return {
+			requested,
+			applied: true,
+			provider,
+			native_value: 'search',
+		};
+	}
+
+	const native_value = NATIVE_NEWS_VALUES[provider];
+	if (native_value) {
+		return {
+			requested,
+			applied: true,
+			provider,
+			native_value,
+		};
+	}
+
+	return {
+		requested,
+		applied: false,
+		provider,
+		reason: `provider ${provider} does not support search_type ${requested}`,
+	};
+};
+
+export const with_search_type_metadata = (
+	results: SearchResult[],
+	provider: string,
+	requested?: SearchType,
+): SearchResult[] => {
+	if (!requested) return results;
+
+	const search_type = search_type_metadata(provider, requested);
+	return results.map((result) => ({
+		...result,
+		metadata: {
+			...result.metadata,
+			search_type,
+		},
+	}));
+};

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -11,11 +11,14 @@ export interface SearchResult {
 	metadata?: ProviderMetadata;
 }
 
+export type SearchType = 'search' | 'news';
+
 export interface BaseSearchParams {
 	query: string;
 	limit?: number;
 	include_domains?: string[];
 	exclude_domains?: string[];
+	search_type?: SearchType;
 }
 
 export interface ProcessingResult {

--- a/src/providers/enhancement/kagi-enrichment/index.test.ts
+++ b/src/providers/enhancement/kagi-enrichment/index.test.ts
@@ -76,4 +76,43 @@ describe('KagiEnrichmentSearchProvider', () => {
 			},
 		]);
 	});
+
+	it('uses only the news enrichment endpoint when search_type is news', async () => {
+		const fetch = vi.fn(
+			async (_input: RequestInfo | URL, _init?: RequestInit) =>
+				json_response({
+					data: [
+						{
+							title: 'News',
+							url: 'https://news.test',
+							snippet: 'Today',
+							rank: 1,
+						},
+					],
+				}),
+		);
+		vi.stubGlobal('fetch', fetch);
+		const { KagiEnrichmentSearchProvider } =
+			await import('./index.js');
+
+		await expect(
+			new KagiEnrichmentSearchProvider().search({
+				query: 'svelte release',
+				limit: 2,
+				search_type: 'news',
+			}),
+		).resolves.toEqual([
+			{
+				title: 'News',
+				url: 'https://news.test',
+				snippet: 'Today',
+				score: 1,
+				source_provider: 'kagi_enrichment',
+			},
+		]);
+		expect(fetch).toHaveBeenCalledTimes(1);
+		const called_url = fetch.mock.calls[0]?.[0] as string;
+		expect(called_url).toContain('/enrich/news?');
+		expect(called_url).toContain('limit=2');
+	});
 });

--- a/src/providers/enhancement/kagi-enrichment/index.ts
+++ b/src/providers/enhancement/kagi-enrichment/index.ts
@@ -5,6 +5,7 @@ import {
 import { http_json } from '../../../common/http.js';
 import { retry_with_backoff } from '../../../common/retry.js';
 import {
+	BaseSearchParams,
 	ErrorType,
 	ProviderError,
 	SearchProvider,
@@ -26,15 +27,38 @@ export interface EnrichmentResponse {
 	};
 }
 
+const decode_enrichment_snippet = (snippet: string) =>
+	snippet
+		.replace(/&#39;/g, "'")
+		.replace(/&quot;/g, '"')
+		.replace(/&amp;/g, '&')
+		.replace(/&lt;/g, '<')
+		.replace(/&gt;/g, '>');
+
+const map_enrichment_results = (
+	data: EnrichmentResponse['data'],
+	provider: string,
+): SearchResult[] =>
+	data.flatMap((result): SearchResult[] => {
+		if (!result.title || !result.url) return [];
+
+		return [
+			{
+				title: result.title,
+				url: result.url,
+				snippet: decode_enrichment_snippet(result.snippet ?? ''),
+				score: result.rank ? 1 / result.rank : undefined,
+				source_provider: provider,
+			},
+		];
+	});
+
 export class KagiEnrichmentSearchProvider implements SearchProvider {
 	name = 'kagi_enrichment';
 	description =
 		'Search specialized indexes (Teclis for web, TinyGem for news). Ideal for discovering non-mainstream results and supplementary knowledge.';
 
-	async search(params: {
-		query: string;
-		limit?: number;
-	}): Promise<SearchResult[]> {
+	async search(params: BaseSearchParams): Promise<SearchResult[]> {
 		const api_key = validate_api_key(
 			config.enhancement.kagi_enrichment.api_key,
 			this.name,
@@ -43,50 +67,48 @@ export class KagiEnrichmentSearchProvider implements SearchProvider {
 		const query = sanitize_query(params.query);
 		const limit = params.limit ?? 5;
 
+		const fetch_index = (index: 'web' | 'news') =>
+			http_json<EnrichmentResponse & { message?: string }>(
+				this.name,
+				`${config.enhancement.kagi_enrichment.base_url}/${index}?${new URLSearchParams(
+					{
+						q: query,
+						limit: String(limit),
+					},
+				)}`,
+				{
+					method: 'GET',
+					headers: {
+						Authorization: `Bot ${api_key}`,
+						Accept: 'application/json',
+					},
+					signal: AbortSignal.timeout(
+						config.enhancement.kagi_enrichment.timeout,
+					),
+				},
+			);
+
 		const enrich_request = async () => {
 			try {
-				const [webData, newsData] = await Promise.all([
-					http_json<EnrichmentResponse & { message?: string }>(
-						this.name,
-						`https://kagi.com/api/v0/enrich/web?${new URLSearchParams(
-							{
-								q: query,
-								limit: String(limit),
-							},
-						)}`,
-						{
-							method: 'GET',
-							headers: {
-								Authorization: `Bot ${api_key}`,
-								Accept: 'application/json',
-							},
-							signal: AbortSignal.timeout(
-								config.enhancement.kagi_enrichment.timeout,
-							),
-						},
-					),
-					http_json<EnrichmentResponse & { message?: string }>(
-						this.name,
-						`https://kagi.com/api/v0/enrich/news?${new URLSearchParams(
-							{
-								q: query,
-								limit: String(limit),
-							},
-						)}`,
-						{
-							method: 'GET',
-							headers: {
-								Authorization: `Bot ${api_key}`,
-								Accept: 'application/json',
-							},
-							signal: AbortSignal.timeout(
-								config.enhancement.kagi_enrichment.timeout,
-							),
-						},
-					),
+				if (params.search_type === 'news') {
+					const news_data = await fetch_index('news');
+					if (!news_data?.data) {
+						throw new ProviderError(
+							ErrorType.API_ERROR,
+							'Unexpected response: missing data from enrichment endpoints',
+							this.name,
+						);
+					}
+
+					return map_enrichment_results(news_data.data, this.name);
+				}
+
+				const [web_data, news_data] = await Promise.all([
+					fetch_index('web'),
+					fetch_index('news'),
 				]);
 
-				if (!webData?.data || !newsData?.data) {
+				if (!web_data?.data || !news_data?.data) {
 					throw new ProviderError(
 						ErrorType.API_ERROR,
 						'Unexpected response: missing data from enrichment endpoints',
@@ -94,26 +116,10 @@ export class KagiEnrichmentSearchProvider implements SearchProvider {
 					);
 				}
 
-				const allData = [...webData.data, ...newsData.data];
-
-				return allData.flatMap((result): SearchResult[] => {
-					if (!result.title || !result.url) return [];
-
-					return [
-						{
-							title: result.title,
-							url: result.url,
-							snippet: (result.snippet ?? '')
-								.replace(/&#39;/g, "'")
-								.replace(/&quot;/g, '"')
-								.replace(/&amp;/g, '&')
-								.replace(/&lt;/g, '<')
-								.replace(/&gt;/g, '>'),
-							score: result.rank ? 1 / result.rank : undefined,
-							source_provider: this.name,
-						},
-					];
-				});
+				return map_enrichment_results(
+					[...web_data.data, ...news_data.data],
+					this.name,
+				);
 			} catch (error) {
 				handle_provider_error(error, this.name, 'enrich content');
 			}

--- a/src/providers/search/brave/index.test.ts
+++ b/src/providers/search/brave/index.test.ts
@@ -55,6 +55,44 @@ describe('BraveSearchProvider', () => {
 		]);
 	});
 
+	it('uses the native news endpoint when search_type is news', async () => {
+		const fetch = vi.fn(
+			async (_input: RequestInfo | URL, _init?: RequestInit) =>
+				json_response({
+					type: 'news',
+					results: [
+						{
+							title: 'Breaking',
+							url: 'https://news.example',
+							description: 'Today',
+							age: '2 hours ago',
+						},
+					],
+				}),
+		);
+		vi.stubGlobal('fetch', fetch);
+		const { BraveSearchProvider } = await import('./index.js');
+
+		await expect(
+			new BraveSearchProvider().search({
+				query: 'svelte release',
+				limit: 3,
+				search_type: 'news',
+			}),
+		).resolves.toEqual([
+			{
+				title: 'Breaking',
+				url: 'https://news.example',
+				snippet: 'Today',
+				source_provider: 'brave',
+				metadata: { age: '2 hours ago' },
+			},
+		]);
+		const called_url = fetch.mock.calls[0]?.[0] as string;
+		expect(called_url).toContain('/news/search?');
+		expect(called_url).toContain('count=3');
+	});
+
 	it('returns no results when the web block is omitted', async () => {
 		vi.stubGlobal(
 			'fetch',

--- a/src/providers/search/brave/index.ts
+++ b/src/providers/search/brave/index.ts
@@ -30,6 +30,20 @@ const brave_search_response_schema = v.object({
 	),
 });
 
+const brave_news_search_response_schema = v.object({
+	results: v.optional(
+		v.array(
+			v.object({
+				title: v.string(),
+				url: v.string(),
+				description: v.optional(v.string()),
+				age: v.optional(v.string()),
+				page_age: v.optional(v.string()),
+			}),
+		),
+	),
+});
+
 export class BraveSearchProvider implements SearchProvider {
 	name = 'brave';
 	description =
@@ -59,9 +73,12 @@ export class BraveSearchProvider implements SearchProvider {
 					count: (params.limit ?? 10).toString(),
 				});
 
+				const is_news = params.search_type === 'news';
+				const endpoint = is_news ? 'news/search' : 'web/search';
+
 				const raw_data = await http_json(
 					this.name,
-					`${config.search.brave.base_url}/web/search?${query_params}`,
+					`${config.search.brave.base_url}/${endpoint}?${query_params}`,
 					{
 						method: 'GET',
 						headers: {
@@ -71,6 +88,33 @@ export class BraveSearchProvider implements SearchProvider {
 						signal: AbortSignal.timeout(config.search.brave.timeout),
 					},
 				);
+
+				if (is_news) {
+					const data = parse_provider_response(
+						this.name,
+						brave_news_search_response_schema,
+						raw_data,
+					);
+
+					return (data.results ?? []).map((result) => {
+						const metadata = {
+							...(result.age ? { age: result.age } : {}),
+							...(result.page_age
+								? { page_age: result.page_age }
+								: {}),
+						};
+
+						return {
+							title: result.title,
+							url: result.url,
+							snippet: result.description ?? '',
+							source_provider: this.name,
+							...(Object.keys(metadata).length > 0
+								? { metadata }
+								: {}),
+						};
+					});
+				}
 
 				const data = parse_provider_response(
 					this.name,

--- a/src/providers/search/exa/index.test.ts
+++ b/src/providers/search/exa/index.test.ts
@@ -67,5 +67,41 @@ describe('ExaSearchProvider', () => {
 			includeDomains: ['example.com'],
 			excludeDomains: ['bad.example'],
 		});
+		expect(
+			JSON.parse(request_init?.body as string).category,
+		).toBeUndefined();
+	});
+
+	it('sends category news when search_type is news', async () => {
+		const fetch = vi.fn(
+			async (_input: RequestInfo | URL, _init?: RequestInit) =>
+				json_response({
+					requestId: 'req-news',
+					results: [
+						{
+							id: 'id-news',
+							title: 'News',
+							url: 'https://news.example',
+							text: 'Today',
+						},
+					],
+				}),
+		);
+		vi.stubGlobal('fetch', fetch);
+		const { ExaSearchProvider } = await import('./index.js');
+
+		await new ExaSearchProvider().search({
+			query: 'svelte release',
+			search_type: 'news',
+		});
+
+		expect(
+			JSON.parse(fetch.mock.calls[0]?.[1]?.body as string),
+		).toEqual(
+			expect.objectContaining({
+				query: 'svelte release',
+				category: 'news',
+			}),
+		);
 	});
 });

--- a/src/providers/search/exa/index.ts
+++ b/src/providers/search/exa/index.ts
@@ -81,6 +81,9 @@ export class ExaSearchProvider implements SearchProvider {
 				) {
 					request_body.excludeDomains = params.exclude_domains;
 				}
+				if (params.search_type === 'news') {
+					request_body.category = 'news';
+				}
 
 				const raw_data = await http_json(
 					this.name,

--- a/src/providers/search/kagi/index.test.ts
+++ b/src/providers/search/kagi/index.test.ts
@@ -80,4 +80,24 @@ describe('KagiSearchProvider', () => {
 			},
 		]);
 	});
+
+	it('keeps the general search endpoint when search_type is news', async () => {
+		const fetch = vi.fn(
+			async (_input: RequestInfo | URL, _init?: RequestInit) =>
+				json_response({
+					data: [{ title: 'General', url: 'https://example.com' }],
+				}),
+		);
+		vi.stubGlobal('fetch', fetch);
+		const { KagiSearchProvider } = await import('./index.js');
+
+		await new KagiSearchProvider().search({
+			query: 'svelte release',
+			search_type: 'news',
+		});
+
+		const called_url = fetch.mock.calls[0]?.[0] as string;
+		expect(called_url).toContain('/search?');
+		expect(called_url).not.toContain('/news');
+	});
 });

--- a/src/providers/search/tavily/index.test.ts
+++ b/src/providers/search/tavily/index.test.ts
@@ -62,6 +62,41 @@ describe('TavilySearchProvider', () => {
 		]);
 	});
 
+	it('sends topic news when search_type is news', async () => {
+		const fetch = vi.fn(
+			async (_input: RequestInfo | URL, _init?: RequestInit) =>
+				json_response({
+					results: [
+						{
+							title: 'News',
+							url: 'https://news.example',
+							content: 'Today',
+							score: 0.9,
+						},
+					],
+					response_time: 0.2,
+				}),
+		);
+		vi.stubGlobal('fetch', fetch);
+		const { TavilySearchProvider } = await import('./index.js');
+
+		await new TavilySearchProvider().search({
+			query: 'svelte release',
+			limit: 1,
+			search_type: 'news',
+		});
+
+		const request_bodies = fetch.mock.calls.map((call) =>
+			JSON.parse((call[1]?.body as string) ?? '{}'),
+		);
+		expect(request_bodies).toContainEqual(
+			expect.objectContaining({
+				topic: 'news',
+				query: 'svelte release',
+			}),
+		);
+	});
+
 	it('normalizes date and country operators for Tavily API fields', async () => {
 		const fetch = vi.fn(
 			async (_input: RequestInfo | URL, _init?: RequestInit) =>

--- a/src/providers/search/tavily/index.ts
+++ b/src/providers/search/tavily/index.ts
@@ -24,7 +24,7 @@ interface TavilySearchRequest {
 	include_domains: string[];
 	exclude_domains: string[];
 	search_depth: 'basic';
-	topic: 'general';
+	topic: 'general' | 'news';
 	start_date?: string;
 	end_date?: string;
 	exact_match?: boolean;
@@ -93,7 +93,7 @@ export class TavilySearchProvider implements SearchProvider {
 					exclude_domains:
 						exclude_domains.length > 0 ? exclude_domains : [],
 					search_depth: 'basic',
-					topic: 'general',
+					topic: params.search_type === 'news' ? 'news' : 'general',
 				};
 
 				// Map date operators to Tavily's start_date/end_date

--- a/src/server/provider-definitions.ts
+++ b/src/server/provider-definitions.ts
@@ -71,6 +71,7 @@ export const web_search_provider_definitions = [
 		tools: ['web_search'],
 		capabilities: [
 			'web_search',
+			'news_search',
 			'domain_filters',
 			'operator_translation',
 		],
@@ -85,6 +86,7 @@ export const web_search_provider_definitions = [
 		tools: ['web_search'],
 		capabilities: [
 			'web_search',
+			'news_search',
 			'domain_filters',
 			'operator_passthrough',
 		],
@@ -111,7 +113,12 @@ export const web_search_provider_definitions = [
 		category: 'search',
 		api_key_name: 'EXA_API_KEY',
 		tools: ['web_search'],
-		capabilities: ['web_search', 'domain_filters', 'semantic_search'],
+		capabilities: [
+			'web_search',
+			'news_search',
+			'domain_filters',
+			'semantic_search',
+		],
 		api_key: config.search.exa.api_key,
 		create: () => new ExaSearchProvider(),
 	},
@@ -121,7 +128,11 @@ export const web_search_provider_definitions = [
 		category: 'search',
 		api_key_name: 'KAGI_API_KEY',
 		tools: ['web_search'],
-		capabilities: ['specialized_indexes', 'web_enrichment'],
+		capabilities: [
+			'specialized_indexes',
+			'web_enrichment',
+			'news_search',
+		],
 		api_key: config.enhancement.kagi_enrichment.api_key,
 		create: () => new KagiEnrichmentSearchProvider(),
 	},

--- a/src/server/tools/contract.test.ts
+++ b/src/server/tools/contract.test.ts
@@ -82,7 +82,7 @@ afterEach(() => {
 	vi.restoreAllMocks();
 });
 
-describe('MCP tool contract', () => {
+describe('MCP tool contract', { timeout: 20_000 }, () => {
 	it('registers no public tools when no providers are configured', async () => {
 		const { tools, tools_module } = await load_contract({});
 
@@ -151,6 +151,20 @@ describe('MCP tool contract', () => {
 		expect(
 			v.safeParse(schema, { query: 'test', provider: 'kagi' })
 				.success,
+		).toBe(false);
+		expect(
+			v.safeParse(schema, {
+				query: 'test',
+				provider: 'brave',
+				search_type: 'news',
+			}).success,
+		).toBe(true);
+		expect(
+			v.safeParse(schema, {
+				query: 'test',
+				provider: 'brave',
+				search_type: 'stories',
+			}).success,
 		).toBe(false);
 	});
 
@@ -261,6 +275,113 @@ describe('MCP tool contract', () => {
 			provider: 'brave',
 			retryable: false,
 		});
+	});
+
+	it('applies Brave news natively and reports applied metadata', async () => {
+		const { tools } = await load_contract({
+			BRAVE_API_KEY: 'brave-key',
+		});
+		const tool = tools.find(
+			(entry) => entry.definition.name === 'web_search',
+		)!;
+		const fetch = vi.fn(
+			async (_input: RequestInfo | URL, _init?: RequestInit) =>
+				new Response(
+					JSON.stringify({
+						type: 'news',
+						results: [
+							{
+								title: 'Breaking',
+								url: 'https://news.example',
+								description: 'Today',
+							},
+						],
+					}),
+					{ status: 200 },
+				),
+		);
+		vi.stubGlobal('fetch', fetch);
+
+		const body = parse_tool_body(
+			await tool.handler({
+				query: 'svelte release',
+				provider: 'brave',
+				search_type: 'news',
+				large_result_mode: 'inline',
+			}),
+		);
+
+		expect(fetch.mock.calls[0]?.[0] as string).toContain(
+			'/news/search?',
+		);
+		expect(body).toEqual([
+			{
+				title: 'Breaking',
+				url: 'https://news.example',
+				snippet: 'Today',
+				source_provider: 'brave',
+				metadata: {
+					search_type: {
+						requested: 'news',
+						applied: true,
+						provider: 'brave',
+						native_value: 'news',
+					},
+				},
+			},
+		]);
+	});
+
+	it('runs Kagi normally for news and reports applied=false', async () => {
+		const { tools } = await load_contract({
+			KAGI_API_KEY: 'kagi-key',
+		});
+		const tool = tools.find(
+			(entry) => entry.definition.name === 'web_search',
+		)!;
+		const fetch = vi.fn(
+			async (_input: RequestInfo | URL, _init?: RequestInit) =>
+				new Response(
+					JSON.stringify({
+						data: [
+							{
+								title: 'General',
+								url: 'https://example.com',
+								snippet: 'Not a news endpoint',
+							},
+						],
+					}),
+					{ status: 200 },
+				),
+		);
+		vi.stubGlobal('fetch', fetch);
+
+		const body = parse_tool_body(
+			await tool.handler({
+				query: 'svelte release',
+				provider: 'kagi',
+				search_type: 'news',
+				large_result_mode: 'inline',
+			}),
+		);
+
+		expect(fetch.mock.calls[0]?.[0] as string).toContain('/search?');
+		expect(body).toEqual([
+			{
+				title: 'General',
+				url: 'https://example.com',
+				snippet: 'Not a news endpoint',
+				source_provider: 'kagi',
+				metadata: {
+					search_type: {
+						requested: 'news',
+						applied: false,
+						provider: 'kagi',
+						reason: 'provider kagi does not support search_type news',
+					},
+				},
+			},
+		]);
 	});
 
 	it('covers large-result inline/file modes and compact extraction at the MCP layer', async () => {

--- a/src/server/tools/schemas.test.ts
+++ b/src/server/tools/schemas.test.ts
@@ -7,6 +7,7 @@ import {
 	large_result_mode_schema,
 	limit_schema,
 	query_schema,
+	search_type_schema,
 	url_or_urls_schema,
 } from './schemas.js';
 
@@ -15,6 +16,20 @@ describe('tool schemas', () => {
 		expect(v.parse(query_schema, 'sveltekit')).toBe('sveltekit');
 		expect(v.safeParse(query_schema, '').success).toBe(false);
 		expect(v.safeParse(query_schema, '   ').success).toBe(false);
+	});
+
+	it('accepts search and news verticals and rejects unknown values', () => {
+		expect(v.safeParse(search_type_schema, undefined).success).toBe(
+			true,
+		);
+		expect(v.parse(search_type_schema, 'search')).toBe('search');
+		expect(v.parse(search_type_schema, 'news')).toBe('news');
+		expect(v.safeParse(search_type_schema, 'stories').success).toBe(
+			false,
+		);
+		expect(v.safeParse(search_type_schema, 'NEWS').success).toBe(
+			false,
+		);
 	});
 
 	it('bounds result limits', () => {

--- a/src/server/tools/schemas.ts
+++ b/src/server/tools/schemas.ts
@@ -10,6 +10,15 @@ export const query_schema = v.pipe(
 	v.description('Search query'),
 );
 
+export const search_type_schema = v.optional(
+	v.pipe(
+		v.picklist(['search', 'news']),
+		v.description(
+			'Result vertical. news uses a native news endpoint where the provider has one; otherwise the normal search runs and search_type.applied is false. Defaults to search.',
+		),
+	),
+);
+
 export const limit_schema = v.optional(
 	v.pipe(
 		v.number(),

--- a/src/server/tools/web-search.ts
+++ b/src/server/tools/web-search.ts
@@ -1,6 +1,7 @@
 import { McpServer } from 'tmcp';
 import type { GenericSchema } from 'valibot';
 import * as v from 'valibot';
+import { with_search_type_metadata } from '../../common/search-type.js';
 import { SearchProvider } from '../../common/types.js';
 import {
 	web_search_provider_definitions,
@@ -14,6 +15,7 @@ import {
 	large_result_mode_schema,
 	limit_schema,
 	query_schema,
+	search_type_schema,
 } from './schemas.js';
 
 const providers = new ProviderRegistry<SearchProvider>();
@@ -41,7 +43,7 @@ export const register_web_search = (
 		{
 			name: 'web_search',
 			description:
-				'Search the web for information. Use when you need to find web pages, articles, or data. Providers: tavily (factual/citations), brave (privacy/operators), kagi (quality/operators), exa (AI-semantic), kagi_enrichment (specialized indexes). Brave/Kagi support query operators like site:, filetype:, lang:, before:, after:.',
+				'Search the web for information. Use when you need to find web pages, articles, or data. Providers: tavily (factual/citations), brave (privacy/operators), kagi (quality/operators), exa (AI-semantic), kagi_enrichment (specialized indexes). Brave/Kagi support query operators like site:, filetype:, lang:, before:, after:. Set search_type=news for a native news vertical where the provider has one; unsupported providers run normal search and report search_type.applied=false.',
 			annotations: {
 				readOnlyHint: true,
 				destructiveHint: false,
@@ -57,6 +59,7 @@ export const register_web_search = (
 				limit: limit_schema,
 				include_domains: include_domains_schema,
 				exclude_domains: exclude_domains_schema,
+				search_type: search_type_schema,
 				large_result_mode: large_result_mode_schema,
 			}),
 		},
@@ -66,6 +69,7 @@ export const register_web_search = (
 			limit,
 			include_domains,
 			exclude_domains,
+			search_type,
 			large_result_mode,
 		}) =>
 			handle_tool_result(
@@ -73,12 +77,17 @@ export const register_web_search = (
 				async () => {
 					const selected = providers.require(provider, 'web_search');
 
-					return selected.search({
-						query,
-						limit,
-						include_domains,
-						exclude_domains,
-					});
+					return with_search_type_metadata(
+						await selected.search({
+							query,
+							limit,
+							include_domains,
+							exclude_domains,
+							search_type,
+						}),
+						provider,
+						search_type,
+					);
 				},
 				{ large_result_mode },
 			),


### PR DESCRIPTION
## Summary

Adds an explicit `search_type` on `web_search` (`search` default | `news`) so current-events queries can use a native news path instead of stuffing `news` into the query string.

- Native news: Brave `/news/search`, Tavily `topic=news`, Exa `category=news`, Kagi Enrichment `/enrich/news`
- Kagi general search stays on `/search` and reports `search_type.applied=false` in result metadata
- Invalid values are rejected by the tool schema

Fixes #199

## Scope

- `web_search` schema/handler and shared `search_type` metadata helper
- Brave, Tavily, Exa, and Kagi Enrichment adapters
- README / provider-selection docs and a patch changeset

## Verification

```bash
pnpm test
pnpm run check
pnpm run build
```

Example:

```json
{
  "query": "what happened today in svelte",
  "provider": "brave",
  "search_type": "news"
}
```

## Impact

- Default omitted `search_type` is unchanged general search (same response shape)
- When `search_type` is set, each result includes `metadata.search_type` (`requested`, `applied`, and `native_value` or `reason`)
- No new API keys or breaking default behavior