### PR TITLE
feat: optional downstream MCP backends for official remotes

### DIFF
--- a/.changeset/optional-mcp-backends.md
+++ b/.changeset/optional-mcp-backends.md
@@ -1,0 +1,5 @@
+---
+'mcp-omnisearch': patch
+---
+
+feat: add optional downstream MCP backends for official remotes

--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ Tavily, Kagi, Firecrawl, or Exa.
 
 - [Provider selection](docs/provider-selection.md) — choose providers
   by task, key, mode, and capability.
+- [MCP backends](docs/mcp-backends.md) — optional downstream official
+  remotes or stdio MCP servers.
 - [Search operators](docs/search-operators.md) — operator support
   matrix and tested examples.
 - [Large results](docs/large-results.md) — inline vs file response
@@ -144,6 +146,8 @@ Tavily, Kagi, Firecrawl, or Exa.
 - `FIRECRAWL_API_KEY`
 - `FIRECRAWL_BASE_URL` optional, for self-hosted Firecrawl
 - `OMNISEARCH_LARGE_RESULT_MODE` optional, `file` default or `inline`
+- `OMNISEARCH_MCP_BACKENDS` optional JSON map of downstream MCP search
+  backends; see [MCP backends](docs/mcp-backends.md)
 
 ## Development
 

--- a/docs/mcp-backends.md
+++ b/docs/mcp-backends.md
@@ -1,0 +1,77 @@
+# Optional downstream MCP backends
+
+Direct HTTP adapters remain the default. Operators who already run an
+official remote MCP (for example through ToolHive) can register that
+server as an extra `web_search` provider. Omnisearch then owns
+timeouts and result mapping; vendor auth and tool schemas stay in the
+official server.
+
+Set `OMNISEARCH_MCP_BACKENDS` to a JSON object keyed by provider id.
+Bad mappings fail startup. A successful path that returns an empty
+list is a real empty result. A path or field alias that does not match
+the tool payload fails the request with `MALFORMED_RESPONSE` instead
+of an empty mystery list.
+
+`$NAME` references are supported only as the entire string value.
+`Bearer $EXA_API_KEY` is left unchanged on purpose. Missing names fail
+configuration.
+
+## Official remote example: Exa
+
+```json
+{
+	"exa_mcp": {
+		"transport": {
+			"url": "https://mcp.exa.ai/mcp",
+			"headers": {
+				"x-api-key": "$EXA_API_KEY"
+			}
+		},
+		"tool": "web_search_exa",
+		"query_argument": "query",
+		"limit_argument": "numResults",
+		"result_path": ["results"],
+		"field_aliases": {
+			"title": ["title"],
+			"url": ["url"],
+			"snippet": ["text", "snippet"],
+			"score": ["score"]
+		},
+		"timeout": 30000,
+		"estimated_cost": 0
+	}
+}
+```
+
+`result_path` is applied to `structuredContent` or to JSON text
+returned by the tool. It must resolve to an array of objects with
+title and URL after aliases. If a remote returns only formatted prose,
+wrap it or point `result_path` at a JSON list; do not expect
+Omnisearch to guess.
+
+Use `web_search` with `"provider": "exa_mcp"`. The built-in `exa` HTTP
+adapter is unchanged.
+
+## Stdio example
+
+```json
+{
+	"local_search": {
+		"command": "npx",
+		"args": ["-y", "some-search-mcp"],
+		"env": {
+			"API_KEY": "$SEARCH_API_KEY"
+		},
+		"tool": "search",
+		"query_argument": "query",
+		"limit_argument": "max_results",
+		"result_path": ["results"],
+		"timeout": 20000,
+		"estimated_cost": 0.01
+	}
+}
+```
+
+`env` is valid only with `command`. Remote headers belong on
+`transport`. A backend id cannot reuse a built-in HTTP adapter id
+(`tavily`, `brave`, `kagi`, `exa`, `kagi_enrichment`).

--- a/docs/provider-selection.md
+++ b/docs/provider-selection.md
@@ -7,13 +7,14 @@ mode.
 
 ## Search providers
 
-| Provider          | API key          | Best for                                                              | Operators and filters                                                                                                               |
-| ----------------- | ---------------- | --------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| `brave`           | `BRAVE_API_KEY`  | Privacy-oriented web search, native search operators, exact discovery | Passes rich operators through in the query string and merges `include_domains` / `exclude_domains` into `site:` / `-site:` clauses. |
-| `kagi`            | `KAGI_API_KEY`   | High-quality web results and focused research                         | Preserves query operators, uses Kagi request parameters for `filetype:` and `before:` / `after:` dates.                             |
-| `tavily`          | `TAVILY_API_KEY` | Factual/cited search and API-native filtering                         | Translates supported operators into Tavily fields: domains, dates, exact phrases, and country.                                      |
-| `exa`             | `EXA_API_KEY`    | Semantic/neural search and discovery                                  | Supports domain filters through request parameters; optimized for meaning rather than exact operator syntax.                        |
-| `kagi_enrichment` | `KAGI_API_KEY`   | Specialized Kagi enrichment indexes                                   | Use when enrichment/specialized-index results are desired rather than general web results.                                          |
+| Provider          | API key                   | Best for                                                              | Operators and filters                                                                                                               |
+| ----------------- | ------------------------- | --------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `brave`           | `BRAVE_API_KEY`           | Privacy-oriented web search, native search operators, exact discovery | Passes rich operators through in the query string and merges `include_domains` / `exclude_domains` into `site:` / `-site:` clauses. |
+| `kagi`            | `KAGI_API_KEY`            | High-quality web results and focused research                         | Preserves query operators, uses Kagi request parameters for `filetype:` and `before:` / `after:` dates.                             |
+| `tavily`          | `TAVILY_API_KEY`          | Factual/cited search and API-native filtering                         | Translates supported operators into Tavily fields: domains, dates, exact phrases, and country.                                      |
+| `exa`             | `EXA_API_KEY`             | Semantic/neural search and discovery                                  | Supports domain filters through request parameters; optimized for meaning rather than exact operator syntax.                        |
+| `kagi_enrichment` | `KAGI_API_KEY`            | Specialized Kagi enrichment indexes                                   | Use when enrichment/specialized-index results are desired rather than general web results.                                          |
+| configured MCP id | `OMNISEARCH_MCP_BACKENDS` | Official remote or stdio MCP that you already run                     | Opt-in only. HTTP adapters stay the default. See [MCP backends](mcp-backends.md).                                                   |
 
 ## AI answer providers
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -15,6 +15,12 @@ Each provider requires its own key:
 Missing keys do not stop the server. The matching provider is skipped
 and configured providers remain available.
 
+`OMNISEARCH_MCP_BACKENDS` is different: invalid JSON, reserved ids,
+unknown fields, or missing `$NAME` header/env references fail startup.
+A bad `result_path` or field alias fails the search with
+`MALFORMED_RESPONSE` instead of an empty list. See
+[MCP backends](mcp-backends.md).
+
 ## Common failure modes
 
 | Symptom                                   | Likely cause                                              | Fix                                                                                                                              |

--- a/src/common/http.test.ts
+++ b/src/common/http.test.ts
@@ -6,7 +6,7 @@ import {
 	it,
 	vi,
 } from 'vitest';
-import { http_json } from './http.js';
+import { http_json, http_json_result } from './http.js';
 import { ErrorType } from './types.js';
 
 const fetch_mock = vi.fn();
