### PR TITLE
feat: add opt-in quality_report diagnostics

### DIFF
--- a/.changeset/quality-report-diagnostics.md
+++ b/.changeset/quality-report-diagnostics.md
@@ -1,0 +1,5 @@
+---
+'mcp-omnisearch': patch
+---
+
+feat: add opt-in quality_report diagnostics on tool responses

--- a/README.md
+++ b/README.md
@@ -120,6 +120,25 @@ Tavily, Kagi, Firecrawl, or Exa.
 }
 ```
 
+### Quality report
+
+Pass `quality_report: true` on any tool to attach structured routing
+diagnostics. Default is off so normal payloads stay small.
+
+The report includes the selected provider and reason, scores when
+auto-routing supplies them, skipped / cooldown / auto-excluded
+providers, result counts, duplicate-URL rate, and an
+extract-recommended hint. It never includes API keys or raw vendor
+response bodies.
+
+```json
+{
+	"query": "sveltekit remote functions",
+	"provider": "brave",
+	"quality_report": true
+}
+```
+
 ## Documentation
 
 - [Provider selection](docs/provider-selection.md) — choose providers

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -55,6 +55,15 @@ rate-limit errors and retries only retryable classes such as 429,
 timeouts, network failures, and 5xx responses. Invalid credentials and
 validation failures are not retried.
 
+## Routing and quality diagnostics
+
+If a provider choice, skip, or empty result set is surprising, retry
+the same call with `quality_report: true`. The extra `quality_report`
+object is structured JSON: selected provider and reason, scores if
+any, skipped / cooldown / auto-excluded providers, result counts,
+duplicate-URL rate, and an extract-recommended hint. It does not
+include API keys or raw vendor error bodies.
+
 ## Large result paths
 
 If a tool response points to a temp file, that file exists on the MCP

--- a/src/server/tools/ai-search.ts
+++ b/src/server/tools/ai-search.ts
@@ -7,10 +7,15 @@ import {
 	type AISearchProviderName,
 } from '../provider-definitions.js';
 import { ProviderRegistry } from '../provider-registry.js';
+import {
+	maybe_quality_report,
+	skipped_from_status,
+} from './quality-report.js';
 import { handle_tool_result } from './responses.js';
 import {
 	large_result_mode_schema,
 	limit_schema,
+	quality_report_schema,
 	query_schema,
 } from './schemas.js';
 
@@ -54,9 +59,16 @@ export const register_ai_search = (
 				),
 				limit: limit_schema,
 				large_result_mode: large_result_mode_schema,
+				quality_report: quality_report_schema,
 			}),
 		},
-		async ({ query, provider, limit, large_result_mode }) =>
+		async ({
+			query,
+			provider,
+			limit,
+			large_result_mode,
+			quality_report,
+		}) =>
 			handle_tool_result(
 				'ai_search',
 				async () => {
@@ -67,7 +79,17 @@ export const register_ai_search = (
 						limit,
 					});
 				},
-				{ large_result_mode },
+				{
+					large_result_mode,
+					quality_report: maybe_quality_report(quality_report, {
+						selected_provider: provider,
+						selection_reason: 'explicit',
+						skipped: skipped_from_status(
+							providers.status_entries(),
+							provider,
+						),
+					}),
+				},
 			),
 	);
 };

--- a/src/server/tools/contract.test.ts
+++ b/src/server/tools/contract.test.ts
@@ -152,6 +152,20 @@ describe('MCP tool contract', () => {
 			v.safeParse(schema, { query: 'test', provider: 'kagi' })
 				.success,
 		).toBe(false);
+		expect(
+			v.safeParse(schema, {
+				query: 'test',
+				provider: 'brave',
+				quality_report: true,
+			}).success,
+		).toBe(true);
+		expect(
+			v.safeParse(schema, {
+				query: 'test',
+				provider: 'brave',
+				quality_report: 'yes',
+			}).success,
+		).toBe(false);
 	});
 
 	it('validates public web_extract payloads and unavailable modes at the MCP layer', async () => {
@@ -261,6 +275,81 @@ describe('MCP tool contract', () => {
 			provider: 'brave',
 			retryable: false,
 		});
+
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValueOnce(
+				new Response(
+					JSON.stringify({
+						web: {
+							results: [
+								{
+									title: 'Example',
+									url: 'https://example.com',
+									description: 'Example result',
+								},
+							],
+						},
+					}),
+					{ status: 200 },
+				),
+			),
+		);
+		const reported = await tool.handler({
+			query: 'example',
+			provider: 'brave',
+			large_result_mode: 'inline',
+			quality_report: true,
+		});
+		const reported_body = parse_tool_body(reported);
+		expect(reported_body.results).toEqual([
+			{
+				title: 'Example',
+				url: 'https://example.com',
+				snippet: 'Example result',
+				source_provider: 'brave',
+			},
+		]);
+		expect(reported_body.quality_report).toEqual(
+			expect.objectContaining({
+				selected: { provider: 'brave', reason: 'explicit' },
+				scores: [],
+				result_count: 1,
+				unique_url_count: 1,
+				duplicate_url_rate: 0,
+				extract_recommended: true,
+			}),
+		);
+		expect(reported_body.quality_report.skipped).toEqual(
+			expect.arrayContaining([
+				{ provider: 'tavily', reason: 'missing_api_key' },
+			]),
+		);
+		expect(JSON.stringify(reported_body.quality_report)).not.toMatch(
+			/TAVILY_API_KEY|BRAVE_API_KEY|brave-key|nope/,
+		);
+
+		vi.stubGlobal(
+			'fetch',
+			vi
+				.fn()
+				.mockResolvedValue(new Response('nope', { status: 401 })),
+		);
+		const reported_failure = await tool.handler({
+			query: 'example',
+			provider: 'brave',
+			quality_report: true,
+		});
+		const reported_error = parse_tool_body(reported_failure);
+		expect(reported_failure.isError).toBe(true);
+		expect(reported_error.error).toBe('Invalid API key');
+		expect(reported_error.quality_report.selected).toEqual({
+			provider: 'brave',
+			reason: 'explicit',
+		});
+		expect(
+			JSON.stringify(reported_error.quality_report),
+		).not.toContain('nope');
 	});
 
 	it('covers large-result inline/file modes and compact extraction at the MCP layer', async () => {

--- a/src/server/tools/github-search.ts
+++ b/src/server/tools/github-search.ts
@@ -4,10 +4,15 @@ import * as v from 'valibot';
 import { GitHubSearchProvider } from '../../providers/search/github/index.js';
 import { github_provider_definitions } from '../provider-definitions.js';
 import { ProviderRegistry } from '../provider-registry.js';
+import {
+	maybe_quality_report,
+	skipped_from_status,
+} from './quality-report.js';
 import { handle_tool_result } from './responses.js';
 import {
 	large_result_mode_schema,
 	limit_schema,
+	quality_report_schema,
 	query_schema,
 } from './schemas.js';
 
@@ -51,6 +56,7 @@ export const register_github_search = (
 				),
 				limit: limit_schema,
 				large_result_mode: large_result_mode_schema,
+				quality_report: quality_report_schema,
 				sort: v.optional(
 					v.pipe(
 						v.picklist(['stars', 'forks', 'updated']),
@@ -64,6 +70,7 @@ export const register_github_search = (
 			search_type = 'code',
 			limit,
 			large_result_mode,
+			quality_report,
 			sort,
 		}) =>
 			handle_tool_result(
@@ -93,7 +100,17 @@ export const register_github_search = (
 							});
 					}
 				},
-				{ large_result_mode },
+				{
+					large_result_mode,
+					quality_report: maybe_quality_report(quality_report, {
+						selected_provider: 'github',
+						selection_reason: 'implicit',
+						skipped: skipped_from_status(
+							providers.status_entries(),
+							'github',
+						),
+					}),
+				},
 			),
 	);
 };

--- a/src/server/tools/quality-report.test.ts
+++ b/src/server/tools/quality-report.test.ts
@@ -1,0 +1,250 @@
+import { describe, expect, it } from 'vitest';
+import type { ProviderStatus } from '../provider-registry.js';
+import {
+	attach_quality_report,
+	build_quality_report,
+	maybe_quality_report,
+	skipped_from_status,
+} from './quality-report.js';
+
+const status = (
+	overrides: Partial<ProviderStatus>,
+): ProviderStatus => ({
+	id: 'brave',
+	name: 'brave',
+	category: 'search',
+	status: 'available',
+	api_key_name: 'BRAVE_API_KEY',
+	tools: ['web_search'],
+	modes: [],
+	capabilities: ['web_search'],
+	...overrides,
+});
+
+describe('skipped_from_status', () => {
+	it('lists unavailable providers without API key names', () => {
+		const skipped = skipped_from_status(
+			[
+				status({ id: 'brave', name: 'brave', status: 'available' }),
+				status({
+					id: 'tavily',
+					name: 'tavily',
+					status: 'unavailable',
+					unavailable_reason: 'missing_api_key',
+					api_key_name: 'TAVILY_API_KEY',
+				}),
+				status({
+					id: 'exa:contents',
+					name: 'exa',
+					status: 'unavailable',
+					unavailable_reason: 'missing_api_key',
+					api_key_name: 'EXA_API_KEY',
+				}),
+				status({
+					id: 'exa:similar',
+					name: 'exa',
+					status: 'unavailable',
+					unavailable_reason: 'missing_api_key',
+					api_key_name: 'EXA_API_KEY',
+				}),
+			],
+			'brave',
+		);
+
+		expect(skipped).toEqual([
+			{ provider: 'exa', reason: 'missing_api_key' },
+			{ provider: 'tavily', reason: 'missing_api_key' },
+		]);
+		expect(JSON.stringify(skipped)).not.toMatch(
+			/TAVILY_API_KEY|EXA_API_KEY|sk-|Bearer/i,
+		);
+	});
+
+	it('omits the selected provider even when unavailable', () => {
+		expect(
+			skipped_from_status(
+				[
+					status({
+						id: 'tavily:extract',
+						name: 'tavily',
+						status: 'unavailable',
+						unavailable_reason: 'missing_api_key',
+					}),
+				],
+				'tavily',
+			),
+		).toEqual([]);
+	});
+});
+
+describe('build_quality_report', () => {
+	it('reports explicit selection, counts, and thin-snippet extract hint', () => {
+		const report = build_quality_report({
+			selected_provider: 'brave',
+			selection_reason: 'explicit',
+			skipped: [{ provider: 'tavily', reason: 'missing_api_key' }],
+			cooldown: [{ provider: 'kagi', remaining_ms: 12_000 }],
+			results: [
+				{
+					title: 'One',
+					url: 'https://example.com/a',
+					snippet: 'short',
+					source_provider: 'brave',
+				},
+				{
+					title: 'Two',
+					url: 'https://example.com/a/',
+					snippet: 'also short',
+					source_provider: 'brave',
+				},
+			],
+		});
+
+		expect(report).toEqual({
+			selected: { provider: 'brave', reason: 'explicit' },
+			scores: [],
+			skipped: [{ provider: 'tavily', reason: 'missing_api_key' }],
+			cooldown: [{ provider: 'kagi', remaining_ms: 12_000 }],
+			auto_excluded: [],
+			result_count: 2,
+			unique_url_count: 1,
+			duplicate_url_rate: 0.5,
+			extract_recommended: true,
+		});
+	});
+
+	it('includes scores when auto-routing supplies them', () => {
+		const report = build_quality_report({
+			selected_provider: 'exa',
+			selection_reason: 'auto_route',
+			scores: [
+				{ provider: 'exa', score: 0.82 },
+				{ provider: 'brave', score: 0.61 },
+			],
+			results: [],
+		});
+
+		expect(report.selected).toEqual({
+			provider: 'exa',
+			reason: 'auto_route',
+		});
+		expect(report.scores).toEqual([
+			{ provider: 'brave', score: 0.61 },
+			{ provider: 'exa', score: 0.82 },
+		]);
+		expect(report.extract_recommended).toBe(false);
+	});
+
+	it('does not recommend extract for rich snippets or processing objects', () => {
+		const rich = 'x'.repeat(200);
+		expect(
+			build_quality_report({
+				selected_provider: 'brave',
+				selection_reason: 'explicit',
+				results: [
+					{
+						title: 'Docs',
+						url: 'https://example.com/docs',
+						snippet: rich,
+					},
+				],
+			}).extract_recommended,
+		).toBe(false);
+
+		expect(
+			build_quality_report({
+				selected_provider: 'tavily',
+				selection_reason: 'explicit',
+				results: {
+					content: 'full page',
+					source_provider: 'tavily',
+					metadata: { successful_extractions: 1 },
+				},
+			}),
+		).toEqual(
+			expect.objectContaining({
+				result_count: 1,
+				extract_recommended: false,
+			}),
+		);
+	});
+
+	it('drops unsafe provider labels and never copies vendor bodies', () => {
+		const report = build_quality_report({
+			selected_provider: 'sk-live-secret-key',
+			selection_reason: 'explicit',
+			scores: [{ provider: 'Bearer abc', score: 1 }],
+			skipped: [
+				{ provider: 'tavily', reason: 'missing_api_key' },
+				{
+					provider: '{"error":"raw vendor body"}',
+					reason: 'unavailable',
+				},
+			],
+			results: [{ url: 'https://example.com', snippet: 'ok' }],
+		});
+
+		const serialized = JSON.stringify(report);
+		expect(report.selected.provider).toBe('unknown');
+		expect(report.scores).toEqual([]);
+		expect(report.skipped).toEqual([
+			{ provider: 'tavily', reason: 'missing_api_key' },
+		]);
+		expect(serialized).not.toContain('sk-live-secret-key');
+		expect(serialized).not.toContain('raw vendor body');
+		expect(serialized).not.toContain('Bearer');
+	});
+});
+
+describe('attach_quality_report', () => {
+	const report = build_quality_report({
+		selected_provider: 'brave',
+		selection_reason: 'explicit',
+		results: [],
+	});
+
+	it('wraps arrays and spreads objects', () => {
+		expect(attach_quality_report([{ title: 'ok' }], report)).toEqual({
+			results: [{ title: 'ok' }],
+			quality_report: report,
+		});
+		expect(
+			attach_quality_report(
+				{ content: 'page', source_provider: 'tavily' },
+				report,
+			),
+		).toEqual({
+			content: 'page',
+			source_provider: 'tavily',
+			quality_report: report,
+		});
+	});
+});
+
+describe('maybe_quality_report', () => {
+	it('is undefined unless explicitly enabled', () => {
+		expect(
+			maybe_quality_report(undefined, {
+				selected_provider: 'brave',
+				selection_reason: 'explicit',
+			}),
+		).toBeUndefined();
+		expect(
+			maybe_quality_report(false, {
+				selected_provider: 'brave',
+				selection_reason: 'explicit',
+			}),
+		).toBeUndefined();
+
+		const builder = maybe_quality_report(true, {
+			selected_provider: 'brave',
+			selection_reason: 'explicit',
+		});
+		expect(
+			builder?.([{ url: 'https://example.com' }]).selected,
+		).toEqual({
+			provider: 'brave',
+			reason: 'explicit',
+		});
+	});
+});

--- a/src/server/tools/quality-report.ts
+++ b/src/server/tools/quality-report.ts
@@ -1,0 +1,274 @@
+import type { ProviderStatus } from '../provider-registry.js';
+
+const PROVIDER_ID = /^[a-z][a-z0-9_]{0,31}$/;
+const THIN_SNIPPET_CHARS = 160;
+
+export type SelectionReason =
+	| 'explicit'
+	| 'implicit'
+	| 'auto_route'
+	| 'failover';
+
+export type SkipReason =
+	| 'missing_api_key'
+	| 'cooldown'
+	| 'auto_excluded'
+	| 'unavailable';
+
+export interface QualityReportScore {
+	provider: string;
+	score: number;
+}
+
+export interface QualityReportSkip {
+	provider: string;
+	reason: SkipReason;
+}
+
+export interface QualityReportCooldown {
+	provider: string;
+	remaining_ms?: number;
+}
+
+export interface QualityReport {
+	selected: {
+		provider: string;
+		reason: SelectionReason;
+	};
+	scores: QualityReportScore[];
+	skipped: QualityReportSkip[];
+	cooldown: QualityReportCooldown[];
+	auto_excluded: QualityReportSkip[];
+	result_count: number;
+	unique_url_count: number;
+	duplicate_url_rate: number;
+	extract_recommended: boolean;
+}
+
+export interface BuildQualityReportInput {
+	selected_provider: string;
+	selection_reason: SelectionReason;
+	scores?: readonly QualityReportScore[];
+	skipped?: readonly QualityReportSkip[];
+	cooldown?: readonly QualityReportCooldown[];
+	auto_excluded?: readonly QualityReportSkip[];
+	results?: unknown;
+}
+
+const safe_provider = (value: string): string =>
+	PROVIDER_ID.test(value) ? value : 'unknown';
+
+const by_provider = <T extends { provider: string }>(
+	left: T,
+	right: T,
+) => left.provider.localeCompare(right.provider);
+
+const sanitize_scores = (
+	scores: readonly QualityReportScore[] = [],
+): QualityReportScore[] =>
+	scores
+		.filter(
+			(score) =>
+				PROVIDER_ID.test(score.provider) &&
+				Number.isFinite(score.score),
+		)
+		.map((score) => ({
+			provider: score.provider,
+			score: score.score,
+		}))
+		.sort(by_provider);
+
+const sanitize_skips = (
+	entries: readonly QualityReportSkip[] = [],
+): QualityReportSkip[] =>
+	entries
+		.filter((entry) => PROVIDER_ID.test(entry.provider))
+		.map((entry) => ({
+			provider: entry.provider,
+			reason: entry.reason,
+		}))
+		.sort(by_provider);
+
+const sanitize_cooldown = (
+	entries: readonly QualityReportCooldown[] = [],
+): QualityReportCooldown[] =>
+	entries
+		.filter((entry) => PROVIDER_ID.test(entry.provider))
+		.map((entry) => {
+			const remaining_ms = entry.remaining_ms;
+			return Number.isFinite(remaining_ms)
+				? { provider: entry.provider, remaining_ms }
+				: { provider: entry.provider };
+		})
+		.sort(by_provider);
+
+const collect_urls = (value: unknown): string[] => {
+	if (Array.isArray(value)) {
+		return value.flatMap(collect_urls);
+	}
+
+	if (!value || typeof value !== 'object') {
+		return [];
+	}
+
+	const record = value as Record<string, unknown>;
+	const urls: string[] = [];
+
+	if (typeof record.url === 'string') {
+		urls.push(record.url);
+	}
+
+	if (Array.isArray(record.raw_contents)) {
+		urls.push(...collect_urls(record.raw_contents));
+	}
+
+	return urls;
+};
+
+const canonicalize_url = (url: string): string => {
+	try {
+		const parsed = new URL(url);
+		parsed.hash = '';
+		parsed.hostname = parsed.hostname.toLowerCase();
+		if (parsed.pathname !== '/' && parsed.pathname.endsWith('/')) {
+			parsed.pathname = parsed.pathname.slice(0, -1);
+		}
+		return parsed.toString();
+	} catch {
+		return url.trim().toLowerCase();
+	}
+};
+
+const count_results = (results: unknown): number => {
+	if (results == null) return 0;
+	if (Array.isArray(results)) return results.length;
+
+	if (typeof results === 'object') {
+		const metadata = (
+			results as { metadata?: Record<string, unknown> }
+		).metadata;
+		const extracted = metadata?.successful_extractions;
+		if (typeof extracted === 'number' && Number.isFinite(extracted)) {
+			return extracted;
+		}
+		return 1;
+	}
+
+	return 0;
+};
+
+const snippets_from = (results: unknown): string[] => {
+	if (!Array.isArray(results)) return [];
+
+	return results.flatMap((item) => {
+		if (!item || typeof item !== 'object') return [];
+		const snippet = (item as { snippet?: unknown }).snippet;
+		return typeof snippet === 'string' ? [snippet] : [];
+	});
+};
+
+const recommend_extract = (results: unknown): boolean => {
+	if (!Array.isArray(results) || results.length === 0) {
+		return false;
+	}
+
+	const url_results = results.filter(
+		(item) =>
+			item &&
+			typeof item === 'object' &&
+			typeof (item as { url?: unknown }).url === 'string',
+	);
+
+	if (url_results.length === 0) {
+		return false;
+	}
+
+	const snippets = snippets_from(url_results);
+	if (snippets.length === 0) {
+		return true;
+	}
+
+	const thin = snippets.filter(
+		(snippet) => snippet.trim().length < THIN_SNIPPET_CHARS,
+	).length;
+
+	return thin >= Math.ceil(snippets.length / 2);
+};
+
+export const skipped_from_status = (
+	entries: readonly ProviderStatus[],
+	selected: string,
+): QualityReportSkip[] => {
+	const seen = new Set<string>();
+	const skipped: QualityReportSkip[] = [];
+
+	for (const entry of entries) {
+		if (entry.id === selected || entry.name === selected) continue;
+		if (entry.status !== 'unavailable') continue;
+		if (seen.has(entry.name)) continue;
+
+		seen.add(entry.name);
+		skipped.push({
+			provider: entry.name,
+			reason:
+				entry.unavailable_reason === 'missing_api_key'
+					? 'missing_api_key'
+					: 'unavailable',
+		});
+	}
+
+	return sanitize_skips(skipped);
+};
+
+export const build_quality_report = (
+	input: BuildQualityReportInput,
+): QualityReport => {
+	const urls = collect_urls(input.results);
+	const unique_urls = new Set(urls.map(canonicalize_url));
+	const result_count = count_results(input.results);
+	const unique_url_count = unique_urls.size;
+	const duplicate_url_rate =
+		urls.length === 0
+			? 0
+			: Number(
+					((urls.length - unique_url_count) / urls.length).toFixed(4),
+				);
+
+	return {
+		selected: {
+			provider: safe_provider(input.selected_provider),
+			reason: input.selection_reason,
+		},
+		scores: sanitize_scores(input.scores),
+		skipped: sanitize_skips(input.skipped),
+		cooldown: sanitize_cooldown(input.cooldown),
+		auto_excluded: sanitize_skips(input.auto_excluded),
+		result_count,
+		unique_url_count,
+		duplicate_url_rate,
+		extract_recommended: recommend_extract(input.results),
+	};
+};
+
+export const attach_quality_report = <T>(
+	payload: T,
+	report: QualityReport,
+) => {
+	if (Array.isArray(payload)) {
+		return { results: payload, quality_report: report };
+	}
+
+	if (payload && typeof payload === 'object') {
+		return { ...payload, quality_report: report };
+	}
+
+	return { results: payload, quality_report: report };
+};
+
+export const maybe_quality_report = (
+	enabled: boolean | undefined,
+	input: Omit<BuildQualityReportInput, 'results'>,
+): ((raw: unknown) => QualityReport) | undefined =>
+	enabled
+		? (raw) => build_quality_report({ ...input, results: raw })
+		: undefined;

--- a/src/server/tools/responses.test.ts
+++ b/src/server/tools/responses.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import { ErrorType, ProviderError } from '../../common/types.js';
+import { build_quality_report } from './quality-report.js';
 import {
 	create_error_tool_response,
 	create_json_tool_response,
@@ -93,6 +94,80 @@ describe('tool responses', () => {
 				},
 			],
 		});
+	});
+
+	it('attaches an opt-in quality report after large-result handling', async () => {
+		const results = [
+			{
+				title: 'ok',
+				url: 'https://example.com',
+				snippet: 'short',
+			},
+		];
+		const report = build_quality_report({
+			selected_provider: 'brave',
+			selection_reason: 'explicit',
+			results,
+		});
+
+		await expect(
+			handle_tool_result('web_search', async () => results, {
+				quality_report: (raw) =>
+					build_quality_report({
+						selected_provider: 'brave',
+						selection_reason: 'explicit',
+						results: raw,
+					}),
+			}),
+		).resolves.toEqual({
+			content: [
+				{
+					type: 'text',
+					text: JSON.stringify(
+						{ results, quality_report: report },
+						null,
+						2,
+					),
+				},
+			],
+		});
+	});
+
+	it('attaches a sanitized quality report on errors when requested', async () => {
+		const report = build_quality_report({
+			selected_provider: 'brave',
+			selection_reason: 'explicit',
+		});
+		await expect(
+			handle_tool_result(
+				'web_search',
+				async () => {
+					throw new Error('vendor body {"secret":"nope"}');
+				},
+				{
+					quality_report: () => report,
+				},
+			),
+		).resolves.toEqual({
+			content: [
+				{
+					type: 'text',
+					text: JSON.stringify(
+						{
+							error:
+								'Unexpected error: vendor body {"secret":"nope"}',
+							type: ErrorType.API_ERROR,
+							retryable: false,
+							quality_report: report,
+						},
+						null,
+						2,
+					),
+				},
+			],
+			isError: true,
+		});
+		expect(JSON.stringify(report)).not.toContain('nope');
 	});
 
 	it('wraps thrown errors as MCP error responses', async () => {

--- a/src/server/tools/responses.ts
+++ b/src/server/tools/responses.ts
@@ -3,6 +3,10 @@ import {
 	handle_large_result,
 	type LargeResultMode,
 } from '../../common/results.js';
+import {
+	attach_quality_report,
+	type QualityReport,
+} from './quality-report.js';
 
 export const create_json_tool_response = (payload: unknown) => ({
 	content: [
@@ -18,22 +22,33 @@ export const create_error_tool_response = (error: Error) => ({
 	isError: true,
 });
 
-export interface ToolResultOptions {
+export interface ToolResultOptions<T = unknown> {
 	large_result_mode?: LargeResultMode;
+	quality_report?: (raw: T | undefined) => QualityReport;
 }
 
 export const handle_tool_result = async <T>(
 	tool_name: string,
 	result: () => Promise<T>,
-	options: ToolResultOptions = {},
+	options: ToolResultOptions<T> = {},
 ) => {
 	try {
+		const raw = await result();
+		const handled = handle_large_result(raw, tool_name, {
+			mode: options.large_result_mode,
+		});
+		const report = options.quality_report?.(raw);
 		return create_json_tool_response(
-			handle_large_result(await result(), tool_name, {
-				mode: options.large_result_mode,
-			}),
+			report ? attach_quality_report(handled, report) : handled,
 		);
 	} catch (error) {
-		return create_error_tool_response(error as Error);
+		const base = create_error_response(error as Error);
+		const report = options.quality_report?.(undefined);
+		return {
+			...create_json_tool_response(
+				report ? attach_quality_report(base, report) : base,
+			),
+			isError: true,
+		};
 	}
 };

--- a/src/server/tools/schemas.test.ts
+++ b/src/server/tools/schemas.test.ts
@@ -6,6 +6,7 @@ import {
 	include_raw_contents_schema,
 	large_result_mode_schema,
 	limit_schema,
+	quality_report_schema,
 	query_schema,
 	url_or_urls_schema,
 } from './schemas.js';
@@ -45,6 +46,18 @@ describe('tool schemas', () => {
 		expect(
 			v.safeParse(include_raw_contents_schema, 'false').success,
 		).toBe(false);
+		expect(
+			v.safeParse(quality_report_schema, undefined).success,
+		).toBe(true);
+		expect(v.safeParse(quality_report_schema, true).success).toBe(
+			true,
+		);
+		expect(v.safeParse(quality_report_schema, false).success).toBe(
+			true,
+		);
+		expect(v.safeParse(quality_report_schema, 'true').success).toBe(
+			false,
+		);
 	});
 
 	it('accepts hostnames but rejects URLs as domain filters', () => {

--- a/src/server/tools/schemas.ts
+++ b/src/server/tools/schemas.ts
@@ -38,6 +38,15 @@ export const include_raw_contents_schema = v.optional(
 	),
 );
 
+export const quality_report_schema = v.optional(
+	v.pipe(
+		v.boolean(),
+		v.description(
+			'When true, attach a structured routing/quality report: selected provider and reason, scores if any, skipped/cooldown/auto-excluded providers, result counts, duplicate-URL rate, and an extract-recommended hint. Default false. Never includes API keys or raw vendor bodies.',
+		),
+	),
+);
+
 export const domain_schema = v.pipe(
 	v.string(),
 	v.regex(DOMAIN_PATTERN, 'Domain must be a hostname, not a URL'),

--- a/src/server/tools/web-extract.ts
+++ b/src/server/tools/web-extract.ts
@@ -15,10 +15,15 @@ import {
 	type WebExtractProvider,
 } from '../provider-definitions.js';
 import { ProviderRegistry } from '../provider-registry.js';
+import {
+	maybe_quality_report,
+	skipped_from_status,
+} from './quality-report.js';
 import { handle_tool_result } from './responses.js';
 import {
 	include_raw_contents_schema,
 	large_result_mode_schema,
+	quality_report_schema,
 	url_or_urls_schema,
 } from './schemas.js';
 
@@ -84,6 +89,7 @@ export const register_web_extract = (
 				),
 				large_result_mode: large_result_mode_schema,
 				include_raw_contents: include_raw_contents_schema,
+				quality_report: quality_report_schema,
 			}),
 		},
 		async ({
@@ -93,6 +99,7 @@ export const register_web_extract = (
 			extract_depth,
 			large_result_mode,
 			include_raw_contents = true,
+			quality_report,
 		}) =>
 			handle_tool_result(
 				'web_extract',
@@ -129,7 +136,17 @@ export const register_web_extract = (
 						? result
 						: omit_raw_contents(result);
 				},
-				{ large_result_mode },
+				{
+					large_result_mode,
+					quality_report: maybe_quality_report(quality_report, {
+						selected_provider: provider,
+						selection_reason: 'explicit',
+						skipped: skipped_from_status(
+							providers.status_entries(),
+							provider,
+						),
+					}),
+				},
 			),
 	);
 };

--- a/src/server/tools/web-search.ts
+++ b/src/server/tools/web-search.ts
@@ -7,12 +7,17 @@ import {
 	type WebSearchProviderName,
 } from '../provider-definitions.js';
 import { ProviderRegistry } from '../provider-registry.js';
+import {
+	maybe_quality_report,
+	skipped_from_status,
+} from './quality-report.js';
 import { handle_tool_result } from './responses.js';
 import {
 	exclude_domains_schema,
 	include_domains_schema,
 	large_result_mode_schema,
 	limit_schema,
+	quality_report_schema,
 	query_schema,
 } from './schemas.js';
 
@@ -58,6 +63,7 @@ export const register_web_search = (
 				include_domains: include_domains_schema,
 				exclude_domains: exclude_domains_schema,
 				large_result_mode: large_result_mode_schema,
+				quality_report: quality_report_schema,
 			}),
 		},
 		async ({
@@ -67,6 +73,7 @@ export const register_web_search = (
 			include_domains,
 			exclude_domains,
 			large_result_mode,
+			quality_report,
 		}) =>
 			handle_tool_result(
 				'web_search',
@@ -80,7 +87,17 @@ export const register_web_search = (
 						exclude_domains,
 					});
 				},
-				{ large_result_mode },
+				{
+					large_result_mode,
+					quality_report: maybe_quality_report(quality_report, {
+						selected_provider: provider,
+						selection_reason: 'explicit',
+						skipped: skipped_from_status(
+							providers.status_entries(),
+							provider,
+						),
+					}),
+				},
 			),
 	);
 };


### PR DESCRIPTION
## Summary

Adds an opt-in `quality_report: true` flag on `web_search`, `ai_search`, `github_search`, and `web_extract` so operators can see why a provider was selected, what was skipped or cooled down, and basic result-quality counts. Default responses are unchanged.

This is the operator-console slice of #187. Auto-routing scores and cooldown entries are included in the schema and stay empty until those features exist.

Fixes #196.

## Scope

- Shared `quality_report` schema and builder (`src/server/tools/quality-report.ts`)
- Attach the report after large-result handling so it stays in the MCP JSON even when content is offloaded
- README and troubleshooting notes
- Patch changeset

The report is structured JSON only. It never includes API keys, env var names, or raw vendor bodies.

## Verification

```bash
pnpm test
pnpm run format
pnpm run build
pnpm run check
```

Local result: 120 tests passed, format/lint/typecheck clean, advisory check passed, build succeeded.

Example:

```json
{
  "query": "sveltekit remote functions",
  "provider": "brave",
  "quality_report": true
}
```

Default (flag omitted or `false`) still returns the original result array/object.

## Impact

- No breaking change: default payloads are identical
- No new API keys or provider requirements
- `scores`, `cooldown`, and `auto_excluded` are present for forward compatibility and are empty on explicit single-provider calls today

## Test plan

- [x] Default `web_search` / `web_extract` payloads unchanged in contract tests
- [x] `quality_report: true` wraps search arrays and attaches `selected`, `skipped`, counts, and `extract_recommended`
- [x] Report JSON does not contain API keys or raw vendor bodies
- [x] Error path can attach a sanitized report without vendor response text
- [ ] CI green on this PR