### PR TITLE
Add unified web_search freshness filter

### DIFF
--- a/.changeset/unified-freshness.md
+++ b/.changeset/unified-freshness.md
@@ -1,0 +1,5 @@
+---
+'mcp-omnisearch': patch
+---
+
+Add a unified web_search freshness filter with per-provider mappings.

--- a/README.md
+++ b/README.md
@@ -80,9 +80,17 @@ Search the web with Tavily, Brave, Kagi, Exa, or Kagi Enrichment.
 {
 	"query": "sveltekit remote functions site:docs.svelte.dev",
 	"provider": "brave",
-	"limit": 10
+	"limit": 10,
+	"freshness": "week"
 }
 ```
+
+`freshness` accepts `day`, `week`, `month`, or `year`
+(case-insensitive) and is translated to each provider's native recency
+filter. Providers without recency support still run the search and set
+`freshness.applied=false` in result metadata. Existing `after:` /
+`before:` operators and Tavily date fields keep working. See
+[search operators](docs/search-operators.md#unified-freshness).
 
 ### `ai_search`
 

--- a/docs/provider-selection.md
+++ b/docs/provider-selection.md
@@ -7,13 +7,13 @@ mode.
 
 ## Search providers
 
-| Provider          | API key          | Best for                                                              | Operators and filters                                                                                                               |
-| ----------------- | ---------------- | --------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| `brave`           | `BRAVE_API_KEY`  | Privacy-oriented web search, native search operators, exact discovery | Passes rich operators through in the query string and merges `include_domains` / `exclude_domains` into `site:` / `-site:` clauses. |
-| `kagi`            | `KAGI_API_KEY`   | High-quality web results and focused research                         | Preserves query operators, uses Kagi request parameters for `filetype:` and `before:` / `after:` dates.                             |
-| `tavily`          | `TAVILY_API_KEY` | Factual/cited search and API-native filtering                         | Translates supported operators into Tavily fields: domains, dates, exact phrases, and country.                                      |
-| `exa`             | `EXA_API_KEY`    | Semantic/neural search and discovery                                  | Supports domain filters through request parameters; optimized for meaning rather than exact operator syntax.                        |
-| `kagi_enrichment` | `KAGI_API_KEY`   | Specialized Kagi enrichment indexes                                   | Use when enrichment/specialized-index results are desired rather than general web results.                                          |
+| Provider          | API key          | Best for                                                              | Operators and filters                                                                                                                                                         |
+| ----------------- | ---------------- | --------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `brave`           | `BRAVE_API_KEY`  | Privacy-oriented web search, native search operators, exact discovery | Passes rich operators through in the query string, maps `freshness` to `pd`/`pw`/`pm`/`py`, and merges `include_domains` / `exclude_domains` into `site:` / `-site:` clauses. |
+| `kagi`            | `KAGI_API_KEY`   | High-quality web results and focused research                         | Preserves query operators, uses Kagi request parameters for `filetype:`, `before:` / `after:` dates, and unified `freshness`.                                                 |
+| `tavily`          | `TAVILY_API_KEY` | Factual/cited search and API-native filtering                         | Translates supported operators into Tavily fields: domains, dates, exact phrases, and country. Maps `freshness` to `time_range`.                                              |
+| `exa`             | `EXA_API_KEY`    | Semantic/neural search and discovery                                  | Supports domain filters through request parameters and maps `freshness` to `startPublishedDate`; optimized for meaning rather than exact operator syntax.                     |
+| `kagi_enrichment` | `KAGI_API_KEY`   | Specialized Kagi enrichment indexes                                   | Use when enrichment/specialized-index results are desired rather than general web results. `freshness` is accepted but not applied (`freshness.applied=false`).               |
 
 ## AI answer providers
 

--- a/docs/search-operators.md
+++ b/docs/search-operators.md
@@ -19,6 +19,7 @@ and GitHub uses GitHub search qualifiers.
 | `lang:en`                             | Native query passthrough                | Query passthrough                      | Left in sanitized query                        | Not a primary operator           | `language:typescript` for GitHub        |
 | `loc:us` / `location:us`              | Native query passthrough                | Query passthrough                      | `country` parameter                            | Not a primary operator           | Not applicable                          |
 | `before:` / `after:`                  | Native query passthrough                | Kagi `time_range` parameter            | `end_date` / `start_date`                      | Not a primary operator           | GitHub supports its own date qualifiers |
+| `freshness`                           | Brave `freshness` (`pd`/`pw`/`pm`/`py`) | Kagi `time_range=after:YYYY-MM-DD`     | Tavily `time_range`                            | Exa `startPublishedDate`         | Not applicable                          |
 | `"exact phrase"`                      | Native query passthrough                | Query passthrough                      | Enables `exact_match`                          | Semantic matching                | Quote strings in GitHub query           |
 | `+required` / `-excluded`             | Native query passthrough                | Query passthrough                      | Left in sanitized query where unsupported      | Not a primary operator           | GitHub query syntax                     |
 | `AND` / `OR` / `NOT`                  | Native query passthrough                | Query passthrough                      | Left in sanitized query where unsupported      | Not a primary operator           | GitHub query syntax varies by endpoint  |
@@ -26,6 +27,25 @@ and GitHub uses GitHub search qualifiers.
 
 Unsupported provider-specific operators remain in the sanitized query
 where possible rather than being flattened globally.
+
+## Unified freshness
+
+`web_search` accepts an optional `freshness` argument: `day`, `week`,
+`month`, or `year` (case-insensitive). Invalid values are rejected
+before the provider is called.
+
+| Provider          | Native mapping                                    | `freshness.applied` |
+| ----------------- | ------------------------------------------------- | ------------------- |
+| `brave`           | Query param `freshness=pd` / `pw` / `pm` / `py`   | `true`              |
+| `tavily`          | Request field `time_range`                        | `true`              |
+| `kagi`            | Query param `time_range=after:YYYY-MM-DD`         | `true`              |
+| `exa`             | Request field `startPublishedDate` (UTC ISO-8601) | `true`              |
+| `kagi_enrichment` | No recency filter; search still runs              | `false`             |
+
+Operator strings such as `after:` / `before:` and Tavily `start_date`
+/ `end_date` keep working alongside `freshness`. When both a freshness
+window and a Kagi `after:` operator are present, the later start date
+is sent so the more restrictive bound wins.
 
 ## Tested examples
 

--- a/src/common/freshness.test.ts
+++ b/src/common/freshness.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+	attach_freshness_metadata,
+	brave_freshness_param,
+	exa_start_published_date,
+	freshness_start_date,
+	kagi_freshness_after,
+	normalize_freshness,
+	provider_supports_freshness,
+	tavily_time_range,
+} from './freshness.js';
+
+describe('freshness', () => {
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('normalizes case-insensitive day/week/month/year values', () => {
+		expect(normalize_freshness('DAY')).toBe('day');
+		expect(normalize_freshness(' Week ')).toBe('week');
+		expect(normalize_freshness('month')).toBe('month');
+		expect(normalize_freshness('YEAR')).toBe('year');
+	});
+
+	it('rejects invalid freshness values with a clear error', () => {
+		expect(() => normalize_freshness('yesterday')).toThrow(
+			/freshness must be one of: day, week, month, year/i,
+		);
+	});
+
+	it('maps freshness to each provider native parameter', () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-08-16T12:00:00.000Z'));
+
+		expect(brave_freshness_param('day')).toBe('pd');
+		expect(brave_freshness_param('week')).toBe('pw');
+		expect(brave_freshness_param('month')).toBe('pm');
+		expect(brave_freshness_param('year')).toBe('py');
+
+		expect(tavily_time_range('week')).toBe('week');
+		expect(freshness_start_date('week')).toBe('2026-08-09');
+		expect(kagi_freshness_after('week')).toBe('after:2026-08-09');
+		expect(exa_start_published_date('week')).toBe(
+			'2026-08-09T12:00:00.000Z',
+		);
+	});
+
+	it('reports recency support truthfully per provider', () => {
+		expect(provider_supports_freshness('brave')).toBe(true);
+		expect(provider_supports_freshness('tavily')).toBe(true);
+		expect(provider_supports_freshness('kagi')).toBe(true);
+		expect(provider_supports_freshness('exa')).toBe(true);
+		expect(provider_supports_freshness('kagi_enrichment')).toBe(
+			false,
+		);
+	});
+
+	it('attaches freshness metadata without claiming unsupported filters ran', () => {
+		const results = [
+			{
+				title: 'Result',
+				url: 'https://example.com',
+				snippet: 'Summary',
+				source_provider: 'kagi_enrichment',
+				metadata: { extra: true },
+			},
+		];
+
+		expect(
+			attach_freshness_metadata(results, undefined, false),
+		).toEqual(results);
+		expect(attach_freshness_metadata(results, 'week', false)).toEqual(
+			[
+				{
+					...results[0],
+					metadata: {
+						extra: true,
+						freshness: { requested: 'week', applied: false },
+					},
+				},
+			],
+		);
+	});
+});

--- a/src/common/freshness.ts
+++ b/src/common/freshness.ts
@@ -1,0 +1,105 @@
+import type { FreshnessValue, SearchResult } from './types.js';
+
+export type { FreshnessValue };
+
+export const FRESHNESS_VALUES = [
+	'day',
+	'week',
+	'month',
+	'year',
+] as const;
+
+export interface FreshnessMetadata {
+	requested: FreshnessValue;
+	applied: boolean;
+}
+
+const FRESHNESS_DAYS: Record<FreshnessValue, number> = {
+	day: 1,
+	week: 7,
+	month: 30,
+	year: 365,
+};
+
+const BRAVE_FRESHNESS_PARAM: Record<FreshnessValue, string> = {
+	day: 'pd',
+	week: 'pw',
+	month: 'pm',
+	year: 'py',
+};
+
+const FRESHNESS_PROVIDERS = new Set([
+	'brave',
+	'tavily',
+	'kagi',
+	'exa',
+]);
+
+const INVALID_FRESHNESS_MESSAGE =
+	'freshness must be one of: day, week, month, year';
+
+export const is_freshness_value = (
+	value: string,
+): value is FreshnessValue =>
+	(FRESHNESS_VALUES as readonly string[]).includes(value);
+
+export const normalize_freshness = (
+	value: string,
+): FreshnessValue => {
+	const normalized = value.trim().toLowerCase();
+	if (!is_freshness_value(normalized)) {
+		throw new Error(INVALID_FRESHNESS_MESSAGE);
+	}
+	return normalized;
+};
+
+export const provider_supports_freshness = (provider: string) =>
+	FRESHNESS_PROVIDERS.has(provider);
+
+export const brave_freshness_param = (freshness: FreshnessValue) =>
+	BRAVE_FRESHNESS_PARAM[freshness];
+
+export const tavily_time_range = (freshness: FreshnessValue) =>
+	freshness;
+
+export const freshness_start_date = (
+	freshness: FreshnessValue,
+	now: Date = new Date(),
+) =>
+	new Date(
+		now.getTime() - FRESHNESS_DAYS[freshness] * 24 * 60 * 60 * 1000,
+	)
+		.toISOString()
+		.slice(0, 10);
+
+export const kagi_freshness_after = (
+	freshness: FreshnessValue,
+	now: Date = new Date(),
+) => `after:${freshness_start_date(freshness, now)}`;
+
+export const exa_start_published_date = (
+	freshness: FreshnessValue,
+	now: Date = new Date(),
+) =>
+	new Date(
+		now.getTime() - FRESHNESS_DAYS[freshness] * 24 * 60 * 60 * 1000,
+	).toISOString();
+
+export const attach_freshness_metadata = (
+	results: SearchResult[],
+	freshness: FreshnessValue | undefined,
+	applied: boolean,
+): SearchResult[] => {
+	if (!freshness) return results;
+
+	return results.map((result) => ({
+		...result,
+		metadata: {
+			...result.metadata,
+			freshness: {
+				requested: freshness,
+				applied,
+			} satisfies FreshnessMetadata,
+		},
+	}));
+};

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -1,5 +1,7 @@
 // Common type definitions for the MCP Omnisearch server
 
+export type FreshnessValue = 'day' | 'week' | 'month' | 'year';
+
 export type ProviderMetadata = Record<string, unknown>;
 
 export interface SearchResult {
@@ -16,6 +18,7 @@ export interface BaseSearchParams {
 	limit?: number;
 	include_domains?: string[];
 	exclude_domains?: string[];
+	freshness?: FreshnessValue;
 }
 
 export interface ProcessingResult {

--- a/src/providers/enhancement/kagi-enrichment/index.test.ts
+++ b/src/providers/enhancement/kagi-enrichment/index.test.ts
@@ -76,4 +76,40 @@ describe('KagiEnrichmentSearchProvider', () => {
 			},
 		]);
 	});
+
+	it('still searches when freshness is set and reports applied=false', async () => {
+		const fetch = vi
+			.fn()
+			.mockResolvedValueOnce(
+				json_response({
+					data: [
+						{
+							title: 'Web',
+							url: 'https://web.test',
+							snippet: 'Hello',
+						},
+					],
+				}),
+			)
+			.mockResolvedValueOnce(
+				json_response({
+					data: [],
+				}),
+			);
+		vi.stubGlobal('fetch', fetch);
+		const { KagiEnrichmentSearchProvider } =
+			await import('./index.js');
+
+		const results = await new KagiEnrichmentSearchProvider().search({
+			query: 'kagi',
+			freshness: 'week',
+			limit: 1,
+		});
+
+		expect(fetch).toHaveBeenCalled();
+		expect(results[0]?.metadata?.freshness).toEqual({
+			requested: 'week',
+			applied: false,
+		});
+	});
 });

--- a/src/providers/enhancement/kagi-enrichment/index.ts
+++ b/src/providers/enhancement/kagi-enrichment/index.ts
@@ -4,7 +4,9 @@ import {
 } from '../../../common/errors.js';
 import { http_json } from '../../../common/http.js';
 import { retry_with_backoff } from '../../../common/retry.js';
+import { attach_freshness_metadata } from '../../../common/freshness.js';
 import {
+	BaseSearchParams,
 	ErrorType,
 	ProviderError,
 	SearchProvider,
@@ -31,10 +33,7 @@ export class KagiEnrichmentSearchProvider implements SearchProvider {
 	description =
 		'Search specialized indexes (Teclis for web, TinyGem for news). Ideal for discovering non-mainstream results and supplementary knowledge.';
 
-	async search(params: {
-		query: string;
-		limit?: number;
-	}): Promise<SearchResult[]> {
+	async search(params: BaseSearchParams): Promise<SearchResult[]> {
 		const api_key = validate_api_key(
 			config.enhancement.kagi_enrichment.api_key,
 			this.name,
@@ -96,24 +95,28 @@ export class KagiEnrichmentSearchProvider implements SearchProvider {
 
 				const allData = [...webData.data, ...newsData.data];
 
-				return allData.flatMap((result): SearchResult[] => {
-					if (!result.title || !result.url) return [];
+				return attach_freshness_metadata(
+					allData.flatMap((result): SearchResult[] => {
+						if (!result.title || !result.url) return [];
 
-					return [
-						{
-							title: result.title,
-							url: result.url,
-							snippet: (result.snippet ?? '')
-								.replace(/&#39;/g, "'")
-								.replace(/&quot;/g, '"')
-								.replace(/&amp;/g, '&')
-								.replace(/&lt;/g, '<')
-								.replace(/&gt;/g, '>'),
-							score: result.rank ? 1 / result.rank : undefined,
-							source_provider: this.name,
-						},
-					];
-				});
+						return [
+							{
+								title: result.title,
+								url: result.url,
+								snippet: (result.snippet ?? '')
+									.replace(/&#39;/g, "'")
+									.replace(/&quot;/g, '"')
+									.replace(/&amp;/g, '&')
+									.replace(/&lt;/g, '<')
+									.replace(/&gt;/g, '>'),
+								score: result.rank ? 1 / result.rank : undefined,
+								source_provider: this.name,
+							},
+						];
+					}),
+					params.freshness,
+					false,
+				);
 			} catch (error) {
 				handle_provider_error(error, this.name, 'enrich content');
 			}

--- a/src/providers/search/brave/index.test.ts
+++ b/src/providers/search/brave/index.test.ts
@@ -55,6 +55,41 @@ describe('BraveSearchProvider', () => {
 		]);
 	});
 
+	it('maps freshness to the Brave query param and keeps after: operators', async () => {
+		const fetch = vi.fn(
+			async (_input: RequestInfo | URL, _init?: RequestInit) =>
+				json_response({
+					web: {
+						results: [
+							{
+								title: 'Result',
+								url: 'https://example.com',
+								description: 'Summary',
+							},
+						],
+					},
+				}),
+		);
+		vi.stubGlobal('fetch', fetch);
+		const { BraveSearchProvider } = await import('./index.js');
+
+		const results = await new BraveSearchProvider().search({
+			query: 'result after:2023',
+			freshness: 'week',
+			limit: 1,
+		});
+		const request_url = fetch.mock.calls[0]?.[0];
+		expect(typeof request_url).toBe('string');
+		const url = new URL(request_url as string);
+
+		expect(url.searchParams.get('freshness')).toBe('pw');
+		expect(url.searchParams.get('q')).toContain('after:2023');
+		expect(results[0]?.metadata?.freshness).toEqual({
+			requested: 'week',
+			applied: true,
+		});
+	});
+
 	it('returns no results when the web block is omitted', async () => {
 		vi.stubGlobal(
 			'fetch',

--- a/src/providers/search/brave/index.ts
+++ b/src/providers/search/brave/index.ts
@@ -4,6 +4,10 @@ import { http_json } from '../../../common/http.js';
 import { parse_provider_response } from '../../../common/provider-response.js';
 import { retry_with_backoff } from '../../../common/retry.js';
 import {
+	attach_freshness_metadata,
+	brave_freshness_param,
+} from '../../../common/freshness.js';
+import {
 	apply_search_operators,
 	build_query_with_operators,
 	parse_search_operators,
@@ -58,6 +62,12 @@ export class BraveSearchProvider implements SearchProvider {
 					q: query,
 					count: (params.limit ?? 10).toString(),
 				});
+				if (params.freshness) {
+					query_params.set(
+						'freshness',
+						brave_freshness_param(params.freshness),
+					);
+				}
 
 				const raw_data = await http_json(
 					this.name,
@@ -78,12 +88,16 @@ export class BraveSearchProvider implements SearchProvider {
 					raw_data,
 				);
 
-				return (data.web?.results ?? []).map((result) => ({
-					title: result.title,
-					url: result.url,
-					snippet: result.description ?? '',
-					source_provider: this.name,
-				}));
+				return attach_freshness_metadata(
+					(data.web?.results ?? []).map((result) => ({
+						title: result.title,
+						url: result.url,
+						snippet: result.description ?? '',
+						source_provider: this.name,
+					})),
+					params.freshness,
+					true,
+				);
 			} catch (error) {
 				handle_provider_error(
 					error,

--- a/src/providers/search/exa/index.test.ts
+++ b/src/providers/search/exa/index.test.ts
@@ -17,6 +17,7 @@ describe('ExaSearchProvider', () => {
 	});
 
 	afterEach(() => {
+		vi.useRealTimers();
 		vi.unstubAllEnvs();
 		vi.restoreAllMocks();
 	});
@@ -66,6 +67,41 @@ describe('ExaSearchProvider', () => {
 			numResults: 1,
 			includeDomains: ['example.com'],
 			excludeDomains: ['bad.example'],
+		});
+	});
+
+	it('maps freshness to Exa startPublishedDate', async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-08-16T12:00:00.000Z'));
+		const fetch = vi.fn(
+			async (_input: RequestInfo | URL, _init?: RequestInit) =>
+				json_response({
+					requestId: 'req-1',
+					results: [
+						{
+							id: 'id-1',
+							title: 'Exa result',
+							url: 'https://example.com',
+							text: 'Body text',
+						},
+					],
+				}),
+		);
+		vi.stubGlobal('fetch', fetch);
+		const { ExaSearchProvider } = await import('./index.js');
+
+		const results = await new ExaSearchProvider().search({
+			query: 'exa search',
+			freshness: 'week',
+			limit: 1,
+		});
+		const request_init = fetch.mock.calls[0]?.[1];
+		expect(JSON.parse(request_init?.body as string)).toMatchObject({
+			startPublishedDate: '2026-08-09T12:00:00.000Z',
+		});
+		expect(results[0]?.metadata?.freshness).toEqual({
+			requested: 'week',
+			applied: true,
 		});
 	});
 });

--- a/src/providers/search/exa/index.ts
+++ b/src/providers/search/exa/index.ts
@@ -3,6 +3,10 @@ import {
 	handle_provider_error,
 	sanitize_query,
 } from '../../../common/errors.js';
+import {
+	attach_freshness_metadata,
+	exa_start_published_date,
+} from '../../../common/freshness.js';
 import { http_json } from '../../../common/http.js';
 import { parse_provider_response } from '../../../common/provider-response.js';
 import { retry_with_backoff } from '../../../common/retry.js';
@@ -24,6 +28,7 @@ interface ExaSearchRequest {
 		text?: { maxCharacters?: number };
 	};
 	category?: string;
+	startPublishedDate?: string;
 }
 
 const exa_search_response_schema = v.object({
@@ -81,6 +86,11 @@ export class ExaSearchProvider implements SearchProvider {
 				) {
 					request_body.excludeDomains = params.exclude_domains;
 				}
+				if (params.freshness) {
+					request_body.startPublishedDate = exa_start_published_date(
+						params.freshness,
+					);
+				}
 
 				const raw_data = await http_json(
 					this.name,
@@ -103,23 +113,27 @@ export class ExaSearchProvider implements SearchProvider {
 					raw_data,
 				);
 
-				return data.results.map((result) => ({
-					title: result.title,
-					url: result.url,
-					snippet:
-						result.text || result.summary || 'No content available',
-					score: result.score || 0,
-					source_provider: this.name,
-					metadata: {
-						id: result.id,
-						author: result.author,
-						publishedDate: result.publishedDate,
-						highlights: result.highlights,
-						autopromptString: data.autopromptString,
-						resolvedSearchType:
-							data.resolvedSearchType ?? data.searchType,
-					},
-				}));
+				return attach_freshness_metadata(
+					data.results.map((result) => ({
+						title: result.title,
+						url: result.url,
+						snippet:
+							result.text || result.summary || 'No content available',
+						score: result.score || 0,
+						source_provider: this.name,
+						metadata: {
+							id: result.id,
+							author: result.author,
+							publishedDate: result.publishedDate,
+							highlights: result.highlights,
+							autopromptString: data.autopromptString,
+							resolvedSearchType:
+								data.resolvedSearchType ?? data.searchType,
+						},
+					})),
+					params.freshness,
+					true,
+				);
 			} catch (error) {
 				handle_provider_error(
 					error,

--- a/src/providers/search/kagi/index.test.ts
+++ b/src/providers/search/kagi/index.test.ts
@@ -20,6 +20,7 @@ describe('KagiSearchProvider', () => {
 	});
 
 	afterEach(() => {
+		vi.useRealTimers();
 		vi.unstubAllEnvs();
 		vi.restoreAllMocks();
 	});
@@ -79,5 +80,35 @@ describe('KagiSearchProvider', () => {
 				source_provider: 'kagi',
 			},
 		]);
+	});
+
+	it('maps freshness to Kagi time_range and keeps before:/after: operators', async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-08-16T12:00:00.000Z'));
+		const fetch = vi.fn(
+			async (_input: RequestInfo | URL, _init?: RequestInit) =>
+				json_response({
+					data: [{ title: 'Good', url: 'https://example.com' }],
+				}),
+		);
+		vi.stubGlobal('fetch', fetch);
+		const { KagiSearchProvider } = await import('./index.js');
+
+		const results = await new KagiSearchProvider().search({
+			query: 'mixed rows after:2023 before:2024',
+			freshness: 'week',
+			limit: 10,
+		});
+		const request_url = fetch.mock.calls[0]?.[0];
+		expect(typeof request_url).toBe('string');
+		const url = new URL(request_url as string);
+
+		expect(url.searchParams.get('time_range')).toBe(
+			'after:2026-08-09,before:2024',
+		);
+		expect(results[0]?.metadata?.freshness).toEqual({
+			requested: 'week',
+			applied: true,
+		});
 	});
 });

--- a/src/providers/search/kagi/index.ts
+++ b/src/providers/search/kagi/index.ts
@@ -4,6 +4,10 @@ import { http_json } from '../../../common/http.js';
 import { parse_provider_response } from '../../../common/provider-response.js';
 import { retry_with_backoff } from '../../../common/retry.js';
 import {
+	attach_freshness_metadata,
+	freshness_start_date,
+} from '../../../common/freshness.js';
+import {
 	apply_search_operators,
 	build_query_with_operators,
 	parse_search_operators,
@@ -82,10 +86,16 @@ export class KagiSearchProvider implements SearchProvider {
 				}
 
 				// Add time range as query parameter (Kagi-specific)
-				if (search_params.date_before || search_params.date_after) {
+				const after_dates = [
+					params.freshness
+						? freshness_start_date(params.freshness)
+						: undefined,
+					search_params.date_after,
+				].filter((value): value is string => Boolean(value));
+				if (after_dates.length > 0 || search_params.date_before) {
 					const time_range: string[] = [];
-					if (search_params.date_after) {
-						time_range.push(`after:${search_params.date_after}`);
+					if (after_dates.length > 0) {
+						time_range.push(`after:${after_dates.sort().at(-1)}`);
 					}
 					if (search_params.date_before) {
 						time_range.push(`before:${search_params.date_before}`);
@@ -112,15 +122,17 @@ export class KagiSearchProvider implements SearchProvider {
 					raw_data,
 				);
 
-				return data.data
-					.filter(is_kagi_search_result)
-					.map((result) => ({
+				return attach_freshness_metadata(
+					data.data.filter(is_kagi_search_result).map((result) => ({
 						title: result.title,
 						url: result.url,
 						snippet: result.snippet ?? '',
 						score: result.rank,
 						source_provider: this.name,
-					}));
+					})),
+					params.freshness,
+					true,
+				);
 			} catch (error) {
 				handle_provider_error(
 					error,

--- a/src/providers/search/tavily/index.test.ts
+++ b/src/providers/search/tavily/index.test.ts
@@ -62,6 +62,44 @@ describe('TavilySearchProvider', () => {
 		]);
 	});
 
+	it('maps freshness to Tavily time_range and keeps date operators', async () => {
+		const fetch = vi.fn(
+			async (_input: RequestInfo | URL, _init?: RequestInit) =>
+				json_response({
+					results: [
+						{
+							title: 'Result',
+							url: 'https://example.com',
+							content: 'Content',
+							score: 0.5,
+						},
+					],
+					response_time: 0.2,
+				}),
+		);
+		vi.stubGlobal('fetch', fetch);
+		const { TavilySearchProvider } = await import('./index.js');
+
+		const results = await new TavilySearchProvider().search({
+			query:
+				'example after:2024-05 before:2024-05-10 loc:United-Kingdom',
+			freshness: 'week',
+			limit: 1,
+		});
+
+		const request_init = fetch.mock.calls[0]?.[1];
+		expect(JSON.parse(request_init?.body as string)).toMatchObject({
+			time_range: 'week',
+			start_date: '2024-05-01',
+			end_date: '2024-05-10',
+			country: 'united kingdom',
+		});
+		expect(results[0]?.metadata?.freshness).toEqual({
+			requested: 'week',
+			applied: true,
+		});
+	});
+
 	it('normalizes date and country operators for Tavily API fields', async () => {
 		const fetch = vi.fn(
 			async (_input: RequestInfo | URL, _init?: RequestInit) =>

--- a/src/providers/search/tavily/index.ts
+++ b/src/providers/search/tavily/index.ts
@@ -7,6 +7,10 @@ import { http_json } from '../../../common/http.js';
 import { parse_provider_response } from '../../../common/provider-response.js';
 import { retry_with_backoff } from '../../../common/retry.js';
 import {
+	attach_freshness_metadata,
+	tavily_time_range,
+} from '../../../common/freshness.js';
+import {
 	apply_search_operators,
 	parse_search_operators,
 } from '../../../common/search-operators.js';
@@ -25,6 +29,7 @@ interface TavilySearchRequest {
 	exclude_domains: string[];
 	search_depth: 'basic';
 	topic: 'general';
+	time_range?: 'day' | 'week' | 'month' | 'year';
 	start_date?: string;
 	end_date?: string;
 	exact_match?: boolean;
@@ -96,6 +101,12 @@ export class TavilySearchProvider implements SearchProvider {
 					topic: 'general',
 				};
 
+				if (params.freshness) {
+					request_body.time_range = tavily_time_range(
+						params.freshness,
+					);
+				}
+
 				// Map date operators to Tavily's start_date/end_date
 				if (search_params.date_after) {
 					request_body.start_date = normalize_tavily_date(
@@ -147,13 +158,17 @@ export class TavilySearchProvider implements SearchProvider {
 					raw_data,
 				);
 
-				return data.results.map((result) => ({
-					title: result.title,
-					url: result.url,
-					snippet: result.content,
-					score: result.score,
-					source_provider: this.name,
-				}));
+				return attach_freshness_metadata(
+					data.results.map((result) => ({
+						title: result.title,
+						url: result.url,
+						snippet: result.content,
+						score: result.score,
+						source_provider: this.name,
+					})),
+					params.freshness,
+					true,
+				);
 			} catch (error) {
 				handle_provider_error(
 					error,

--- a/src/server/tools/contract.test.ts
+++ b/src/server/tools/contract.test.ts
@@ -152,6 +152,20 @@ describe('MCP tool contract', () => {
 			v.safeParse(schema, { query: 'test', provider: 'kagi' })
 				.success,
 		).toBe(false);
+		expect(
+			v.safeParse(schema, {
+				query: 'test',
+				provider: 'brave',
+				freshness: 'WEEK',
+			}).success,
+		).toBe(true);
+		expect(
+			v.safeParse(schema, {
+				query: 'test',
+				provider: 'brave',
+				freshness: 'yesterday',
+			}).success,
+		).toBe(false);
 	});
 
 	it('validates public web_extract payloads and unavailable modes at the MCP layer', async () => {

--- a/src/server/tools/schemas.test.ts
+++ b/src/server/tools/schemas.test.ts
@@ -2,6 +2,7 @@ import * as v from 'valibot';
 import { describe, expect, it } from 'vitest';
 import {
 	domain_schema,
+	freshness_schema,
 	http_url_schema,
 	include_raw_contents_schema,
 	large_result_mode_schema,
@@ -24,6 +25,18 @@ describe('tool schemas', () => {
 		expect(v.safeParse(limit_schema, 0).success).toBe(false);
 		expect(v.safeParse(limit_schema, 51).success).toBe(false);
 		expect(v.safeParse(limit_schema, 1.5).success).toBe(false);
+	});
+
+	it('accepts case-insensitive freshness and rejects invalid values', () => {
+		expect(v.parse(freshness_schema, undefined)).toBeUndefined();
+		expect(v.parse(freshness_schema, 'week')).toBe('week');
+		expect(v.parse(freshness_schema, 'WEEK')).toBe('week');
+		expect(v.parse(freshness_schema, ' Day ')).toBe('day');
+		const invalid = v.safeParse(freshness_schema, 'yesterday');
+		expect(invalid.success).toBe(false);
+		expect(JSON.stringify(invalid.issues)).toMatch(
+			/day, week, month, year/i,
+		);
 	});
 
 	it('validates large-result and extraction payload controls', () => {

--- a/src/server/tools/schemas.ts
+++ b/src/server/tools/schemas.ts
@@ -1,4 +1,8 @@
 import * as v from 'valibot';
+import {
+	is_freshness_value,
+	type FreshnessValue,
+} from '../../common/freshness.js';
 
 const DOMAIN_PATTERN =
 	/^(?:\*\.)?(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,63}$/;
@@ -17,6 +21,21 @@ export const limit_schema = v.optional(
 		v.minValue(1, 'Limit must be at least 1'),
 		v.maxValue(50, 'Limit must be at most 50'),
 		v.description('Maximum number of results (default: 10)'),
+	),
+);
+
+export const freshness_schema = v.optional(
+	v.pipe(
+		v.string(),
+		v.transform((value) => value.trim().toLowerCase()),
+		v.check(
+			(value) => is_freshness_value(value),
+			'freshness must be one of: day, week, month, year',
+		),
+		v.transform((value) => value as FreshnessValue),
+		v.description(
+			'Restrict results to the last day, week, month, or year. Mapped to each provider native recency filter. Unsupported providers still search and set freshness.applied=false.',
+		),
 	),
 );
 

--- a/src/server/tools/web-search.ts
+++ b/src/server/tools/web-search.ts
@@ -1,7 +1,10 @@
 import { McpServer } from 'tmcp';
 import type { GenericSchema } from 'valibot';
 import * as v from 'valibot';
-import { SearchProvider } from '../../common/types.js';
+import {
+	SearchProvider,
+	type FreshnessValue,
+} from '../../common/types.js';
 import {
 	web_search_provider_definitions,
 	type WebSearchProviderName,
@@ -10,6 +13,7 @@ import { ProviderRegistry } from '../provider-registry.js';
 import { handle_tool_result } from './responses.js';
 import {
 	exclude_domains_schema,
+	freshness_schema,
 	include_domains_schema,
 	large_result_mode_schema,
 	limit_schema,
@@ -41,7 +45,7 @@ export const register_web_search = (
 		{
 			name: 'web_search',
 			description:
-				'Search the web for information. Use when you need to find web pages, articles, or data. Providers: tavily (factual/citations), brave (privacy/operators), kagi (quality/operators), exa (AI-semantic), kagi_enrichment (specialized indexes). Brave/Kagi support query operators like site:, filetype:, lang:, before:, after:.',
+				'Search the web for information. Use when you need to find web pages, articles, or data. Providers: tavily (factual/citations), brave (privacy/operators), kagi (quality/operators), exa (AI-semantic), kagi_enrichment (specialized indexes). Optional freshness (day|week|month|year) maps to each provider native recency filter; unsupported providers still search and set freshness.applied=false. Brave/Kagi support query operators like site:, filetype:, lang:, before:, after:.',
 			annotations: {
 				readOnlyHint: true,
 				destructiveHint: false,
@@ -57,6 +61,7 @@ export const register_web_search = (
 				limit: limit_schema,
 				include_domains: include_domains_schema,
 				exclude_domains: exclude_domains_schema,
+				freshness: freshness_schema,
 				large_result_mode: large_result_mode_schema,
 			}),
 		},
@@ -66,6 +71,7 @@ export const register_web_search = (
 			limit,
 			include_domains,
 			exclude_domains,
+			freshness,
 			large_result_mode,
 		}) =>
 			handle_tool_result(
@@ -78,6 +84,7 @@ export const register_web_search = (
 						limit,
 						include_domains,
 						exclude_domains,
+						freshness: freshness as FreshnessValue | undefined,
 					});
 				},
 				{ large_result_mode },


### PR DESCRIPTION
## Summary

Adds an optional `freshness` argument on `web_search` (`day` | `week` | `month` | `year`, case-insensitive) and maps it to each provider's native recency filter so agents do not have to learn vendor date syntax.

- Brave: `freshness=pd|pw|pm|py`
- Tavily: `time_range`
- Kagi: `time_range=after:YYYY-MM-DD`
- Exa: `startPublishedDate`
- `kagi_enrichment`: search still runs, result metadata sets `freshness.applied=false`

Invalid values are rejected at the tool schema. Existing `after:` / `before:` operators and Tavily `start_date` / `end_date` keep working.

Fixes #198.

## Scope

- Shared freshness helpers and `web_search` schema
- Provider request mapping plus result metadata
- Docs (README, operator matrix, provider selection) and a patch changeset

## Verification

```text
corepack pnpm run check   # format, lint, types, advisories
corepack pnpm run test    # 119 tests
corepack pnpm run build
```

## Impact

Backward compatible. `freshness` is optional. No new API keys or breaking response shape when the argument is omitted.