@@ -20,6 +20,25 @@ describe('http_json', () => {
 	afterEach(() => {
 		vi.unstubAllGlobals();
 		vi.restoreAllMocks();
+	});
+
+	it('exposes response headers for MCP session handling', async () => {
+		fetch_mock.mockResolvedValue(
+			new Response(JSON.stringify({ ok: true }), {
+				status: 200,
+				headers: {
+					'Content-Type': 'application/json',
+					'Mcp-Session-Id': 'session-1',
+				},
+			}),
+		);
+
+		const result = await http_json_result(
+			'exa_mcp',
+			'https://mcp.exa.ai/mcp',
+		);
+		expect(result.data).toEqual({ ok: true });
+		expect(result.headers.get('mcp-session-id')).toBe('session-1');
 	});
 
 	it('returns parsed JSON for successful responses', async () => {

--- a/src/common/http.ts
+++ b/src/common/http.ts
@@ -23,11 +23,17 @@ const get_error_message = (body: unknown) => {
 	}
 };
 
-export const http_json = async <T = unknown>(
+export interface HttpJsonResult<T = unknown> {
+	data: T;
+	status: number;
+	headers: Headers;
+}
+
+export const http_json_result = async <T = unknown>(
 	provider: string,
 	url: string,
 	options: HttpJsonOptions = {},
-): Promise<T> => {
+): Promise<HttpJsonResult<T>> => {
 	const res = await fetch(url, options);
 	const raw = await res.text();
 	const body = tryParseJson(raw);
@@ -46,6 +52,18 @@ export const http_json = async <T = unknown>(
 		);
 	}
 
-	// Prefer JSON if parseable, otherwise return raw text.
-	return (body ?? raw) as T;
+	return {
+		data: (body ?? raw) as T,
+		status: res.status,
+		headers: res.headers,
+	};
+};
+
+export const http_json = async <T = unknown>(
+	provider: string,
+	url: string,
+	options: HttpJsonOptions = {},
+): Promise<T> => {
+	const { data } = await http_json_result<T>(provider, url, options);
+	return data;
 };

--- a/src/common/mcp-client.test.ts
+++ b/src/common/mcp-client.test.ts
@@ -1,0 +1,258 @@
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	vi,
+} from 'vitest';
+import type { ResolvedMcpBackend } from '../config/mcp-backends.js';
+import {
+	call_mcp_tool,
+	parse_mcp_response_body,
+	unwrap_jsonrpc_result,
+} from './mcp-client.js';
+import { ErrorType } from './types.js';
+
+const http_backend: ResolvedMcpBackend = {
+	id: 'exa_mcp',
+	kind: 'http',
+	transport_url: 'https://mcp.exa.ai/mcp',
+	headers: { 'x-api-key': 'exa-key' },
+	env: {},
+	tool: 'web_search_exa',
+	query_argument: 'query',
+	limit_argument: 'numResults',
+	static_arguments: {},
+	result_path: ['results'],
+	field_aliases: {
+		title: ['title'],
+		url: ['url'],
+		snippet: ['text'],
+		score: ['score'],
+	},
+	timeout: 5_000,
+	estimated_cost: 0,
+};
+
+const json_response = (
+	body: unknown,
+	headers: Record<string, string> = {},
+) =>
+	new Response(JSON.stringify(body), {
+		status: 200,
+		headers: {
+			'content-type': 'application/json',
+			...headers,
+		},
+	});
+
+describe('mcp client helpers', () => {
+	it('parses JSON-RPC bodies and SSE data frames', () => {
+		expect(
+			parse_mcp_response_body({
+				jsonrpc: '2.0',
+				result: { ok: true },
+			}),
+		).toEqual({ jsonrpc: '2.0', result: { ok: true } });
+		expect(
+			parse_mcp_response_body(
+				'event: message\ndata: {"jsonrpc":"2.0","id":1,"result":{"ok":true}}\n\n',
+			),
+		).toEqual({ jsonrpc: '2.0', id: 1, result: { ok: true } });
+	});
+
+	it('unwraps JSON-RPC errors', () => {
+		expect(() =>
+			unwrap_jsonrpc_result(
+				{ jsonrpc: '2.0', error: { message: 'nope' } },
+				'exa_mcp',
+			),
+		).toThrow(
+			expect.objectContaining({
+				type: ErrorType.PROVIDER_ERROR,
+				message: 'nope',
+			}),
+		);
+	});
+});
+
+describe('call_mcp_tool HTTP', () => {
+	const fetch_mock = vi.fn();
+
+	beforeEach(() => {
+		fetch_mock.mockReset();
+		vi.stubGlobal('fetch', fetch_mock);
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		vi.restoreAllMocks();
+	});
+
+	it('initializes a session then calls the mapped tool', async () => {
+		fetch_mock
+			.mockResolvedValueOnce(
+				json_response(
+					{
+						jsonrpc: '2.0',
+						id: 1,
+						result: {
+							protocolVersion: '2025-03-26',
+							capabilities: {},
+							serverInfo: { name: 'exa', version: '1' },
+						},
+					},
+					{ 'mcp-session-id': 'session-1' },
+				),
+			)
+			.mockResolvedValueOnce(new Response(null, { status: 202 }))
+			.mockResolvedValueOnce(
+				json_response({
+					jsonrpc: '2.0',
+					id: 2,
+					result: {
+						structuredContent: {
+							results: [
+								{
+									title: 'Example',
+									url: 'https://example.com',
+								},
+							],
+						},
+					},
+				}),
+			);
+
+		await expect(
+			call_mcp_tool({
+				backend: http_backend,
+				tool: 'web_search_exa',
+				arguments: { query: 'svelte', numResults: 1 },
+			}),
+		).resolves.toEqual({
+			structuredContent: {
+				results: [{ title: 'Example', url: 'https://example.com' }],
+			},
+		});
+
+		expect(fetch_mock).toHaveBeenCalledTimes(3);
+		expect(
+			fetch_mock.mock.calls[2][1].headers['Mcp-Session-Id'],
+		).toBe('session-1');
+		expect(JSON.parse(fetch_mock.mock.calls[2][1].body)).toEqual({
+			jsonrpc: '2.0',
+			id: 2,
+			method: 'tools/call',
+			params: {
+				name: 'web_search_exa',
+				arguments: { query: 'svelte', numResults: 1 },
+			},
+		});
+	});
+
+	it('maps abort timeouts to ProviderError TIMEOUT', async () => {
+		const abort_error = new Error('aborted');
+		abort_error.name = 'TimeoutError';
+		fetch_mock.mockRejectedValue(abort_error);
+
+		await expect(
+			call_mcp_tool({
+				backend: http_backend,
+				tool: 'web_search_exa',
+				arguments: { query: 'svelte' },
+			}),
+		).rejects.toMatchObject({
+			type: ErrorType.TIMEOUT,
+			provider: 'exa_mcp',
+		});
+	});
+
+	it('rejects HTTP backends without a transport URL', async () => {
+		await expect(
+			call_mcp_tool({
+				backend: { ...http_backend, transport_url: undefined },
+				tool: 'web_search_exa',
+				arguments: { query: 'svelte' },
+			}),
+		).rejects.toMatchObject({
+			type: ErrorType.INVALID_INPUT,
+			message: expect.stringContaining('transport_url'),
+		});
+	});
+});
+
+describe('call_mcp_tool stdio', () => {
+	it('rejects stdio backends without a command', async () => {
+		await expect(
+			call_mcp_tool({
+				backend: {
+					...http_backend,
+					kind: 'stdio',
+					command: undefined,
+				},
+				tool: 'search',
+				arguments: { query: 'stdio' },
+			}),
+		).rejects.toMatchObject({
+			type: ErrorType.INVALID_INPUT,
+			message: expect.stringContaining('command'),
+		});
+	});
+
+	it('speaks Content-Length JSON-RPC with a child process', async () => {
+		const dir = await mkdtemp(join(tmpdir(), 'mcp-backend-'));
+		const script = join(dir, 'server.mjs');
+		await writeFile(
+			script,
+			`
+let buf = Buffer.alloc(0);
+process.stdin.on('data', (chunk) => {
+  buf = Buffer.concat([buf, chunk]);
+  for (;;) {
+    const idx = buf.indexOf('\\r\\n\\r\\n');
+    if (idx === -1) break;
+    const header = buf.subarray(0, idx).toString('utf8');
+    const match = header.match(/Content-Length:\\s*(\\d+)/i);
+    const n = Number(match[1]);
+    if (buf.length < idx + 4 + n) break;
+    const msg = JSON.parse(buf.subarray(idx + 4, idx + 4 + n).toString('utf8'));
+    buf = buf.subarray(idx + 4 + n);
+    const send = (obj) => {
+      const json = JSON.stringify(obj);
+      const body = Buffer.from(json, 'utf8');
+      process.stdout.write('Content-Length: ' + body.length + '\\r\\n\\r\\n');
+      process.stdout.write(body);
+    };
+    if (msg.method === 'initialize') {
+      send({ jsonrpc: '2.0', id: msg.id, result: { protocolVersion: '2025-03-26', capabilities: {}, serverInfo: { name: 'mock', version: '0' } } });
+    } else if (msg.method === 'tools/call') {
+      send({ jsonrpc: '2.0', id: msg.id, result: { structuredContent: { results: [{ title: 'Stdio', url: 'https://example.com' }] } } });
+    }
+  }
+});
+`,
+		);
+
+		await expect(
+			call_mcp_tool({
+				backend: {
+					...http_backend,
+					id: 'local_search',
+					kind: 'stdio',
+					command: [process.execPath, script],
+					transport_url: undefined,
+				},
+				tool: 'search',
+				arguments: { query: 'stdio' },
+			}),
+		).resolves.toEqual({
+			structuredContent: {
+				results: [{ title: 'Stdio', url: 'https://example.com' }],
+			},
+		});
+	});
+});

--- a/src/common/mcp-client.ts
+++ b/src/common/mcp-client.ts
@@ -1,0 +1,361 @@
+import { spawn } from 'node:child_process';
+import type { ResolvedMcpBackend } from '../config/mcp-backends.js';
+import { http_json_result } from './http.js';
+import { ErrorType, ProviderError } from './types.js';
+
+const PROTOCOL_VERSION = '2025-03-26';
+const CLIENT_INFO = {
+	name: 'mcp-omnisearch',
+	version: 'mcp-backend',
+};
+
+const is_record = (
+	value: unknown,
+): value is Record<string, unknown> =>
+	typeof value === 'object' &&
+	value !== null &&
+	!Array.isArray(value);
+
+const try_parse_json = (text: string): unknown => {
+	try {
+		return JSON.parse(text) as unknown;
+	} catch {
+		return undefined;
+	}
+};
+
+const is_abort_error = (error: unknown): boolean =>
+	typeof error === 'object' &&
+	error !== null &&
+	'name' in error &&
+	(error.name === 'AbortError' || error.name === 'TimeoutError');
+
+export const parse_mcp_response_body = (data: unknown): unknown => {
+	if (typeof data === 'object' && data !== null) return data;
+	if (typeof data !== 'string') return data;
+
+	const trimmed = data.trim();
+	if (
+		trimmed.startsWith('event:') ||
+		trimmed.startsWith('data:') ||
+		trimmed.includes('\ndata:')
+	) {
+		const payloads: unknown[] = [];
+		for (const line of data.split(/\r?\n/)) {
+			if (!line.startsWith('data:')) continue;
+			const payload = line.slice(5).trim();
+			if (!payload || payload === '[DONE]') continue;
+			const parsed = try_parse_json(payload);
+			if (parsed !== undefined) payloads.push(parsed);
+		}
+		for (let index = payloads.length - 1; index >= 0; index -= 1) {
+			const candidate = payloads[index];
+			if (
+				is_record(candidate) &&
+				('result' in candidate || 'error' in candidate)
+			) {
+				return candidate;
+			}
+		}
+		return payloads.at(-1);
+	}
+
+	return try_parse_json(trimmed) ?? data;
+};
+
+export const unwrap_jsonrpc_result = (
+	message: unknown,
+	provider: string,
+): unknown => {
+	if (!is_record(message)) {
+		throw new ProviderError(
+			ErrorType.MALFORMED_RESPONSE,
+			'Downstream MCP returned a non-object JSON-RPC message',
+			provider,
+		);
+	}
+	if (message.error !== undefined) {
+		const error = message.error;
+		const text =
+			is_record(error) && typeof error.message === 'string'
+				? error.message
+				: 'Downstream MCP JSON-RPC error';
+		throw new ProviderError(
+			ErrorType.PROVIDER_ERROR,
+			text,
+			provider,
+			{
+				mcp_error: error,
+			},
+		);
+	}
+	return message.result;
+};
+
+const encode_stdio_message = (message: unknown): Buffer => {
+	const json = JSON.stringify(message);
+	const body = Buffer.from(json, 'utf8');
+	return Buffer.concat([
+		Buffer.from(`Content-Length: ${body.length}\r\n\r\n`, 'utf8'),
+		body,
+	]);
+};
+
+class ContentLengthReader {
+	private buffer = Buffer.alloc(0);
+
+	push(chunk: Buffer) {
+		this.buffer = Buffer.concat([this.buffer, chunk]);
+	}
+
+	try_read(): { ok: true; value: unknown } | { ok: false } {
+		const header_end = this.buffer.indexOf('\r\n\r\n');
+		if (header_end === -1) return { ok: false };
+		const header = this.buffer
+			.subarray(0, header_end)
+			.toString('utf8');
+		const match = header.match(/Content-Length:\s*(\d+)/i);
+		if (!match) {
+			throw new Error('stdio MCP message is missing Content-Length');
+		}
+		const length = Number(match[1]);
+		const start = header_end + 4;
+		if (this.buffer.length < start + length) return { ok: false };
+		const body = this.buffer
+			.subarray(start, start + length)
+			.toString('utf8');
+		this.buffer = this.buffer.subarray(start + length);
+		return { ok: true, value: JSON.parse(body) as unknown };
+	}
+}
+
+export interface McpToolCallInput {
+	backend: ResolvedMcpBackend;
+	tool: string;
+	arguments: Record<string, unknown>;
+}
+
+const initialize_params = {
+	protocolVersion: PROTOCOL_VERSION,
+	capabilities: {},
+	clientInfo: CLIENT_INFO,
+};
+
+const post_http_mcp = async (
+	backend: ResolvedMcpBackend,
+	body: unknown,
+	session_id?: string,
+	expected_statuses?: number[],
+) => {
+	if (!backend.transport_url) {
+		throw new ProviderError(
+			ErrorType.INVALID_INPUT,
+			'HTTP MCP backend is missing transport_url',
+			backend.id,
+		);
+	}
+
+	try {
+		const result = await http_json_result(
+			backend.id,
+			backend.transport_url,
+			{
+				method: 'POST',
+				headers: {
+					Accept: 'application/json, text/event-stream',
+					'Content-Type': 'application/json',
+					'MCP-Protocol-Version': PROTOCOL_VERSION,
+					...backend.headers,
+					...(session_id ? { 'Mcp-Session-Id': session_id } : {}),
+				},
+				body: JSON.stringify(body),
+				signal: AbortSignal.timeout(backend.timeout),
+				expectedStatuses: expected_statuses,
+			},
+		);
+		return result;
+	} catch (error) {
+		if (is_abort_error(error)) {
+			throw new ProviderError(
+				ErrorType.TIMEOUT,
+				`${backend.id} MCP request timed out`,
+				backend.id,
+				{ retryable: true },
+			);
+		}
+		throw error;
+	}
+};
+
+const call_http_mcp_tool = async (
+	input: McpToolCallInput,
+): Promise<unknown> => {
+	const { backend } = input;
+	const initialize = await post_http_mcp(backend, {
+		jsonrpc: '2.0',
+		id: 1,
+		method: 'initialize',
+		params: initialize_params,
+	});
+	unwrap_jsonrpc_result(
+		parse_mcp_response_body(initialize.data),
+		backend.id,
+	);
+	const session_id =
+		initialize.headers.get('mcp-session-id') ?? undefined;
+
+	await post_http_mcp(
+		backend,
+		{
+			jsonrpc: '2.0',
+			method: 'notifications/initialized',
+		},
+		session_id,
+		[200, 202, 204],
+	);
+
+	const call = await post_http_mcp(
+		backend,
+		{
+			jsonrpc: '2.0',
+			id: 2,
+			method: 'tools/call',
+			params: {
+				name: input.tool,
+				arguments: input.arguments,
+			},
+		},
+		session_id,
+	);
+	return unwrap_jsonrpc_result(
+		parse_mcp_response_body(call.data),
+		backend.id,
+	);
+};
+
+const call_stdio_mcp_tool = async (
+	input: McpToolCallInput,
+): Promise<unknown> => {
+	const { backend } = input;
+	if (!backend.command || backend.command.length === 0) {
+		throw new ProviderError(
+			ErrorType.INVALID_INPUT,
+			'stdio MCP backend is missing command',
+			backend.id,
+		);
+	}
+
+	const child = spawn(backend.command[0]!, backend.command.slice(1), {
+		env: { ...process.env, ...backend.env },
+		stdio: ['pipe', 'pipe', 'ignore'],
+	});
+	const reader = new ContentLengthReader();
+	let pending:
+		| {
+				resolve: (value: unknown) => void;
+				reject: (error: Error) => void;
+		  }
+		| undefined;
+
+	const fail = (error: Error) => {
+		pending?.reject(error);
+		pending = undefined;
+	};
+
+	child.stdout?.on('data', (chunk: Buffer) => {
+		try {
+			reader.push(chunk);
+			let message = reader.try_read();
+			while (message.ok) {
+				pending?.resolve(message.value);
+				pending = undefined;
+				message = reader.try_read();
+			}
+		} catch (error) {
+			fail(
+				error instanceof Error
+					? error
+					: new Error('Failed to parse stdio MCP message'),
+			);
+		}
+	});
+	child.on('error', (error) => fail(error));
+	child.on('exit', (code) => {
+		if (pending) {
+			fail(
+				new Error(
+					`stdio MCP process exited before responding (${code ?? 'null'})`,
+				),
+			);
+		}
+	});
+
+	const request = async (message: unknown): Promise<unknown> => {
+		const response = new Promise<unknown>((resolve, reject) => {
+			pending = { resolve, reject };
+		});
+		child.stdin?.write(encode_stdio_message(message));
+		return response;
+	};
+
+	const timeout = setTimeout(() => {
+		fail(
+			new ProviderError(
+				ErrorType.TIMEOUT,
+				`${backend.id} MCP request timed out`,
+				backend.id,
+				{ retryable: true },
+			),
+		);
+		child.kill('SIGTERM');
+	}, backend.timeout);
+
+	try {
+		unwrap_jsonrpc_result(
+			await request({
+				jsonrpc: '2.0',
+				id: 1,
+				method: 'initialize',
+				params: initialize_params,
+			}),
+			backend.id,
+		);
+		child.stdin?.write(
+			encode_stdio_message({
+				jsonrpc: '2.0',
+				method: 'notifications/initialized',
+			}),
+		);
+		return unwrap_jsonrpc_result(
+			await request({
+				jsonrpc: '2.0',
+				id: 2,
+				method: 'tools/call',
+				params: {
+					name: input.tool,
+					arguments: input.arguments,
+				},
+			}),
+			backend.id,
+		);
+	} catch (error) {
+		if (error instanceof ProviderError) throw error;
+		throw new ProviderError(
+			ErrorType.API_ERROR,
+			`Failed to call downstream MCP tool: ${
+				error instanceof Error ? error.message : 'Unknown error'
+			}`,
+			backend.id,
+		);
+	} finally {
+		clearTimeout(timeout);
+		if (!child.killed) child.kill('SIGTERM');
+	}
+};
+
+export const call_mcp_tool = async (
+	input: McpToolCallInput,
+): Promise<unknown> =>
+	input.backend.kind === 'http'
+		? call_http_mcp_tool(input)
+		: call_stdio_mcp_tool(input);

--- a/src/common/mcp-results.test.ts
+++ b/src/common/mcp-results.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it } from 'vitest';
+import { ErrorType } from './types.js';
+import {
+	extract_result_list,
+	map_mcp_search_results,
+	walk_result_path,
+} from './mcp-results.js';
+
+const aliases = {
+	title: ['title', 'name'],
+	url: ['url', 'link'],
+	snippet: ['snippet', 'text'],
+	score: ['score'],
+};
+
+describe('mcp result mapping', () => {
+	it('walks object and array path segments', () => {
+		expect(
+			walk_result_path({ payload: [{ items: ['ok'] }] }, [
+				'payload',
+				0,
+				'items',
+			]),
+		).toEqual({ ok: true, value: ['ok'] });
+		expect(walk_result_path({ results: [] }, ['hits'])).toEqual({
+			ok: false,
+		});
+	});
+
+	it('reads structuredContent and JSON text tool payloads', () => {
+		expect(
+			extract_result_list(
+				{
+					structuredContent: {
+						results: [
+							{
+								title: 'From structured',
+								url: 'https://example.com/a',
+							},
+						],
+					},
+				},
+				['results'],
+				'exa_mcp',
+			),
+		).toEqual([
+			{ title: 'From structured', url: 'https://example.com/a' },
+		]);
+
+		expect(
+			extract_result_list(
+				{
+					content: [
+						{
+							type: 'text',
+							text: JSON.stringify({
+								results: [
+									{
+										title: 'From text',
+										url: 'https://example.com/b',
+									},
+								],
+							}),
+						},
+					],
+				},
+				['results'],
+				'exa_mcp',
+			),
+		).toEqual([{ title: 'From text', url: 'https://example.com/b' }]);
+	});
+
+	it('treats a successful empty array as a real empty result', () => {
+		expect(
+			extract_result_list(
+				{ structuredContent: { results: [] } },
+				['results'],
+				'exa_mcp',
+			),
+		).toEqual([]);
+	});
+
+	it('fails when the path is missing or not an array', () => {
+		expect(() =>
+			extract_result_list(
+				{ content: [{ type: 'text', text: 'Title: Example' }] },
+				['results'],
+				'exa_mcp',
+			),
+		).toThrow(
+			expect.objectContaining({
+				type: ErrorType.MALFORMED_RESPONSE,
+				message: expect.stringContaining('was not found'),
+			}),
+		);
+
+		expect(() =>
+			extract_result_list(
+				{ structuredContent: { results: { title: 'nope' } } },
+				['results'],
+				'exa_mcp',
+			),
+		).toThrow(
+			expect.objectContaining({
+				type: ErrorType.MALFORMED_RESPONSE,
+				message: expect.stringContaining(
+					'did not resolve to an array',
+				),
+			}),
+		);
+	});
+
+	it('fails tool errors and unmapped title/url fields', () => {
+		expect(() =>
+			extract_result_list(
+				{
+					isError: true,
+					content: [{ type: 'text', text: 'tool exploded' }],
+				},
+				['results'],
+				'exa_mcp',
+			),
+		).toThrow(
+			expect.objectContaining({
+				type: ErrorType.PROVIDER_ERROR,
+				message: 'tool exploded',
+				provider: 'exa_mcp',
+			}),
+		);
+
+		expect(() =>
+			map_mcp_search_results(
+				[{ heading: 'Missing aliases', href: 'https://x.test' }],
+				aliases,
+				'exa_mcp',
+			),
+		).toThrow(
+			expect.objectContaining({
+				type: ErrorType.MALFORMED_RESPONSE,
+				message: expect.stringContaining('missing title/url'),
+			}),
+		);
+	});
+
+	it('uses an empty result_path as the root list', () => {
+		expect(
+			extract_result_list(
+				[
+					{
+						title: 'Root',
+						url: 'https://example.com/root',
+					},
+				],
+				[],
+				'exa_mcp',
+			),
+		).toEqual([{ title: 'Root', url: 'https://example.com/root' }]);
+	});
+
+	it('fails when a result item is not an object', () => {
+		expect(() =>
+			map_mcp_search_results(['not-an-object'], aliases, 'exa_mcp'),
+		).toThrow(
+			expect.objectContaining({
+				type: ErrorType.MALFORMED_RESPONSE,
+				message: expect.stringContaining('is not an object'),
+			}),
+		);
+	});
+
+	it('maps field aliases into SearchResult rows', () => {
+		expect(
+			map_mcp_search_results(
+				[
+					{
+						name: 'Example',
+						link: 'https://example.com',
+						text: 'Snippet',
+						score: 0.4,
+					},
+				],
+				aliases,
+				'exa_mcp',
+			),
+		).toEqual([
+			{
+				title: 'Example',
+				url: 'https://example.com',
+				snippet: 'Snippet',
+				score: 0.4,
+				source_provider: 'exa_mcp',
+			},
+		]);
+	});
+});

--- a/src/common/mcp-results.ts
+++ b/src/common/mcp-results.ts
@@ -1,0 +1,207 @@
+import type { ResolvedMcpBackend } from '../config/mcp-backends.js';
+import { ErrorType, ProviderError } from './types.js';
+import type { SearchResult } from './types.js';
+
+const is_record = (
+	value: unknown,
+): value is Record<string, unknown> =>
+	typeof value === 'object' &&
+	value !== null &&
+	!Array.isArray(value);
+
+const try_parse_json = (text: string): unknown => {
+	try {
+		return JSON.parse(text) as unknown;
+	} catch {
+		return undefined;
+	}
+};
+
+const format_path = (path: Array<string | number>): string =>
+	path.length === 0
+		? '<root>'
+		: path
+				.map((segment) =>
+					typeof segment === 'number'
+						? `[${segment}]`
+						: `.${segment}`,
+				)
+				.join('')
+				.replace(/^\./, '');
+
+const text_from_unknown = (value: unknown): string | undefined => {
+	if (typeof value === 'string') {
+		const trimmed = value.trim();
+		return trimmed.length > 0 ? trimmed : undefined;
+	}
+	if (typeof value === 'number' && Number.isFinite(value)) {
+		return String(value);
+	}
+	return undefined;
+};
+
+const first_alias_value = (
+	item: Record<string, unknown>,
+	aliases: readonly string[],
+): unknown => {
+	for (const alias of aliases) {
+		if (!(alias in item)) continue;
+		const value = item[alias];
+		if (value === undefined || value === null) continue;
+		if (typeof value === 'string' && value.trim() === '') continue;
+		return value;
+	}
+	return undefined;
+};
+
+export const walk_result_path = (
+	root: unknown,
+	path: Array<string | number>,
+): { ok: true; value: unknown } | { ok: false } => {
+	let current = root;
+	for (const segment of path) {
+		if (typeof segment === 'number') {
+			if (
+				!Array.isArray(current) ||
+				segment < 0 ||
+				segment >= current.length
+			) {
+				return { ok: false };
+			}
+			current = current[segment];
+			continue;
+		}
+		if (!is_record(current) || !(segment in current)) {
+			return { ok: false };
+		}
+		current = current[segment];
+	}
+	return { ok: true, value: current };
+};
+
+export const mcp_tool_payload_roots = (
+	result: unknown,
+	provider: string,
+): unknown[] => {
+	if (!is_record(result)) return [result];
+
+	if (result.isError === true) {
+		const content = result.content;
+		const text =
+			Array.isArray(content) &&
+			content.some(
+				(block) => is_record(block) && typeof block.text === 'string',
+			)
+				? (
+						content.find(
+							(block) =>
+								is_record(block) && typeof block.text === 'string',
+						) as { text: string }
+					).text
+				: 'downstream MCP tool returned isError';
+		throw new ProviderError(ErrorType.PROVIDER_ERROR, text, provider);
+	}
+
+	const roots: unknown[] = [];
+	if (result.structuredContent !== undefined) {
+		roots.push(result.structuredContent);
+	}
+	if (Array.isArray(result.content)) {
+		for (const block of result.content) {
+			if (
+				!is_record(block) ||
+				block.type !== 'text' ||
+				typeof block.text !== 'string'
+			) {
+				continue;
+			}
+			const parsed = try_parse_json(block.text);
+			if (parsed !== undefined) roots.push(parsed);
+		}
+	}
+	if (
+		result.results !== undefined ||
+		(roots.length === 0 && result.content === undefined)
+	) {
+		roots.push(result);
+	}
+	return roots;
+};
+
+export const extract_result_list = (
+	result: unknown,
+	path: Array<string | number>,
+	provider: string,
+): unknown[] => {
+	const roots = mcp_tool_payload_roots(result, provider);
+	let saw_non_array = false;
+
+	for (const root of roots) {
+		const walked = walk_result_path(root, path);
+		if (!walked.ok) continue;
+		if (Array.isArray(walked.value)) return walked.value;
+		saw_non_array = true;
+	}
+
+	throw new ProviderError(
+		ErrorType.MALFORMED_RESPONSE,
+		saw_non_array
+			? `MCP backend ${provider} result_path ${format_path(path)} did not resolve to an array`
+			: `MCP backend ${provider} result_path ${format_path(path)} was not found in the tool result`,
+		provider,
+		{ result_path: path },
+	);
+};
+
+export const map_mcp_search_results = (
+	items: unknown[],
+	field_aliases: ResolvedMcpBackend['field_aliases'],
+	provider: string,
+): SearchResult[] =>
+	items.map((item, index) => {
+		if (!is_record(item)) {
+			throw new ProviderError(
+				ErrorType.MALFORMED_RESPONSE,
+				`MCP backend ${provider} result[${index}] is not an object`,
+				provider,
+				{ index },
+			);
+		}
+
+		const title = text_from_unknown(
+			first_alias_value(item, field_aliases.title),
+		);
+		const url = text_from_unknown(
+			first_alias_value(item, field_aliases.url),
+		);
+		if (!title || !url) {
+			throw new ProviderError(
+				ErrorType.MALFORMED_RESPONSE,
+				`MCP backend ${provider} result[${index}] is missing title/url after field aliases`,
+				provider,
+				{
+					index,
+					title_aliases: field_aliases.title,
+					url_aliases: field_aliases.url,
+				},
+			);
+		}
+
+		const snippet =
+			text_from_unknown(
+				first_alias_value(item, field_aliases.snippet),
+			) ?? '';
+		const score_value = first_alias_value(item, field_aliases.score);
+		const score =
+			typeof score_value === 'number' && Number.isFinite(score_value)
+				? score_value
+				: undefined;
+
+		return {
+			title,
+			url,
+			snippet,
+			score,
+			source_provider: provider,
+		};
+	});

--- a/src/config/env.test.ts
+++ b/src/config/env.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
 	should_warn_for_local_file_offload,
+	validate_config,
 	warn_for_local_file_offload,
 } from './env.js';
 
