### PR TITLE
Add partial-success metadata for multi-provider search

### DIFF
--- a/.changeset/partial-success-metadata.md
+++ b/.changeset/partial-success-metadata.md
@@ -1,0 +1,5 @@
+---
+'mcp-omnisearch': patch
+---
+
+feat: return typed partial-success metadata for multi-provider search

--- a/README.md
+++ b/README.md
@@ -84,6 +84,17 @@ Search the web with Tavily, Brave, Kagi, Exa, or Kagi Enrichment.
 }
 ```
 
+Pass a provider list to keep successful hits when some engines fail.
+The response then includes `results` plus `selected` / `successful` /
+`failed` / `timed_out` metadata (error types only).
+
+```json
+{
+	"query": "sveltekit remote functions",
+	"provider": ["brave", "tavily"]
+}
+```
+
 ### `ai_search`
 
 Get sourced AI answers with Kagi FastGPT, Exa Answer, or Linkup.

--- a/docs/provider-selection.md
+++ b/docs/provider-selection.md
@@ -42,6 +42,25 @@ search only. See
 | `firecrawl` | `FIRECRAWL_API_KEY` | `scrape`, `crawl`, `map`, `extract`, `actions` | Scraping, crawling, site maps, structured extraction, and browser actions. |
 | `exa`       | `EXA_API_KEY`       | `contents`, `similar`                          | Page content retrieval and semantically similar URLs.                      |
 
+## Partial success
+
+`web_search` and `ai_search` accept either one `provider` string or a
+list. A single string keeps the existing result array and still fails
+the whole tool when that provider errors.
+
+A list runs the selected providers concurrently and always returns
+whatever succeeded, plus metadata:
+
+- `selected` — providers that were invoked
+- `successful` — providers that returned results
+- `failed` — `{ provider, type }` only; no exception text or secrets
+- `timed_out` — providers that hit `TIMEOUT` / abort
+- `preempted` — optional cooldown / skip list when a caller supplies
+  one
+
+Empty successful lists are valid. Use this to debug “why did only
+Firecrawl come back?” without leaking raw provider errors.
+
 ## Provider choice cheatsheet
 
 - Need native operators like `filetype:pdf`, `intitle:`, or `before:`?

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -23,6 +23,7 @@ and configured providers remain available.
 | Request fails with unauthorized/forbidden | Invalid key or plan mismatch                              | Verify the key belongs to the provider and has access to the endpoint or plan tier.                                              |
 | Query rejected before provider call       | Invalid input                                             | Check for empty queries, unsupported modes, malformed domains, or unsupported URL protocols.                                     |
 | Repeated transient errors                 | Rate limits, timeout, network failure, or provider 5xx    | Retry later or lower request volume. Retryable failures are handled separately from invalid credentials and validation failures. |
+| Only some providers returned results      | Multi-provider list had a failure or timeout              | Read `metadata.failed` / `metadata.timed_out` for error types only. A single `provider` string still fails the whole tool.       |
 | Returned file path cannot be read         | Server wrote a temp file on a remote/container filesystem | Retry with `large_result_mode: "inline"` or set `OMNISEARCH_LARGE_RESULT_MODE=inline`.                                           |
 
 ## GitHub token setup

--- a/src/common/partial-success.test.ts
+++ b/src/common/partial-success.test.ts
@@ -1,0 +1,308 @@
+import { describe, expect, it } from 'vitest';
+import { ErrorType, ProviderError } from './types.js';
+import {
+	build_partial_success_metadata,
+	classify_provider_failure,
+	normalize_provider_selection,
+	run_selected_providers,
+	settle_provider_calls,
+} from './partial-success.js';
+
+const SECRET = 'sk-live-super-secret-key';
+const STACK_FRAGMENT = 'at BraveSearchProvider.search';
+
+const serialized = (value: unknown) => JSON.stringify(value);
+
+describe('classify_provider_failure', () => {
+	it('uses ProviderError type and ignores timeout-like names on that class', () => {
+		expect(
+			classify_provider_failure(
+				new ProviderError(
+					ErrorType.RATE_LIMIT,
+					`Rate limit for key ${SECRET}`,
+					'tavily',
+				),
+			),
+		).toBe(ErrorType.RATE_LIMIT);
+	});
+
+	it('classifies TimeoutError and AbortError as TIMEOUT', () => {
+		const timeout = new Error(`timed out talking to ${SECRET}`);
+		timeout.name = 'TimeoutError';
+		const abort = new Error('aborted');
+		abort.name = 'AbortError';
+
+		expect(classify_provider_failure(timeout)).toBe(
+			ErrorType.TIMEOUT,
+		);
+		expect(classify_provider_failure(abort)).toBe(ErrorType.TIMEOUT);
+	});
+
+	it('classifies unknown errors as API_ERROR', () => {
+		expect(classify_provider_failure(new Error('boom'))).toBe(
+			ErrorType.API_ERROR,
+		);
+		expect(classify_provider_failure('nope')).toBe(
+			ErrorType.API_ERROR,
+		);
+	});
+});
+
+describe('build_partial_success_metadata', () => {
+	it('copies provider sets and omits empty preempted', () => {
+		expect(
+			build_partial_success_metadata({
+				selected: ['brave', 'tavily'],
+				successful: ['brave'],
+				failed: [{ provider: 'tavily', type: ErrorType.RATE_LIMIT }],
+				timed_out: [],
+				preempted: [],
+			}),
+		).toEqual({
+			selected: ['brave', 'tavily'],
+			successful: ['brave'],
+			failed: [{ provider: 'tavily', type: ErrorType.RATE_LIMIT }],
+			timed_out: [],
+		});
+	});
+
+	it('includes preempted cooldown skips when present', () => {
+		expect(
+			build_partial_success_metadata({
+				selected: ['brave'],
+				successful: ['brave'],
+				failed: [],
+				timed_out: [],
+				preempted: ['kagi'],
+			}).preempted,
+		).toEqual(['kagi']);
+	});
+
+	it('strips extra fields from failed entries', () => {
+		const metadata = build_partial_success_metadata({
+			selected: ['tavily'],
+			successful: [],
+			failed: [
+				{
+					provider: 'tavily',
+					type: ErrorType.AUTH_ERROR,
+					message: `Invalid key ${SECRET}`,
+					stack: STACK_FRAGMENT,
+				} as { provider: string; type: ErrorType },
+			],
+			timed_out: [],
+		});
+
+		expect(metadata.failed).toEqual([
+			{ provider: 'tavily', type: ErrorType.AUTH_ERROR },
+		]);
+		expect(serialized(metadata)).not.toContain(SECRET);
+		expect(serialized(metadata)).not.toContain(STACK_FRAGMENT);
+	});
+});
+
+describe('settle_provider_calls', () => {
+	it('returns concatenated successful results and names the provider sets', async () => {
+		const outcome = await settle_provider_calls([
+			{
+				provider: 'brave',
+				run: async () => [{ title: 'brave-hit' }],
+			},
+			{
+				provider: 'tavily',
+				run: async () => [{ title: 'tavily-hit' }],
+			},
+		]);
+
+		expect(outcome.values).toEqual([
+			[{ title: 'brave-hit' }],
+			[{ title: 'tavily-hit' }],
+		]);
+		expect(outcome.metadata).toEqual({
+			selected: ['brave', 'tavily'],
+			successful: ['brave', 'tavily'],
+			failed: [],
+			timed_out: [],
+		});
+	});
+
+	it('keeps successful results when another provider fails', async () => {
+		const outcome = await settle_provider_calls([
+			{
+				provider: 'brave',
+				run: async () => [{ title: 'only-brave' }],
+			},
+			{
+				provider: 'tavily',
+				run: async () => {
+					throw new ProviderError(
+						ErrorType.RATE_LIMIT,
+						`Rate limit exceeded for ${SECRET}`,
+						'tavily',
+						{ cause: `stack ${STACK_FRAGMENT}` },
+					);
+				},
+			},
+		]);
+
+		expect(outcome.values).toEqual([[{ title: 'only-brave' }]]);
+		expect(outcome.metadata).toEqual({
+			selected: ['brave', 'tavily'],
+			successful: ['brave'],
+			failed: [{ provider: 'tavily', type: ErrorType.RATE_LIMIT }],
+			timed_out: [],
+		});
+		expect(serialized(outcome)).not.toContain(SECRET);
+		expect(serialized(outcome)).not.toContain(STACK_FRAGMENT);
+		expect(serialized(outcome.metadata.failed)).not.toContain(
+			'message',
+		);
+	});
+
+	it('records timeouts separately from failed providers', async () => {
+		const timeout = new Error(`AbortSignal.timeout ${SECRET}`);
+		timeout.name = 'TimeoutError';
+
+		const outcome = await settle_provider_calls([
+			{
+				provider: 'brave',
+				run: async () => [{ title: 'ok' }],
+			},
+			{
+				provider: 'exa',
+				run: async () => {
+					throw timeout;
+				},
+			},
+			{
+				provider: 'kagi',
+				run: async () => {
+					throw new ProviderError(
+						ErrorType.TIMEOUT,
+						`kagi exceeded ${SECRET}`,
+						'kagi',
+					);
+				},
+			},
+		]);
+
+		expect(outcome.values).toEqual([[{ title: 'ok' }]]);
+		expect(outcome.metadata.successful).toEqual(['brave']);
+		expect(outcome.metadata.failed).toEqual([]);
+		expect(outcome.metadata.timed_out).toEqual(['exa', 'kagi']);
+		expect(serialized(outcome)).not.toContain(SECRET);
+	});
+
+	it('returns an empty result list when every selected provider fails', async () => {
+		const outcome = await settle_provider_calls([
+			{
+				provider: 'brave',
+				run: async () => {
+					throw new ProviderError(
+						ErrorType.AUTH_ERROR,
+						`Invalid API key ${SECRET}`,
+						'brave',
+					);
+				},
+			},
+			{
+				provider: 'tavily',
+				run: async () => {
+					throw new Error(`upstream 500 ${SECRET}`);
+				},
+			},
+		]);
+
+		expect(outcome.values).toEqual([]);
+		expect(outcome.metadata).toEqual({
+			selected: ['brave', 'tavily'],
+			successful: [],
+			failed: [
+				{ provider: 'brave', type: ErrorType.AUTH_ERROR },
+				{ provider: 'tavily', type: ErrorType.API_ERROR },
+			],
+			timed_out: [],
+		});
+		expect(serialized(outcome)).not.toContain(SECRET);
+	});
+
+	it('deduplicates selected providers and preserves first-call order', async () => {
+		const outcome = await settle_provider_calls([
+			{
+				provider: 'tavily',
+				run: async () => [{ title: 'first' }],
+			},
+			{
+				provider: 'brave',
+				run: async () => [{ title: 'second' }],
+			},
+			{
+				provider: 'tavily',
+				run: async () => [{ title: 'duplicate' }],
+			},
+		]);
+
+		expect(outcome.metadata.selected).toEqual(['tavily', 'brave']);
+		expect(outcome.values).toEqual([
+			[{ title: 'first' }],
+			[{ title: 'second' }],
+		]);
+	});
+
+	it('normalizes a string or list into unique selected ids', () => {
+		expect(normalize_provider_selection('brave')).toEqual(['brave']);
+		expect(
+			normalize_provider_selection(['tavily', 'brave', 'tavily']),
+		).toEqual(['tavily', 'brave']);
+	});
+
+	it('keeps the single-provider result shape', async () => {
+		await expect(
+			run_selected_providers('brave', async () => [
+				{ title: 'solo' },
+			]),
+		).resolves.toEqual([{ title: 'solo' }]);
+	});
+
+	it('wraps multi-provider calls with flattened results and metadata', async () => {
+		const payload = await run_selected_providers(
+			['brave', 'tavily'],
+			async (id) => {
+				if (id === 'tavily') {
+					throw new ProviderError(
+						ErrorType.AUTH_ERROR,
+						`Invalid API key ${SECRET}`,
+						'tavily',
+					);
+				}
+				return [{ title: 'brave-hit' }];
+			},
+		);
+
+		expect(payload).toEqual({
+			results: [{ title: 'brave-hit' }],
+			metadata: {
+				selected: ['brave', 'tavily'],
+				successful: ['brave'],
+				failed: [{ provider: 'tavily', type: ErrorType.AUTH_ERROR }],
+				timed_out: [],
+			},
+		});
+		expect(serialized(payload)).not.toContain(SECRET);
+	});
+
+	it('attaches preempted skips without treating them as selected', async () => {
+		const outcome = await settle_provider_calls(
+			[
+				{
+					provider: 'brave',
+					run: async () => [{ title: 'ok' }],
+				},
+			],
+			{ preempted: ['kagi'] },
+		);
+
+		expect(outcome.metadata.selected).toEqual(['brave']);
+		expect(outcome.metadata.preempted).toEqual(['kagi']);
+	});
+});

--- a/src/common/partial-success.ts
+++ b/src/common/partial-success.ts
@@ -1,0 +1,185 @@
+import { ErrorType, ProviderError } from './types.js';
+
+export interface ProviderFailure {
+	provider: string;
+	type: ErrorType;
+}
+
+export interface PartialSuccessMetadata {
+	selected: string[];
+	successful: string[];
+	failed: ProviderFailure[];
+	timed_out: string[];
+	preempted?: string[];
+}
+
+export interface ProviderCall<T> {
+	provider: string;
+	run: () => Promise<T>;
+}
+
+export interface SettleProviderCallOptions {
+	preempted?: readonly string[];
+}
+
+export interface PartialSuccess<T> {
+	values: T[];
+	metadata: PartialSuccessMetadata;
+}
+
+export interface PartialSuccessPayload<T> {
+	results: T[];
+	metadata: PartialSuccessMetadata;
+}
+
+/**
+ * Normalize a single provider or list into unique ids, first-seen order.
+ */
+export const normalize_provider_selection = (
+	provider: string | readonly string[],
+): string[] =>
+	typeof provider === 'string'
+		? [provider]
+		: unique_preserving_order(provider);
+
+const unique_preserving_order = (values: readonly string[]) =>
+	Array.from(new Set(values));
+
+const is_timeout_like = (error: unknown): boolean => {
+	if (typeof error !== 'object' || error === null) return false;
+	if (!('name' in error) || typeof error.name !== 'string') {
+		return false;
+	}
+
+	return error.name === 'TimeoutError' || error.name === 'AbortError';
+};
+
+/**
+ * Map a thrown value to a public error type. Never returns messages,
+ * stacks, or provider details that could contain secrets.
+ */
+export const classify_provider_failure = (
+	error: unknown,
+): ErrorType => {
+	if (error instanceof ProviderError) {
+		return error.type;
+	}
+
+	if (is_timeout_like(error)) {
+		return ErrorType.TIMEOUT;
+	}
+
+	return ErrorType.API_ERROR;
+};
+
+/**
+ * Build caller-safe provider outcome metadata. Failed entries keep
+ * only the provider id and error type.
+ */
+export const build_partial_success_metadata = (input: {
+	selected: readonly string[];
+	successful: readonly string[];
+	failed: readonly ProviderFailure[];
+	timed_out: readonly string[];
+	preempted?: readonly string[];
+}): PartialSuccessMetadata => {
+	const metadata: PartialSuccessMetadata = {
+		selected: [...input.selected],
+		successful: [...input.successful],
+		failed: input.failed.map(({ provider, type }) => ({
+			provider,
+			type,
+		})),
+		timed_out: [...input.timed_out],
+	};
+
+	if (input.preempted && input.preempted.length > 0) {
+		metadata.preempted = [...input.preempted];
+	}
+
+	return metadata;
+};
+
+/**
+ * Run selected provider calls concurrently and keep whatever
+ * succeeded. Timeouts are listed separately from other failures.
+ */
+export const settle_provider_calls = async <T>(
+	calls: readonly ProviderCall<T>[],
+	options: SettleProviderCallOptions = {},
+): Promise<PartialSuccess<T>> => {
+	const selected = unique_preserving_order(
+		calls.map((call) => call.provider),
+	);
+	const unique_calls = selected.map(
+		(provider) =>
+			calls.find(
+				(call) => call.provider === provider,
+			) as ProviderCall<T>,
+	);
+
+	const settled = await Promise.allSettled(
+		unique_calls.map((call) => call.run()),
+	);
+
+	const values: T[] = [];
+	const successful: string[] = [];
+	const failed: ProviderFailure[] = [];
+	const timed_out: string[] = [];
+
+	settled.forEach((result, index) => {
+		const provider = unique_calls[index].provider;
+
+		if (result.status === 'fulfilled') {
+			successful.push(provider);
+			values.push(result.value);
+			return;
+		}
+
+		const type = classify_provider_failure(result.reason);
+		if (type === ErrorType.TIMEOUT) {
+			timed_out.push(provider);
+			return;
+		}
+
+		failed.push({ provider, type });
+	});
+
+	return {
+		values,
+		metadata: build_partial_success_metadata({
+			selected,
+			successful,
+			failed,
+			timed_out,
+			preempted: options.preempted,
+		}),
+	};
+};
+
+/**
+ * Run one provider and return its results, or run several and return
+ * flattened successes plus structured outcome metadata.
+ */
+export const run_selected_providers = async <T>(
+	provider: string | readonly string[],
+	run: (id: string) => Promise<T[]>,
+	options: SettleProviderCallOptions = {},
+): Promise<T[] | PartialSuccessPayload<T>> => {
+	if (typeof provider === 'string') {
+		return run(provider);
+	}
+
+	const { values, metadata } = await settle_provider_calls(
+		normalize_provider_selection(provider).map((id) => ({
+			provider: id,
+			run: () => run(id),
+		})),
+		options,
+	);
+
+	return {
+		results: values.flat(),
+		metadata,
+	};
+};

--- a/src/server/tools/ai-search.ts
+++ b/src/server/tools/ai-search.ts
@@ -1,6 +1,7 @@
 import { McpServer } from 'tmcp';
 import type { GenericSchema } from 'valibot';
 import * as v from 'valibot';
+import { run_selected_providers } from '../../common/partial-success.js';
 import { SearchProvider } from '../../common/types.js';
 import {
 	ai_search_provider_definitions,
@@ -11,6 +12,7 @@ import { handle_tool_result } from './responses.js';
 import {
 	large_result_mode_schema,
 	limit_schema,
+	provider_selection_schema,
 	query_schema,
 } from './schemas.js';
 
@@ -48,9 +50,9 @@ export const register_ai_search = (
 			},
 			schema: v.object({
 				query: query_schema,
-				provider: v.pipe(
-					v.picklist(provider_names),
-					v.description('AI search provider to use'),
+				provider: provider_selection_schema(
+					provider_names,
+					'AI search provider to use, or a list to keep successful results when some providers fail',
 				),
 				limit: limit_schema,
 				large_result_mode: large_result_mode_schema,
@@ -59,14 +61,15 @@ export const register_ai_search = (
 		async ({ query, provider, limit, large_result_mode }) =>
 			handle_tool_result(
 				'ai_search',
-				async () => {
-					const selected = providers.require(provider, 'ai_search');
+				async () =>
+					run_selected_providers(provider, async (id) => {
+						const selected = providers.require(id, 'ai_search');
 
-					return selected.search({
-						query,
-						limit,
-					});
-				},
+						return selected.search({
+							query,
+							limit,
+						});
+					}),
 				{ large_result_mode },
 			),
 	);

--- a/src/server/tools/contract.test.ts
+++ b/src/server/tools/contract.test.ts
@@ -82,7 +82,7 @@ afterEach(() => {
 	vi.restoreAllMocks();
 });
 
-describe('MCP tool contract', () => {
+describe('MCP tool contract', { timeout: 20_000 }, () => {
 	it('registers no public tools when no providers are configured', async () => {
 		const { tools, tools_module } = await load_contract({});
 
@@ -261,6 +261,80 @@ describe('MCP tool contract', () => {
 			provider: 'brave',
 			retryable: false,
 		});
+	});
+
+	it('returns successful web_search results with typed partial-success metadata', async () => {
+		const secret = 'sk-live-contract-secret';
+		const { tools } = await load_contract({
+			BRAVE_API_KEY: 'brave-key',
+			TAVILY_API_KEY: secret,
+		});
+		const tool = tools.find(
+			(entry) => entry.definition.name === 'web_search',
+		)!;
+
+		expect(
+			v.safeParse(tool.definition.schema, {
+				query: 'example',
+				provider: ['brave', 'tavily'],
+			}).success,
+		).toBe(true);
+
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(async (url: string | URL) => {
+				if (String(url).includes('api.search.brave.com')) {
+					return new Response(
+						JSON.stringify({
+							web: {
+								results: [
+									{
+										title: 'Brave Result',
+										url: 'https://example.com/brave',
+										description: 'From brave',
+									},
+								],
+							},
+						}),
+						{ status: 200 },
+					);
+				}
+
+				return new Response(
+					JSON.stringify({ error: `Invalid API key ${secret}` }),
+					{ status: 401 },
+				);
+			}),
+		);
+
+		const response = await tool.handler({
+			query: 'example',
+			provider: ['brave', 'tavily'],
+			large_result_mode: 'inline',
+		});
+		const body = parse_tool_body(response);
+		const payload = JSON.stringify(body);
+
+		expect(response.isError).toBeUndefined();
+		expect(body).toEqual({
+			results: [
+				{
+					title: 'Brave Result',
+					url: 'https://example.com/brave',
+					snippet: 'From brave',
+					source_provider: 'brave',
+				},
+			],
+			metadata: {
+				selected: ['brave', 'tavily'],
+				successful: ['brave'],
+				failed: [{ provider: 'tavily', type: 'AUTH_ERROR' }],
+				timed_out: [],
+			},
+		});
+		expect(payload).not.toContain(secret);
+		expect(payload).not.toContain('Invalid API key');
+		expect(payload).not.toContain('stack');
 	});
 
 	it('covers large-result inline/file modes and compact extraction at the MCP layer', async () => {

--- a/src/server/tools/schemas.test.ts
+++ b/src/server/tools/schemas.test.ts
@@ -6,11 +6,26 @@ import {
 	include_raw_contents_schema,
 	large_result_mode_schema,
 	limit_schema,
+	provider_selection_schema,
 	query_schema,
 	url_or_urls_schema,
 } from './schemas.js';
 
 describe('tool schemas', () => {
+	it('accepts a single provider or a non-empty provider list', () => {
+		const schema = provider_selection_schema(
+			['brave', 'tavily'],
+			'Search provider',
+		);
+
+		expect(v.safeParse(schema, 'brave').success).toBe(true);
+		expect(v.safeParse(schema, ['brave', 'tavily']).success).toBe(
+			true,
+		);
+		expect(v.safeParse(schema, []).success).toBe(false);
+		expect(v.safeParse(schema, ['kagi']).success).toBe(false);
+	});
+
 	it('accepts non-empty queries and rejects empty queries', () => {
 		expect(v.parse(query_schema, 'sveltekit')).toBe('sveltekit');
 		expect(v.safeParse(query_schema, '').success).toBe(false);

--- a/src/server/tools/schemas.ts
+++ b/src/server/tools/schemas.ts
@@ -3,6 +3,24 @@ import * as v from 'valibot';
 const DOMAIN_PATTERN =
 	/^(?:\*\.)?(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,63}$/;
 
+export const provider_selection_schema = (
+	provider_names: string[],
+	description: string,
+) => {
+	const names = provider_names as [string, ...string[]];
+
+	return v.pipe(
+		v.union([
+			v.picklist(names),
+			v.pipe(
+				v.array(v.picklist(names)),
+				v.minLength(1, 'Provide at least one provider'),
+			),
+		]),
+		v.description(description),
+	);
+};
+
 export const query_schema = v.pipe(
 	v.string(),
 	v.minLength(1, 'Query cannot be empty'),

--- a/src/server/tools/web-search.ts
+++ b/src/server/tools/web-search.ts
@@ -1,6 +1,7 @@
 import { McpServer } from 'tmcp';
 import type { GenericSchema } from 'valibot';
 import * as v from 'valibot';
+import { run_selected_providers } from '../../common/partial-success.js';
 import { SearchProvider } from '../../common/types.js';
 import {
 	web_search_provider_definitions,
@@ -13,6 +14,7 @@ import {
 	include_domains_schema,
 	large_result_mode_schema,
 	limit_schema,
+	provider_selection_schema,
 	query_schema,
 } from './schemas.js';
 
@@ -50,9 +52,9 @@ export const register_web_search = (
 			},
 			schema: v.object({
 				query: query_schema,
-				provider: v.pipe(
-					v.picklist(provider_names),
-					v.description('Search provider to use'),
+				provider: provider_selection_schema(
+					provider_names,
+					'Search provider to use, or a list to keep successful results when some providers fail',
 				),
 				limit: limit_schema,
 				include_domains: include_domains_schema,
@@ -70,16 +72,17 @@ export const register_web_search = (
 		}) =>
 			handle_tool_result(
 				'web_search',
-				async () => {
-					const selected = providers.require(provider, 'web_search');
+				async () =>
+					run_selected_providers(provider, async (id) => {
+						const selected = providers.require(id, 'web_search');
 
-					return selected.search({
-						query,
-						limit,
-						include_domains,
-						exclude_domains,
-					});
-				},
+						return selected.search({
+							query,
+							limit,
+							include_domains,
+							exclude_domains,
+						});
+					}),
 				{ large_result_mode },
 			),
 	);


### PR DESCRIPTION
## Summary

A single provider error currently becomes the whole tool error, so callers cannot tell which engines were selected, succeeded, failed, or timed out. This PR keeps whatever results did succeed on multi-provider `web_search` / `ai_search` calls and attaches structured metadata with error *types* only.

Fixes #195.

## Scope

- `src/common/partial-success.ts` — concurrent settle helper, type-only failure classification, optional `preempted` skips
- `web_search` / `ai_search` — `provider` accepts a string (unchanged shape) or a list (returns `{ results, metadata }`)
- Docs, changeset, and contract coverage for the new payload

No merge/dedupe, routing, cache, or failover behavior.

## Verification

```bash
pnpm run check
pnpm test
pnpm run build
```

Expected: format/lint/types clean, 127 tests passing, `dist/index.js` built.

Example MCP call:

```json
{
  "query": "sveltekit remote functions",
  "provider": ["brave", "tavily"]
}
```

Example partial payload (no exception text or secrets):

```json
{
  "results": [{ "title": "…", "source_provider": "brave" }],
  "metadata": {
    "selected": ["brave", "tavily"],
    "successful": ["brave"],
    "failed": [{ "provider": "tavily", "type": "AUTH_ERROR" }],
    "timed_out": []
  }
}
```

## Impact

- Single-string `provider` is unchanged: still a result array, still a whole-tool error on failure
- A provider list is a valid partial response even when every selected engine fails
- `failed` entries are `{ provider, type }` only; raw stacks and provider messages stay off the tool payload