@@ -36,5 +37,22 @@ describe('large-result local file offload warnings', () => {
 				OMNISEARCH_LARGE_RESULT_MODE: 'file',
 			}),
 		).toBe(false);
+	});
+});
+
+describe('validate_config MCP backends', () => {
+	afterEach(() => {
+		delete process.env.OMNISEARCH_MCP_BACKENDS;
+		vi.restoreAllMocks();
+	});
+
+	it('fails startup when OMNISEARCH_MCP_BACKENDS is invalid', () => {
+		vi.spyOn(console, 'error').mockImplementation(() => {});
+		vi.spyOn(console, 'warn').mockImplementation(() => {});
+		process.env.OMNISEARCH_MCP_BACKENDS = '{';
+
+		expect(() => validate_config()).toThrow(
+			/OMNISEARCH_MCP_BACKENDS: must be valid JSON/,
+		);
 	});
 });

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,3 +1,5 @@
+import { load_mcp_backends } from './mcp-backends.js';
+
 // Environment variable configuration for the MCP Omnisearch server
 
 // Search provider API keys
@@ -197,4 +199,5 @@ export const validate_config = () => {
 	}
 
 	warn_for_local_file_offload();
+	load_mcp_backends();
 };

--- a/src/config/mcp-backends.test.ts
+++ b/src/config/mcp-backends.test.ts
@@ -1,0 +1,261 @@
+import { describe, expect, it } from 'vitest';
+import { web_search_provider_definitions } from '../server/provider-definitions.js';
+import {
+	DEFAULT_RESERVED_MCP_BACKEND_IDS,
+	McpBackendConfigError,
+	load_mcp_backends,
+	parse_result_path,
+	resolve_env_references,
+} from './mcp-backends.js';
+
+const valid_exa_backend = {
+	transport: {
+		url: 'https://mcp.exa.ai/mcp',
+		headers: { 'x-api-key': '$EXA_API_KEY' },
+	},
+	tool: 'web_search_exa',
+	query_argument: 'query',
+	limit_argument: 'numResults',
+	result_path: ['results'],
+	field_aliases: {
+		title: ['title'],
+		url: ['url'],
+		snippet: ['text', 'snippet'],
+		score: ['score'],
+	},
+	timeout: 30_000,
+	estimated_cost: 0,
+};
+
+const load = (
+	backends: unknown,
+	env: NodeJS.ProcessEnv = { EXA_API_KEY: 'exa-key' },
+) =>
+	load_mcp_backends({
+		...env,
+		OMNISEARCH_MCP_BACKENDS: JSON.stringify(backends),
+	});
+
+describe('load_mcp_backends', () => {
+	it('keeps reserved ids aligned with built-in HTTP search adapters', () => {
+		expect([...DEFAULT_RESERVED_MCP_BACKEND_IDS]).toEqual(
+			web_search_provider_definitions.map(
+				(definition) => definition.id,
+			),
+		);
+	});
+
+	it('returns no backends when the env var is unset or blank', () => {
+		expect(load_mcp_backends({})).toEqual([]);
+		expect(
+			load_mcp_backends({ OMNISEARCH_MCP_BACKENDS: '   ' }),
+		).toEqual([]);
+	});
+
+	it('loads the official Exa remote mapping', () => {
+		expect(load({ exa_mcp: valid_exa_backend })).toEqual([
+			{
+				id: 'exa_mcp',
+				kind: 'http',
+				transport_url: 'https://mcp.exa.ai/mcp',
+				headers: { 'x-api-key': 'exa-key' },
+				env: {},
+				tool: 'web_search_exa',
+				query_argument: 'query',
+				limit_argument: 'numResults',
+				static_arguments: {},
+				result_path: ['results'],
+				field_aliases: {
+					title: ['title'],
+					url: ['url'],
+					snippet: ['text', 'snippet'],
+					score: ['score'],
+				},
+				timeout: 30_000,
+				estimated_cost: 0,
+			},
+		]);
+	});
+
+	it('loads a stdio command backend and resolves exact $ENV values', () => {
+		expect(
+			load(
+				{
+					local_search: {
+						command: 'npx',
+						args: ['-y', 'search-mcp'],
+						env: { API_KEY: '$SEARCH_API_KEY' },
+						tool: 'search',
+					},
+				},
+				{ SEARCH_API_KEY: 'secret' },
+			),
+		).toEqual([
+			expect.objectContaining({
+				id: 'local_search',
+				kind: 'stdio',
+				command: ['npx', '-y', 'search-mcp'],
+				env: { API_KEY: 'secret' },
+				query_argument: 'query',
+				limit_argument: 'limit',
+				result_path: ['results'],
+			}),
+		]);
+	});
+
+	it('does not interpolate $NAME inside a larger string', () => {
+		expect(
+			resolve_env_references(
+				'Bearer $EXA_API_KEY',
+				{ EXA_API_KEY: 'exa-key' },
+				'header',
+			),
+		).toBe('Bearer $EXA_API_KEY');
+	});
+
+	it('fails closed on invalid JSON, reserved ids, and unknown fields', () => {
+		expect(() =>
+			load_mcp_backends({ OMNISEARCH_MCP_BACKENDS: '{' }),
+		).toThrow(McpBackendConfigError);
+		expect(() => load({ exa: valid_exa_backend })).toThrow(
+			/collides with a built-in HTTP adapter/,
+		);
+		expect(() =>
+			load({
+				exa_mcp: { ...valid_exa_backend, weight: 1 },
+			}),
+		).toThrow(/unknown fields: weight/);
+	});
+
+	it('requires exactly one of transport or command', () => {
+		expect(() =>
+			load({
+				broken: { tool: 'search' },
+			}),
+		).toThrow(/exactly one of transport or command/);
+		expect(() =>
+			load({
+				broken: {
+					transport: 'https://mcp.exa.ai/mcp',
+					command: ['npx'],
+					tool: 'search',
+				},
+			}),
+		).toThrow(/exactly one of transport or command/);
+	});
+
+	it('rejects env on HTTP transports and missing $ENV references', () => {
+		expect(() =>
+			load({
+				exa_mcp: {
+					...valid_exa_backend,
+					env: { API_KEY: '$EXA_API_KEY' },
+				},
+			}),
+		).toThrow(/env is only valid with command/);
+		expect(() => load({ exa_mcp: valid_exa_backend }, {})).toThrow(
+			/missing environment variable EXA_API_KEY/,
+		);
+	});
+
+	it('rejects blank mappings and colliding argument names', () => {
+		expect(() =>
+			load({
+				exa_mcp: { ...valid_exa_backend, tool: ' search' },
+			}),
+		).toThrow(/tool must be a nonblank trimmed string/);
+		expect(() =>
+			load({
+				exa_mcp: {
+					...valid_exa_backend,
+					query_argument: 'q',
+					limit_argument: 'q',
+				},
+			}),
+		).toThrow(/must be unique/);
+		expect(() =>
+			load({
+				exa_mcp: {
+					...valid_exa_backend,
+					field_aliases: { heading: ['title'] },
+				},
+			}),
+		).toThrow(/unknown fields: heading/);
+	});
+
+	it('accepts a transport URL string and a command argv array', () => {
+		expect(
+			load({
+				remote: {
+					transport: 'https://mcp.exa.ai/mcp',
+					tool: 'web_search_exa',
+					limit_argument: null,
+				},
+			}),
+		).toEqual([
+			expect.objectContaining({
+				id: 'remote',
+				kind: 'http',
+				transport_url: 'https://mcp.exa.ai/mcp',
+				limit_argument: null,
+			}),
+		]);
+		expect(
+			load({
+				local_search: {
+					command: ['npx', '-y', 'search-mcp'],
+					tool: 'search',
+				},
+			}),
+		).toEqual([
+			expect.objectContaining({
+				kind: 'stdio',
+				command: ['npx', '-y', 'search-mcp'],
+			}),
+		]);
+	});
+
+	it('rejects invalid URLs, ids, and timeout values', () => {
+		expect(() =>
+			load({
+				'Bad Id': {
+					transport: 'https://mcp.exa.ai/mcp',
+					tool: 'search',
+				},
+			}),
+		).toThrow(/must match/);
+		expect(() =>
+			load({
+				remote: {
+					transport: 'ftp://example.com/mcp',
+					tool: 'search',
+				},
+			}),
+		).toThrow(/absolute http\(s\) URL/);
+		expect(() =>
+			load({
+				remote: {
+					transport: 'https://mcp.exa.ai/mcp',
+					tool: 'search',
+					timeout: 0,
+				},
+			}),
+		).toThrow(/milliseconds/);
+	});
+
+	it('parses dotted result paths and integer segments', () => {
+		expect(parse_result_path('payload.items', 'path')).toEqual([
+			'payload',
+			'items',
+		]);
+		expect(parse_result_path('payload.0.items', 'path')).toEqual([
+			'payload',
+			0,
+			'items',
+		]);
+		expect(parse_result_path([], 'path')).toEqual([]);
+		expect(() => parse_result_path('', 'path')).toThrow(
+			/must not be empty/,
+		);
+	});
+});

--- a/src/config/mcp-backends.ts
+++ b/src/config/mcp-backends.ts
@@ -1,0 +1,542 @@
+export const MCP_BACKENDS_ENV = 'OMNISEARCH_MCP_BACKENDS';
+
+export const DEFAULT_RESERVED_MCP_BACKEND_IDS = [
+	'tavily',
+	'brave',
+	'kagi',
+	'exa',
+	'kagi_enrichment',
+] as const;
+
+const PROVIDER_ID = /^[a-z][a-z0-9_-]*$/;
+const ENV_REFERENCE = /^\$[A-Za-z_][A-Za-z0-9_]*$/;
+const ALLOWED_BACKEND_KEYS = new Set([
+	'transport',
+	'command',
+	'args',
+	'env',
+	'tool',
+	'query_argument',
+	'limit_argument',
+	'static_arguments',
+	'result_path',
+	'field_aliases',
+	'timeout',
+	'estimated_cost',
+]);
+const CANONICAL_RESULT_FIELDS = [
+	'title',
+	'url',
+	'snippet',
+	'score',
+] as const;
+const DEFAULT_FIELD_ALIASES: Record<
+	(typeof CANONICAL_RESULT_FIELDS)[number],
+	string[]
+> = {
+	title: ['title', 'name'],
+	url: ['url', 'link'],
+	snippet: ['snippet', 'description', 'text', 'content'],
+	score: ['score', 'relevance', 'confidence'],
+};
+const DEFAULT_TIMEOUT_MS = 30_000;
+const MAX_TIMEOUT_MS = 300_000;
+
+export class McpBackendConfigError extends Error {
+	constructor(message: string) {
+		super(`${MCP_BACKENDS_ENV}: ${message}`);
+		this.name = 'McpBackendConfigError';
+	}
+}
+
+export type McpBackendKind = 'http' | 'stdio';
+
+export interface ResolvedMcpBackend {
+	id: string;
+	kind: McpBackendKind;
+	transport_url?: string;
+	headers: Record<string, string>;
+	command?: string[];
+	env: Record<string, string>;
+	tool: string;
+	query_argument: string;
+	limit_argument: string | null;
+	static_arguments: Record<string, unknown>;
+	result_path: Array<string | number>;
+	field_aliases: {
+		title: string[];
+		url: string[];
+		snippet: string[];
+		score: string[];
+	};
+	timeout: number;
+	estimated_cost: number;
+}
+
+const is_record = (
+	value: unknown,
+): value is Record<string, unknown> =>
+	typeof value === 'object' &&
+	value !== null &&
+	!Array.isArray(value);
+
+const fail = (message: string): never => {
+	throw new McpBackendConfigError(message);
+};
+
+const require_trimmed_name = (
+	value: unknown,
+	label: string,
+): string => {
+	if (typeof value !== 'string') {
+		return fail(`${label} must be a nonblank trimmed string`);
+	}
+	if (value !== value.trim() || value.length === 0) {
+		return fail(`${label} must be a nonblank trimmed string`);
+	}
+	return value;
+};
+
+export const resolve_env_references = (
+	value: unknown,
+	env: NodeJS.ProcessEnv,
+	label: string,
+): unknown => {
+	if (typeof value === 'string' && ENV_REFERENCE.test(value)) {
+		const name = value.slice(1);
+		const resolved = env[name];
+		if (resolved === undefined) {
+			return fail(
+				`missing environment variable ${name} referenced by ${label}`,
+			);
+		}
+		return resolved;
+	}
+	if (Array.isArray(value)) {
+		return value.map((item, index) =>
+			resolve_env_references(item, env, `${label}[${index}]`),
+		);
+	}
+	if (is_record(value)) {
+		return Object.fromEntries(
+			Object.entries(value).map(([key, item]) => [
+				key,
+				resolve_env_references(item, env, `${label}.${key}`),
+			]),
+		);
+	}
+	return value;
+};
+
+export const parse_result_path = (
+	value: unknown,
+	label: string,
+): Array<string | number> => {
+	if (value === undefined) return ['results'];
+	if (Array.isArray(value)) {
+		if (
+			value.some(
+				(segment) =>
+					!(
+						(typeof segment === 'string' &&
+							segment === segment.trim() &&
+							segment.length > 0) ||
+						(typeof segment === 'number' &&
+							Number.isInteger(segment) &&
+							segment >= 0)
+					),
+			)
+		) {
+			return fail(
+				`${label} must contain nonblank trimmed strings or non-negative integers`,
+			);
+		}
+		return value as Array<string | number>;
+	}
+	if (typeof value !== 'string') {
+		return fail(
+			`${label} must be a trimmed dotted path or an array of segments`,
+		);
+	}
+	if (value !== value.trim() || value.length === 0) {
+		return fail(`${label} must not be empty`);
+	}
+	return value
+		.split('.')
+		.map((segment) =>
+			/^\d+$/.test(segment) ? Number(segment) : segment,
+		);
+};
+
+const parse_field_aliases = (
+	value: unknown,
+	label: string,
+): ResolvedMcpBackend['field_aliases'] => {
+	if (value === undefined) {
+		return {
+			title: [...DEFAULT_FIELD_ALIASES.title],
+			url: [...DEFAULT_FIELD_ALIASES.url],
+			snippet: [...DEFAULT_FIELD_ALIASES.snippet],
+			score: [...DEFAULT_FIELD_ALIASES.score],
+		};
+	}
+	if (!is_record(value)) {
+		return fail(`${label} must be an object`);
+	}
+	const unknown_fields = Object.keys(value).filter(
+		(key) =>
+			!CANONICAL_RESULT_FIELDS.includes(
+				key as (typeof CANONICAL_RESULT_FIELDS)[number],
+			),
+	);
+	if (unknown_fields.length > 0) {
+		return fail(
+			`${label} has unknown fields: ${unknown_fields.sort().join(', ')}`,
+		);
+	}
+
+	const read_aliases = (
+		field: (typeof CANONICAL_RESULT_FIELDS)[number],
+	): string[] => {
+		const raw = value[field];
+		if (raw === undefined) {
+			return [...DEFAULT_FIELD_ALIASES[field]];
+		}
+		const aliases = typeof raw === 'string' ? [raw] : raw;
+		if (
+			!Array.isArray(aliases) ||
+			aliases.length === 0 ||
+			aliases.some(
+				(alias) =>
+					typeof alias !== 'string' ||
+					alias !== alias.trim() ||
+					alias.length === 0,
+			)
+		) {
+			return fail(
+				`${label}.${field} must be a nonblank trimmed string or a non-empty list of them`,
+			);
+		}
+		return Array.from(new Set(aliases as string[]));
+	};
+
+	return {
+		title: read_aliases('title'),
+		url: read_aliases('url'),
+		snippet: read_aliases('snippet'),
+		score: read_aliases('score'),
+	};
+};
+
+const parse_timeout = (value: unknown, label: string): number => {
+	if (value === undefined) return DEFAULT_TIMEOUT_MS;
+	if (
+		typeof value !== 'number' ||
+		!Number.isFinite(value) ||
+		value <= 0 ||
+		value > MAX_TIMEOUT_MS
+	) {
+		return fail(
+			`${label} must be a finite number of milliseconds between 1 and ${MAX_TIMEOUT_MS}`,
+		);
+	}
+	return value;
+};
+
+const parse_estimated_cost = (
+	value: unknown,
+	label: string,
+): number => {
+	if (value === undefined) return 0;
+	if (
+		typeof value !== 'number' ||
+		!Number.isFinite(value) ||
+		value < 0
+	) {
+		return fail(
+			`${label} must be a finite number greater than or equal to 0`,
+		);
+	}
+	return value;
+};
+
+const parse_http_url = (value: unknown, label: string): string => {
+	const url = require_trimmed_name(value, label);
+	let parsed: URL;
+	try {
+		parsed = new URL(url);
+	} catch {
+		return fail(`${label} must be an absolute http(s) URL`);
+	}
+	if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+		return fail(`${label} must be an absolute http(s) URL`);
+	}
+	return url;
+};
+
+const parse_string_record = (
+	value: unknown,
+	label: string,
+): Record<string, string> => {
+	if (value === undefined) return {};
+	if (!is_record(value)) return fail(`${label} must be an object`);
+	const entries = Object.entries(value);
+	for (const [key, item] of entries) {
+		if (typeof item !== 'string') {
+			return fail(`${label}.${key} must be a string`);
+		}
+	}
+	return value as Record<string, string>;
+};
+
+const parse_backend = (
+	id: string,
+	value: unknown,
+	env: NodeJS.ProcessEnv,
+	reserved_ids: ReadonlySet<string>,
+): ResolvedMcpBackend => {
+	if (!PROVIDER_ID.test(id)) {
+		return fail(
+			`provider id ${JSON.stringify(id)} must match ${PROVIDER_ID}`,
+		);
+	}
+	if (reserved_ids.has(id)) {
+		return fail(
+			`provider id ${JSON.stringify(id)} collides with a built-in HTTP adapter`,
+		);
+	}
+	if (!is_record(value)) {
+		return fail(`${id} must be an object`);
+	}
+	const unknown_keys = Object.keys(value).filter(
+		(key) => !ALLOWED_BACKEND_KEYS.has(key),
+	);
+	if (unknown_keys.length > 0) {
+		return fail(
+			`${id} has unknown fields: ${unknown_keys.sort().join(', ')}`,
+		);
+	}
+
+	const has_transport = value.transport !== undefined;
+	const has_command = value.command !== undefined;
+	if (has_transport === has_command) {
+		return fail(`${id} requires exactly one of transport or command`);
+	}
+	if (value.env !== undefined && !has_command) {
+		return fail(
+			`${id}.env is only valid with command; put remote headers on transport`,
+		);
+	}
+	if (value.args !== undefined && typeof value.command !== 'string') {
+		return fail(`${id}.args is only valid when command is a string`);
+	}
+
+	const tool = require_trimmed_name(value.tool, `${id}.tool`);
+	const query_argument = require_trimmed_name(
+		value.query_argument ?? 'query',
+		`${id}.query_argument`,
+	);
+	let limit_argument: string | null = 'limit';
+	if (value.limit_argument === null) {
+		limit_argument = null;
+	} else if (value.limit_argument !== undefined) {
+		limit_argument = require_trimmed_name(
+			value.limit_argument,
+			`${id}.limit_argument`,
+		);
+	}
+	if (limit_argument === query_argument) {
+		return fail(
+			`${id} query_argument and limit_argument must be unique`,
+		);
+	}
+
+	if (
+		value.static_arguments !== undefined &&
+		!is_record(value.static_arguments)
+	) {
+		return fail(`${id}.static_arguments must be an object`);
+	}
+	const static_arguments = (value.static_arguments ?? {}) as Record<
+		string,
+		unknown
+	>;
+	const shadowed = [query_argument, limit_argument].filter(
+		(argument): argument is string =>
+			argument !== null && argument in static_arguments,
+	);
+	if (shadowed.length > 0) {
+		return fail(
+			`${id}.static_arguments must not shadow ${shadowed.join(', ')}`,
+		);
+	}
+
+	const result_path = parse_result_path(
+		value.result_path,
+		`${id}.result_path`,
+	);
+	const field_aliases = parse_field_aliases(
+		value.field_aliases,
+		`${id}.field_aliases`,
+	);
+	const timeout = parse_timeout(value.timeout, `${id}.timeout`);
+	const estimated_cost = parse_estimated_cost(
+		value.estimated_cost,
+		`${id}.estimated_cost`,
+	);
+
+	if (has_transport) {
+		const transport = value.transport;
+		let transport_url: string;
+		let headers: Record<string, string> = {};
+		if (typeof transport === 'string') {
+			transport_url = parse_http_url(transport, `${id}.transport`);
+		} else if (is_record(transport)) {
+			const unknown_transport_keys = Object.keys(transport).filter(
+				(key) => key !== 'url' && key !== 'headers',
+			);
+			if (unknown_transport_keys.length > 0) {
+				return fail(
+					`${id}.transport has unknown fields: ${unknown_transport_keys.sort().join(', ')}`,
+				);
+			}
+			transport_url = parse_http_url(
+				transport.url,
+				`${id}.transport.url`,
+			);
+			headers = parse_string_record(
+				transport.headers,
+				`${id}.transport.headers`,
+			);
+		} else {
+			return fail(
+				`${id}.transport must be a URL string or { url, headers }`,
+			);
+		}
+
+		const resolved_url = resolve_env_references(
+			transport_url,
+			env,
+			`${id}.transport`,
+		);
+		const resolved_headers = resolve_env_references(
+			headers,
+			env,
+			`${id}.transport.headers`,
+		) as Record<string, string>;
+
+		return {
+			id,
+			kind: 'http',
+			transport_url: parse_http_url(resolved_url, `${id}.transport`),
+			headers: resolved_headers,
+			env: {},
+			tool,
+			query_argument,
+			limit_argument,
+			static_arguments: resolve_env_references(
+				static_arguments,
+				env,
+				`${id}.static_arguments`,
+			) as Record<string, unknown>,
+			result_path,
+			field_aliases,
+			timeout,
+			estimated_cost,
+		};
+	}
+
+	const command_value = value.command;
+	let command: string[];
+	if (typeof command_value === 'string') {
+		const executable = require_trimmed_name(
+			command_value,
+			`${id}.command`,
+		);
+		const args =
+			value.args === undefined
+				? []
+				: Array.isArray(value.args) &&
+					  value.args.every(
+							(arg) => typeof arg === 'string' && arg === arg.trim(),
+					  )
+					? (value.args as string[])
+					: fail(`${id}.args must be an array of trimmed strings`);
+		command = [executable, ...args];
+	} else if (
+		Array.isArray(command_value) &&
+		command_value.length > 0 &&
+		command_value.every(
+			(part) => typeof part === 'string' && part === part.trim(),
+		) &&
+		command_value[0]!.length > 0
+	) {
+		command = command_value as string[];
+	} else {
+		return fail(
+			`${id}.command must be a trimmed executable or a non-empty argv array`,
+		);
+	}
+
+	const resolved_command = resolve_env_references(
+		command,
+		env,
+		`${id}.command`,
+	) as string[];
+	if (
+		resolved_command.length === 0 ||
+		typeof resolved_command[0] !== 'string' ||
+		resolved_command[0].trim() !== resolved_command[0] ||
+		resolved_command[0].length === 0
+	) {
+		return fail(`${id}.command must resolve to a trimmed executable`);
+	}
+
+	const env_map = parse_string_record(value.env, `${id}.env`);
+
+	return {
+		id,
+		kind: 'stdio',
+		command: resolved_command,
+		headers: {},
+		env: resolve_env_references(env_map, env, `${id}.env`) as Record<
+			string,
+			string
+		>,
+		tool,
+		query_argument,
+		limit_argument,
+		static_arguments: resolve_env_references(
+			static_arguments,
+			env,
+			`${id}.static_arguments`,
+		) as Record<string, unknown>,
+		result_path,
+		field_aliases,
+		timeout,
+		estimated_cost,
+	};
+};
+
+export const load_mcp_backends = (
+	env: NodeJS.ProcessEnv = process.env,
+	reserved_ids: readonly string[] = DEFAULT_RESERVED_MCP_BACKEND_IDS,
+): ResolvedMcpBackend[] => {
+	const raw = env[MCP_BACKENDS_ENV];
+	if (raw === undefined || raw.trim() === '') return [];
+
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(raw);
+	} catch {
+		return fail('must be valid JSON');
+	}
+	if (!is_record(parsed)) {
+		return fail('must be a JSON object keyed by provider id');
+	}
+
+	const reserved = new Set(reserved_ids);
+	return Object.entries(parsed).map(([id, backend]) =>
+		parse_backend(id, backend, env, reserved),
+	);
+};

--- a/src/providers/search/mcp-backend/index.test.ts
+++ b/src/providers/search/mcp-backend/index.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ResolvedMcpBackend } from '../../../config/mcp-backends.js';
+import {
+	McpBackendSearchProvider,
+	create_mcp_backend_definitions,
+} from './index.js';
+
+const backend: ResolvedMcpBackend = {
+	id: 'exa_mcp',
+	kind: 'http',
+	transport_url: 'https://mcp.exa.ai/mcp',
+	headers: { 'x-api-key': 'exa-key' },
+	env: {},
+	tool: 'web_search_exa',
+	query_argument: 'query',
+	limit_argument: 'numResults',
+	static_arguments: { type: 'auto' },
+	result_path: ['results'],
+	field_aliases: {
+		title: ['title'],
+		url: ['url'],
+		snippet: ['text'],
+		score: ['score'],
+	},
+	timeout: 30_000,
+	estimated_cost: 0.01,
+};
+
+describe('McpBackendSearchProvider', () => {
+	it('calls the mapped tool and normalizes results', async () => {
+		const call_tool = vi.fn(async () => ({
+			structuredContent: {
+				results: [
+					{
+						title: 'Example',
+						url: 'https://example.com',
+						text: 'Hello',
+						score: 0.9,
+					},
+				],
+			},
+		}));
+
+		const provider = new McpBackendSearchProvider(backend, call_tool);
+
+		await expect(
+			provider.search({ query: '  sveltekit\nremote  ', limit: 3 }),
+		).resolves.toEqual([
+			{
+				title: 'Example',
+				url: 'https://example.com',
+				snippet: 'Hello',
+				score: 0.9,
+				source_provider: 'exa_mcp',
+			},
+		]);
+		expect(call_tool).toHaveBeenCalledWith({
+			backend,
+			tool: 'web_search_exa',
+			arguments: {
+				type: 'auto',
+				query: 'sveltekit remote',
+				numResults: 3,
+			},
+		});
+	});
+
+	it('creates registry definitions without requiring an API key field', () => {
+		const definitions = create_mcp_backend_definitions({
+			EXA_API_KEY: 'exa-key',
+			OMNISEARCH_MCP_BACKENDS: JSON.stringify({
+				exa_mcp: {
+					transport: 'https://mcp.exa.ai/mcp',
+					tool: 'web_search_exa',
+				},
+			}),
+		});
+
+		expect(definitions).toEqual([
+			expect.objectContaining({
+				id: 'exa_mcp',
+				requires_api_key: false,
+				api_key_name: 'OMNISEARCH_MCP_BACKENDS',
+				tools: ['web_search'],
+			}),
+		]);
+	});
+});

--- a/src/providers/search/mcp-backend/index.ts
+++ b/src/providers/search/mcp-backend/index.ts
@@ -1,0 +1,93 @@
+import {
+	handle_provider_error,
+	sanitize_query,
+} from '../../../common/errors.js';
+import { call_mcp_tool } from '../../../common/mcp-client.js';
+import {
+	extract_result_list,
+	map_mcp_search_results,
+} from '../../../common/mcp-results.js';
+import { retry_with_backoff } from '../../../common/retry.js';
+import type {
+	BaseSearchParams,
+	SearchProvider,
+	SearchResult,
+} from '../../../common/types.js';
+import {
+	MCP_BACKENDS_ENV,
+	load_mcp_backends,
+	type ResolvedMcpBackend,
+} from '../../../config/mcp-backends.js';
+import type { ProviderDefinition } from '../../../server/provider-registry.js';
+
+export type McpToolCaller = typeof call_mcp_tool;
+
+export class McpBackendSearchProvider implements SearchProvider {
+	name: string;
+	description: string;
+	estimated_cost: number;
+
+	constructor(
+		private readonly backend: ResolvedMcpBackend,
+		private readonly call_tool: McpToolCaller = call_mcp_tool,
+	) {
+		this.name = backend.id;
+		this.estimated_cost = backend.estimated_cost;
+		this.description = `Downstream MCP search backend (${backend.kind}) calling ${backend.tool}. Estimated cost ${backend.estimated_cost}.`;
+	}
+
+	async search(params: BaseSearchParams): Promise<SearchResult[]> {
+		const arguments_: Record<string, unknown> = {
+			...this.backend.static_arguments,
+			[this.backend.query_argument]: sanitize_query(params.query),
+		};
+		if (this.backend.limit_argument) {
+			arguments_[this.backend.limit_argument] = params.limit ?? 5;
+		}
+
+		const search_request = async () => {
+			try {
+				const result = await this.call_tool({
+					backend: this.backend,
+					tool: this.backend.tool,
+					arguments: arguments_,
+				});
+				const items = extract_result_list(
+					result,
+					this.backend.result_path,
+					this.name,
+				);
+				return map_mcp_search_results(
+					items,
+					this.backend.field_aliases,
+					this.name,
+				);
+			} catch (error) {
+				handle_provider_error(
+					error,
+					this.name,
+					'call downstream MCP tool',
+				);
+			}
+		};
+
+		return retry_with_backoff(search_request);
+	}
+}
+
+export const create_mcp_backend_definitions = (
+	env: NodeJS.ProcessEnv = process.env,
+	reserved_ids?: readonly string[],
+): ProviderDefinition<SearchProvider>[] =>
+	load_mcp_backends(env, reserved_ids).map((backend) => ({
+		id: backend.id,
+		name: backend.id,
+		category: 'search',
+		api_key: undefined,
+		api_key_name: MCP_BACKENDS_ENV,
+		requires_api_key: false,
+		tools: ['web_search'],
+		capabilities: ['mcp_backend', 'web_search'],
+		description: `Downstream MCP backend calling ${backend.tool}`,
+		create: () => new McpBackendSearchProvider(backend),
+	}));

--- a/src/server/provider-registry.test.ts
+++ b/src/server/provider-registry.test.ts
@@ -75,6 +75,30 @@ describe('ProviderRegistry', () => {
 		expect(registry.names()).toEqual(['exa']);
 	});
 
+	it('registers configured providers that do not require API keys', () => {
+		const registry = new ProviderRegistry<{ name: string }>();
+
+		registry.register({
+			id: 'exa_mcp',
+			name: 'exa_mcp',
+			category: 'search',
+			api_key: undefined,
+			api_key_name: 'OMNISEARCH_MCP_BACKENDS',
+			requires_api_key: false,
+			create: () => ({ name: 'exa_mcp' }),
+		});
+
+		expect(registry.size).toBe(1);
+		expect(registry.get('exa_mcp')).toEqual({ name: 'exa_mcp' });
+		expect(registry.status_entries()).toEqual([
+			expect.objectContaining({
+				id: 'exa_mcp',
+				status: 'available',
+				api_key_name: 'OMNISEARCH_MCP_BACKENDS',
+			}),
+		]);
+	});
+
 	it('throws a ProviderError when requiring a missing provider', () => {
 		const registry = new ProviderRegistry<{ name: string }>();
 

--- a/src/server/provider-registry.ts
+++ b/src/server/provider-registry.ts
@@ -12,6 +12,7 @@ export interface ProviderDefinition<T> {
 	category: ProviderCategory;
 	api_key: string | undefined;
 	api_key_name?: string;
+	requires_api_key?: boolean;
 	create: () => T;
 	description?: string;
 	tools?: readonly string[];
@@ -69,6 +70,25 @@ export class ProviderRegistry<T> {
 			modes: definition.modes ?? [],
 			capabilities: definition.capabilities ?? [],
 		};
+
+		if (definition.requires_api_key === false) {
+			const instance = definition.create();
+			this.providers.set(definition.id, {
+				...base_status,
+				instance,
+				description:
+					definition.description ??
+					(instance as { description?: string }).description,
+			});
+			this.statuses.set(definition.id, {
+				...base_status,
+				status: 'available',
+				description:
+					definition.description ??
+					(instance as { description?: string }).description,
+			});
+			return;
+		}
 
 		if (!definition.api_key || definition.api_key.trim() === '') {
 			if (!this.missing_api_key_names.has(api_key_name)) {

--- a/src/server/tools/contract.test.ts
+++ b/src/server/tools/contract.test.ts
@@ -17,6 +17,7 @@ const API_KEY_NAMES = [
 	'EXA_API_KEY',
 	'LINKUP_API_KEY',
 	'FIRECRAWL_API_KEY',
+	'OMNISEARCH_MCP_BACKENDS',
 ];
 
 const create_mock_server = () => {
@@ -152,6 +153,52 @@ describe('MCP tool contract', () => {
 			v.safeParse(schema, { query: 'test', provider: 'kagi' })
 				.success,
 		).toBe(false);
+	});
+
+	it('registers optional MCP backends beside HTTP adapters', async () => {
+		const { tools } = await load_contract({
+			BRAVE_API_KEY: 'brave-key',
+			EXA_API_KEY: 'exa-key',
+			OMNISEARCH_MCP_BACKENDS: JSON.stringify({
+				exa_mcp: {
+					transport: {
+						url: 'https://mcp.exa.ai/mcp',
+						headers: { 'x-api-key': '$EXA_API_KEY' },
+					},
+					tool: 'web_search_exa',
+					limit_argument: 'numResults',
+				},
+			}),
+		});
+		const schema = tools.find(
+			(tool) => tool.definition.name === 'web_search',
+		)!.definition.schema;
+
+		expect(
+			v.safeParse(schema, {
+				query: 'sveltekit docs',
+				provider: 'brave',
+			}).success,
+		).toBe(true);
+		expect(
+			v.safeParse(schema, {
+				query: 'sveltekit docs',
+				provider: 'exa_mcp',
+			}).success,
+		).toBe(true);
+	});
+
+	it('fails configuration when an MCP backend mapping is invalid', async () => {
+		await expect(
+			load_contract({
+				OMNISEARCH_MCP_BACKENDS: JSON.stringify({
+					exa: {
+						transport: 'https://mcp.exa.ai/mcp',
+						tool: 'web_search_exa',
+					},
+				}),
+			}),
+		).rejects.toThrow(/collides with a built-in HTTP adapter/);
 	});
 
 	it('validates public web_extract payloads and unavailable modes at the MCP layer', async () => {

--- a/src/server/tools/web-search.ts
+++ b/src/server/tools/web-search.ts
@@ -2,10 +2,8 @@ import { McpServer } from 'tmcp';
 import type { GenericSchema } from 'valibot';
 import * as v from 'valibot';
 import { SearchProvider } from '../../common/types.js';
-import {
-	web_search_provider_definitions,
-	type WebSearchProviderName,
-} from '../provider-definitions.js';
+import { create_mcp_backend_definitions } from '../../providers/search/mcp-backend/index.js';
+import { web_search_provider_definitions } from '../provider-definitions.js';
 import { ProviderRegistry } from '../provider-registry.js';
 import { handle_tool_result } from './responses.js';
 import {
@@ -21,6 +19,14 @@ const providers = new ProviderRegistry<SearchProvider>();
 export const initialize_web_search = (): boolean => {
 	providers.clear();
 	providers.register_all(web_search_provider_definitions);
+	providers.register_all(
+		create_mcp_backend_definitions(
+			process.env,
+			web_search_provider_definitions.map(
+				(definition) => definition.id,
+			),
+		),
+	);
 
 	return providers.size > 0;
 };
@@ -35,13 +41,13 @@ export const register_web_search = (
 ) => {
 	if (providers.size === 0) return;
 
-	const provider_names = providers.ids() as WebSearchProviderName[];
+	const provider_names = providers.ids() as [string, ...string[]];
 
 	server.tool(
 		{
 			name: 'web_search',
 			description:
-				'Search the web for information. Use when you need to find web pages, articles, or data. Providers: tavily (factual/citations), brave (privacy/operators), kagi (quality/operators), exa (AI-semantic), kagi_enrichment (specialized indexes). Brave/Kagi support query operators like site:, filetype:, lang:, before:, after:.',
+				'Search the web for information. Use when you need to find web pages, articles, or data. Providers: tavily (factual/citations), brave (privacy/operators), kagi (quality/operators), exa (AI-semantic), kagi_enrichment (specialized indexes). Optional MCP backends appear by configured id. Brave/Kagi support query operators like site:, filetype:, lang:, before:, after:.',
 			annotations: {
 				readOnlyHint: true,
 				destructiveHint: false,


### PR DESCRIPTION
## Summary

Adds an optional `OMNISEARCH_MCP_BACKENDS` provider type so operators can call an official remote or stdio MCP (tool name, argument aliases, `result_path`, field aliases, timeout, estimated cost, exact `$ENV` headers) from `web_search`. Direct HTTP adapters stay the default and keep their existing ids.

Fixes #204.

## Scope

- Config parser for `OMNISEARCH_MCP_BACKENDS` (unknown fields, reserved HTTP ids, and missing `$NAME` refs fail startup)
- Streamable HTTP + stdio MCP client using `http_json` / Content-Length JSON-RPC
- Result mapping that fails with `MALFORMED_RESPONSE` instead of empty mystery lists
- Docs: official Exa remote example in `docs/mcp-backends.md`

## Verification

```bash
pnpm install
pnpm run format
pnpm run test
pnpm run check
pnpm run build
```

144 tests passed, including config fail-closed cases, HTTP/stdio client coverage, and a contract test that `exa_mcp` appears beside `brave`.

## Impact

- No breaking change for existing HTTP providers or tool schemas
- New optional env var only; unset means no MCP backends
- Bad mappings fail configuration or the request, not with an empty list