### PR TITLE
Add optional You.com search and Contents extract provider

### DIFF
--- a/.changeset/you-provider.md
+++ b/.changeset/you-provider.md
@@ -1,0 +1,5 @@
+---
+'mcp-omnisearch': patch
+---
+
+Add optional You.com search and Contents extract provider

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# Optional provider keys. Missing keys are not registered.
+TAVILY_API_KEY=
+KAGI_API_KEY=
+BRAVE_API_KEY=
+GITHUB_API_KEY=
+EXA_API_KEY=
+LINKUP_API_KEY=
+FIRECRAWL_API_KEY=
+# Optional self-hosted Firecrawl
+FIRECRAWL_BASE_URL=
+YOU_API_KEY=
+# Optional large-result handling: file (default) or inline
+OMNISEARCH_LARGE_RESULT_MODE=

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 [![tested with vitest](https://img.shields.io/badge/tested%20with-Vitest-6E9F18?logo=vitest&logoColor=white)](https://vitest.dev)
 
 A Model Context Protocol (MCP) server that provides unified access to
-Tavily, Brave, Kagi, Exa AI, GitHub, Linkup, and Firecrawl through
-four consolidated tools.
+Tavily, Brave, Kagi, Exa AI, GitHub, Linkup, Firecrawl, and You.com
+through four consolidated tools.
 
 <a href="https://glama.ai/mcp/servers/gz5wgmptd8">
   <img width="380" height="200" src="https://glama.ai/mcp/servers/gz5wgmptd8/badge" alt="Glama badge" />
@@ -63,7 +63,8 @@ working.
 				"GITHUB_API_KEY": "your-github-token",
 				"EXA_API_KEY": "your-exa-key",
 				"LINKUP_API_KEY": "your-linkup-key",
-				"FIRECRAWL_API_KEY": "your-firecrawl-key"
+				"FIRECRAWL_API_KEY": "your-firecrawl-key",
+				"YOU_API_KEY": "your-you-key"
 			}
 		}
 	}
@@ -74,7 +75,8 @@ working.
 
 ### `web_search`
 
-Search the web with Tavily, Brave, Kagi, Exa, or Kagi Enrichment.
+Search the web with Tavily, Brave, Kagi, Exa, Kagi Enrichment, or
+You.com.
 
 ```json
 {
@@ -110,7 +112,7 @@ Search GitHub code, repositories, or users.
 ### `web_extract`
 
 Extract, crawl, scrape, summarize, or find similar content with
-Tavily, Kagi, Firecrawl, or Exa.
+Tavily, Kagi, Firecrawl, Exa, or You.com.
 
 ```json
 {
@@ -142,6 +144,7 @@ Tavily, Kagi, Firecrawl, or Exa.
 - `EXA_API_KEY`
 - `LINKUP_API_KEY`
 - `FIRECRAWL_API_KEY`
+- `YOU_API_KEY`
 - `FIRECRAWL_BASE_URL` optional, for self-hosted Firecrawl
 - `OMNISEARCH_LARGE_RESULT_MODE` optional, `file` default or `inline`
 
@@ -165,4 +168,5 @@ Built on
 [Model Context Protocol](https://github.com/modelcontextprotocol),
 [Tavily](https://tavily.com), [Kagi](https://kagi.com),
 [Brave Search](https://search.brave.com), [Exa AI](https://exa.ai),
-[Linkup](https://linkup.so), and [Firecrawl](https://firecrawl.dev).
+[Linkup](https://linkup.so), [Firecrawl](https://firecrawl.dev), and
+[You.com](https://you.com).

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -67,6 +67,7 @@ matching providers.
 				"EXA_API_KEY": "your-exa-key",
 				"LINKUP_API_KEY": "your-linkup-key",
 				"FIRECRAWL_API_KEY": "your-firecrawl-key",
+				"YOU_API_KEY": "your-you-key",
 				"FIRECRAWL_BASE_URL": "http://localhost:3002"
 			}
 		}
@@ -126,6 +127,7 @@ Container variables:
 - `EXA_API_KEY`
 - `LINKUP_API_KEY`
 - `FIRECRAWL_API_KEY`
+- `YOU_API_KEY`
 - `FIRECRAWL_BASE_URL`
 - `PORT`, defaults to `8000`
 

--- a/docs/provider-selection.md
+++ b/docs/provider-selection.md
@@ -7,13 +7,14 @@ mode.
 
 ## Search providers
 
-| Provider          | API key          | Best for                                                              | Operators and filters                                                                                                               |
-| ----------------- | ---------------- | --------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| `brave`           | `BRAVE_API_KEY`  | Privacy-oriented web search, native search operators, exact discovery | Passes rich operators through in the query string and merges `include_domains` / `exclude_domains` into `site:` / `-site:` clauses. |
-| `kagi`            | `KAGI_API_KEY`   | High-quality web results and focused research                         | Preserves query operators, uses Kagi request parameters for `filetype:` and `before:` / `after:` dates.                             |
-| `tavily`          | `TAVILY_API_KEY` | Factual/cited search and API-native filtering                         | Translates supported operators into Tavily fields: domains, dates, exact phrases, and country.                                      |
-| `exa`             | `EXA_API_KEY`    | Semantic/neural search and discovery                                  | Supports domain filters through request parameters; optimized for meaning rather than exact operator syntax.                        |
-| `kagi_enrichment` | `KAGI_API_KEY`   | Specialized Kagi enrichment indexes                                   | Use when enrichment/specialized-index results are desired rather than general web results.                                          |
+| Provider          | API key          | Best for                                                              | Operators and filters                                                                                                                                                                                           |
+| ----------------- | ---------------- | --------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `brave`           | `BRAVE_API_KEY`  | Privacy-oriented web search, native search operators, exact discovery | Passes rich operators through in the query string and merges `include_domains` / `exclude_domains` into `site:` / `-site:` clauses.                                                                             |
+| `kagi`            | `KAGI_API_KEY`   | High-quality web results and focused research                         | Preserves query operators, uses Kagi request parameters for `filetype:` and `before:` / `after:` dates.                                                                                                         |
+| `tavily`          | `TAVILY_API_KEY` | Factual/cited search and API-native filtering                         | Translates supported operators into Tavily fields: domains, dates, exact phrases, and country.                                                                                                                  |
+| `exa`             | `EXA_API_KEY`    | Semantic/neural search and discovery                                  | Supports domain filters through request parameters; optimized for meaning rather than exact operator syntax.                                                                                                    |
+| `kagi_enrichment` | `KAGI_API_KEY`   | Specialized Kagi enrichment indexes                                   | Use when enrichment/specialized-index results are desired rather than general web results.                                                                                                                      |
+| `you`             | `YOU_API_KEY`    | Fast LLM-ready web/news snippets for RAG                              | Translates `site:` / `-site:`, `include_domains` / `exclude_domains`, `lang:`, `loc:`, and `before:` / `after:` into You.com fields (`include_domains`, `exclude_domains`, `language`, `country`, `freshness`). |
 
 ## AI answer providers
 
@@ -41,6 +42,7 @@ search only. See
 | `kagi`      | `KAGI_API_KEY`      | `summarize`                                    | Summaries of pages, videos, and podcasts.                                  |
 | `firecrawl` | `FIRECRAWL_API_KEY` | `scrape`, `crawl`, `map`, `extract`, `actions` | Scraping, crawling, site maps, structured extraction, and browser actions. |
 | `exa`       | `EXA_API_KEY`       | `contents`, `similar`                          | Page content retrieval and semantically similar URLs.                      |
+| `you`       | `YOU_API_KEY`       | `contents`                                     | Clean Markdown via the You.com Contents API.                               |
 
 ## Provider choice cheatsheet
 
@@ -49,6 +51,8 @@ search only. See
 - Need API-level domain/date/country filtering? Use `tavily`.
 - Need semantic discovery, similar pages, or meaning-based results?
   Use `exa`.
+- Need fast LLM-ready web/news snippets or Contents API markdown? Use
+  `you`.
 - Need source-grounded narrative answers? Use `ai_search` with
   `kagi_fastgpt`, `exa_answer`, or `linkup`.
 - Need to crawl/scrape/map a site? Use `web_extract` with `firecrawl`.

--- a/docs/search-operators.md
+++ b/docs/search-operators.md
@@ -7,22 +7,22 @@ and GitHub uses GitHub search qualifiers.
 
 ## Operator matrix
 
-| Feature                               | Brave                                   | Kagi                                   | Tavily                                         | Exa                              | GitHub                                  |
-| ------------------------------------- | --------------------------------------- | -------------------------------------- | ---------------------------------------------- | -------------------------------- | --------------------------------------- |
-| `site:example.com`                    | Native query passthrough                | Query passthrough                      | `include_domains`                              | Domain parameter                 | Use `repo:` / `user:` where relevant    |
-| `-site:example.com`                   | Native query passthrough                | Query passthrough                      | `exclude_domains`                              | Domain parameter where supported | Not applicable                          |
-| `include_domains` / `exclude_domains` | Merged into query as `site:` / `-site:` | Merged/preserved as provider filtering | Native request fields                          | Native request fields            | Not applicable                          |
-| `filetype:pdf` / `ext:pdf`            | Native query passthrough                | Kagi `file_type` parameter             | Left in sanitized query only where unsupported | Not a primary operator           | Not applicable                          |
-| `intitle:`                            | Native query passthrough                | Query passthrough                      | Left in sanitized query                        | Not a primary operator           | Not applicable                          |
-| `inurl:`                              | Native query passthrough                | Query passthrough                      | Left in sanitized query                        | Not a primary operator           | Not applicable                          |
-| `inbody:` / `inpage:`                 | Native query passthrough                | Query passthrough                      | Left in sanitized query                        | Not a primary operator           | Not applicable                          |
-| `lang:en`                             | Native query passthrough                | Query passthrough                      | Left in sanitized query                        | Not a primary operator           | `language:typescript` for GitHub        |
-| `loc:us` / `location:us`              | Native query passthrough                | Query passthrough                      | `country` parameter                            | Not a primary operator           | Not applicable                          |
-| `before:` / `after:`                  | Native query passthrough                | Kagi `time_range` parameter            | `end_date` / `start_date`                      | Not a primary operator           | GitHub supports its own date qualifiers |
-| `"exact phrase"`                      | Native query passthrough                | Query passthrough                      | Enables `exact_match`                          | Semantic matching                | Quote strings in GitHub query           |
-| `+required` / `-excluded`             | Native query passthrough                | Query passthrough                      | Left in sanitized query where unsupported      | Not a primary operator           | GitHub query syntax                     |
-| `AND` / `OR` / `NOT`                  | Native query passthrough                | Query passthrough                      | Left in sanitized query where unsupported      | Not a primary operator           | GitHub query syntax varies by endpoint  |
-| `filename:` / `path:` / `repo:`       | Not primary                             | Not primary                            | Not primary                                    | Not primary                      | Native GitHub qualifiers                |
+| Feature                               | Brave                                   | Kagi                                   | Tavily                                         | Exa                              | You.com                                            | GitHub                                  |
+| ------------------------------------- | --------------------------------------- | -------------------------------------- | ---------------------------------------------- | -------------------------------- | -------------------------------------------------- | --------------------------------------- |
+| `site:example.com`                    | Native query passthrough                | Query passthrough                      | `include_domains`                              | Domain parameter                 | `include_domains`                                  | Use `repo:` / `user:` where relevant    |
+| `-site:example.com`                   | Native query passthrough                | Query passthrough                      | `exclude_domains`                              | Domain parameter where supported | `exclude_domains`                                  | Not applicable                          |
+| `include_domains` / `exclude_domains` | Merged into query as `site:` / `-site:` | Merged/preserved as provider filtering | Native request fields                          | Native request fields            | Native request fields                              | Not applicable                          |
+| `filetype:pdf` / `ext:pdf`            | Native query passthrough                | Kagi `file_type` parameter             | Left in sanitized query only where unsupported | Not a primary operator           | Left in sanitized query                            | Not applicable                          |
+| `intitle:`                            | Native query passthrough                | Query passthrough                      | Left in sanitized query                        | Not a primary operator           | Left in sanitized query                            | Not applicable                          |
+| `inurl:`                              | Native query passthrough                | Query passthrough                      | Left in sanitized query                        | Not a primary operator           | Left in sanitized query                            | Not applicable                          |
+| `inbody:` / `inpage:`                 | Native query passthrough                | Query passthrough                      | Left in sanitized query                        | Not a primary operator           | Left in sanitized query                            | Not applicable                          |
+| `lang:en`                             | Native query passthrough                | Query passthrough                      | Left in sanitized query                        | Not a primary operator           | `language`                                         | `language:typescript` for GitHub        |
+| `loc:us` / `location:us`              | Native query passthrough                | Query passthrough                      | `country` parameter                            | Not a primary operator           | `country`                                          | Not applicable                          |
+| `before:` / `after:`                  | Native query passthrough                | Kagi `time_range` parameter            | `end_date` / `start_date`                      | Not a primary operator           | `freshness` (`day`/`week`/`month`/`year` or range) | GitHub supports its own date qualifiers |
+| `"exact phrase"`                      | Native query passthrough                | Query passthrough                      | Enables `exact_match`                          | Semantic matching                | Left in sanitized query                            | Quote strings in GitHub query           |
+| `+required` / `-excluded`             | Native query passthrough                | Query passthrough                      | Left in sanitized query where unsupported      | Not a primary operator           | Left in sanitized query                            | GitHub query syntax                     |
+| `AND` / `OR` / `NOT`                  | Native query passthrough                | Query passthrough                      | Left in sanitized query where unsupported      | Not a primary operator           | Left in sanitized query                            | GitHub query syntax varies by endpoint  |
+| `filename:` / `path:` / `repo:`       | Not primary                             | Not primary                            | Not primary                                    | Not primary                      | Not primary                                        | Native GitHub qualifiers                |
 
 Unsupported provider-specific operators remain in the sanitized query
 where possible rather than being flattened globally.
@@ -71,6 +71,20 @@ and a cleaned query preserving other supported operators.
 
 Tavily receives merged domain arrays, `start_date`, `end_date`,
 `country`, and `exact_match` fields.
+
+### You.com: translated operators
+
+```json
+{
+	"query": "sveltekit site:kit.svelte.dev -site:spam.dev lang:en loc:us after:2024-05-01 before:2024-05-10",
+	"provider": "you",
+	"limit": 5,
+	"include_domains": ["docs.example.com"]
+}
+```
+
+You.com receives merged domain arrays plus `language`, `country`, and
+`freshness`.
 
 ### GitHub search qualifiers
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -11,6 +11,7 @@ Each provider requires its own key:
 - Exa: `EXA_API_KEY`
 - Linkup: `LINKUP_API_KEY`
 - Firecrawl: `FIRECRAWL_API_KEY`
+- You.com: `YOU_API_KEY`
 
 Missing keys do not stop the server. The matching provider is skipped
 and configured providers remain available.

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -7,6 +7,7 @@ export const KAGI_API_KEY = process.env.KAGI_API_KEY;
 export const GITHUB_API_KEY = process.env.GITHUB_API_KEY;
 export const EXA_API_KEY = process.env.EXA_API_KEY;
 export const LINKUP_API_KEY = process.env.LINKUP_API_KEY;
+export const YOU_API_KEY = process.env.YOU_API_KEY;
 
 // Content processing API keys
 export const FIRECRAWL_API_KEY = process.env.FIRECRAWL_API_KEY;
@@ -38,6 +39,11 @@ export const config = {
 		exa: {
 			api_key: EXA_API_KEY,
 			base_url: 'https://api.exa.ai',
+			timeout: 30000, // 30 seconds
+		},
+		you: {
+			api_key: YOU_API_KEY,
+			base_url: 'https://ydc-index.io',
 			timeout: 30000, // 30 seconds
 		},
 	},
@@ -114,6 +120,11 @@ export const config = {
 			base_url: 'https://api.exa.ai',
 			timeout: 30000, // 30 seconds
 		},
+		you_contents: {
+			api_key: YOU_API_KEY,
+			base_url: 'https://ydc-index.io',
+			timeout: 30000, // 30 seconds
+		},
 	},
 	enhancement: {
 		kagi_enrichment: {
@@ -177,6 +188,9 @@ export const validate_config = () => {
 
 	if (!LINKUP_API_KEY) missing_keys.push('LINKUP_API_KEY');
 	else available_keys.push('LINKUP_API_KEY');
+
+	if (!YOU_API_KEY) missing_keys.push('YOU_API_KEY');
+	else available_keys.push('YOU_API_KEY');
 
 	// Log available keys
 	if (available_keys.length > 0) {

--- a/src/providers/processing/you-contents/index.test.ts
+++ b/src/providers/processing/you-contents/index.test.ts
@@ -1,0 +1,78 @@
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	vi,
+} from 'vitest';
+
+const json_response = (body: unknown) =>
+	new Response(JSON.stringify(body), { status: 200 });
+
+describe('YouContentsProvider', () => {
+	beforeEach(() => {
+		vi.resetModules();
+		vi.stubEnv('YOU_API_KEY', 'test-you-key');
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		vi.unstubAllEnvs();
+		vi.restoreAllMocks();
+	});
+
+	it('combines Markdown contents from the You.com Contents API', async () => {
+		const fetch = vi.fn(
+			async (_input: RequestInfo | URL, _init?: RequestInit) =>
+				json_response([
+					{
+						url: 'https://ok.test',
+						title: 'OK',
+						markdown: 'Extracted words here',
+					},
+					{
+						url: 'https://empty.test',
+						markdown: '',
+					},
+				]),
+		);
+		vi.stubGlobal('fetch', fetch);
+		const { YouContentsProvider } = await import('./index.js');
+
+		await expect(
+			new YouContentsProvider().process_content([
+				'https://ok.test',
+				'https://empty.test',
+			]),
+		).resolves.toMatchObject({
+			content: 'Extracted words here',
+			raw_contents: [
+				{ url: 'https://ok.test', content: 'Extracted words here' },
+			],
+			metadata: {
+				title: 'OK',
+				urls_processed: 2,
+				successful_extractions: 1,
+				extract_depth: 'basic',
+			},
+			source_provider: 'you_contents',
+		});
+
+		expect(fetch).toHaveBeenCalledWith(
+			'https://ydc-index.io/v1/contents',
+			expect.objectContaining({
+				method: 'POST',
+				headers: expect.objectContaining({
+					'X-API-Key': 'test-you-key',
+				}),
+			}),
+		);
+		expect(
+			JSON.parse(fetch.mock.calls[0]?.[1]?.body as string),
+		).toEqual({
+			urls: ['https://ok.test', 'https://empty.test'],
+			formats: ['markdown'],
+		});
+	});
+});

--- a/src/providers/processing/you-contents/index.ts
+++ b/src/providers/processing/you-contents/index.ts
@@ -1,0 +1,111 @@
+import * as v from 'valibot';
+import { handle_provider_error } from '../../../common/errors.js';
+import { http_json } from '../../../common/http.js';
+import { parse_provider_response } from '../../../common/provider-response.js';
+import { retry_with_backoff } from '../../../common/retry.js';
+import {
+	ErrorType,
+	ProcessingProvider,
+	ProcessingResult,
+	ProviderError,
+} from '../../../common/types.js';
+import {
+	validate_api_key,
+	validate_processing_urls,
+} from '../../../common/validation.js';
+import { config } from '../../../config/env.js';
+
+const you_contents_response_schema = v.array(
+	v.object({
+		url: v.optional(v.string()),
+		title: v.optional(v.string()),
+		markdown: v.optional(v.nullable(v.string())),
+		html: v.optional(v.nullable(v.string())),
+	}),
+);
+
+export class YouContentsProvider implements ProcessingProvider {
+	name = 'you_contents';
+	description =
+		'Extract clean Markdown from one or more URLs using the You.com Contents API. Best for LLM-ready page text without a separate crawler.';
+
+	async process_content(
+		url: string | string[],
+		extract_depth: 'basic' | 'advanced' = 'basic',
+	): Promise<ProcessingResult> {
+		const urls = validate_processing_urls(url, this.name);
+		const api_key = validate_api_key(
+			config.processing.you_contents.api_key,
+			this.name,
+		);
+
+		const extract_request = async () => {
+			try {
+				const raw_data = await http_json(
+					this.name,
+					`${config.processing.you_contents.base_url}/v1/contents`,
+					{
+						method: 'POST',
+						headers: {
+							Accept: 'application/json',
+							'Content-Type': 'application/json',
+							'X-API-Key': api_key,
+						},
+						body: JSON.stringify({
+							urls,
+							formats:
+								extract_depth === 'advanced'
+									? ['markdown', 'metadata']
+									: ['markdown'],
+						}),
+						signal: AbortSignal.timeout(
+							config.processing.you_contents.timeout,
+						),
+					},
+				);
+				const data = parse_provider_response(
+					this.name,
+					you_contents_response_schema,
+					raw_data,
+				);
+
+				const raw_contents = data
+					.map((result, index) => ({
+						url: result.url ?? urls[index] ?? urls[0],
+						content: result.markdown || result.html || '',
+					}))
+					.filter((result) => result.content.length > 0);
+
+				if (raw_contents.length === 0) {
+					throw new ProviderError(
+						ErrorType.PROVIDER_ERROR,
+						'No content extracted from URL',
+						this.name,
+					);
+				}
+
+				const combined_content = raw_contents
+					.map((result) => result.content)
+					.join('\n\n');
+
+				return {
+					content: combined_content,
+					raw_contents,
+					metadata: {
+						title: data[0]?.title,
+						word_count: combined_content.split(/\s+/).filter(Boolean)
+							.length,
+						urls_processed: urls.length,
+						successful_extractions: raw_contents.length,
+						extract_depth,
+					},
+					source_provider: this.name,
+				};
+			} catch (error) {
+				handle_provider_error(error, this.name, 'extract content');
+			}
+		};
+
+		return retry_with_backoff(extract_request);
+	}
+}

--- a/src/providers/search/you/index.test.ts
+++ b/src/providers/search/you/index.test.ts
@@ -1,0 +1,130 @@
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	vi,
+} from 'vitest';
+
+const json_response = (body: unknown) =>
+	new Response(JSON.stringify(body), {
+		status: 200,
+		headers: { 'content-type': 'application/json' },
+	});
+
+describe('YouSearchProvider', () => {
+	beforeEach(() => {
+		vi.resetModules();
+		vi.stubEnv('YOU_API_KEY', 'test-you-key');
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		vi.unstubAllEnvs();
+		vi.restoreAllMocks();
+	});
+
+	it('maps web and news results and sends domain filters', async () => {
+		const fetch = vi.fn(
+			async (_input: RequestInfo | URL, _init?: RequestInit) =>
+				json_response({
+					results: {
+						web: [
+							{
+								title: 'Web result',
+								url: 'https://example.com',
+								description: 'Web summary',
+							},
+						],
+						news: [
+							{
+								url: 'https://news.example.com',
+								snippets: ['News snippet'],
+							},
+						],
+					},
+				}),
+		);
+		vi.stubGlobal('fetch', fetch);
+		const { YouSearchProvider } = await import('./index.js');
+
+		await expect(
+			new YouSearchProvider().search({
+				query: 'example site:docs.example.com -site:ads.example.com',
+				limit: 5,
+				include_domains: ['included.example.com'],
+			}),
+		).resolves.toEqual([
+			{
+				title: 'Web result',
+				url: 'https://example.com',
+				snippet: 'Web summary',
+				source_provider: 'you',
+			},
+			{
+				title: 'https://news.example.com',
+				url: 'https://news.example.com',
+				snippet: 'News snippet',
+				source_provider: 'you',
+			},
+		]);
+
+		expect(fetch).toHaveBeenCalledWith(
+			'https://ydc-index.io/v1/search',
+			expect.objectContaining({
+				method: 'POST',
+				headers: expect.objectContaining({
+					'X-API-Key': 'test-you-key',
+				}),
+			}),
+		);
+		expect(
+			JSON.parse(fetch.mock.calls[0]?.[1]?.body as string),
+		).toEqual({
+			query: 'example',
+			count: 5,
+			include_domains: ['included.example.com', 'docs.example.com'],
+			exclude_domains: ['ads.example.com'],
+		});
+	});
+
+	it('maps language, country, and date operators to You.com fields', async () => {
+		const fetch = vi.fn(
+			async (_input: RequestInfo | URL, _init?: RequestInit) =>
+				json_response({
+					results: [],
+				}),
+		);
+		vi.stubGlobal('fetch', fetch);
+		const { YouSearchProvider } = await import('./index.js');
+
+		await new YouSearchProvider().search({
+			query:
+				'example lang:en loc:uk after:2024-05-01 before:2024-05-10',
+			limit: 3,
+		});
+
+		expect(
+			JSON.parse(fetch.mock.calls[0]?.[1]?.body as string),
+		).toEqual({
+			query: 'example',
+			count: 3,
+			country: 'GB',
+			language: 'EN',
+			freshness: '2024-05-01to2024-05-10',
+		});
+	});
+
+	it('returns no results when the results block is omitted', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(async () => json_response({})),
+		);
+		const { YouSearchProvider } = await import('./index.js');
+
+		await expect(
+			new YouSearchProvider().search({ query: 'empty' }),
+		).resolves.toEqual([]);
+	});
+});

--- a/src/providers/search/you/index.ts
+++ b/src/providers/search/you/index.ts
@@ -1,0 +1,235 @@
+import * as v from 'valibot';
+import {
+	handle_provider_error,
+	sanitize_query,
+} from '../../../common/errors.js';
+import { http_json } from '../../../common/http.js';
+import { parse_provider_response } from '../../../common/provider-response.js';
+import { retry_with_backoff } from '../../../common/retry.js';
+import {
+	apply_search_operators,
+	build_query_with_operators,
+	parse_search_operators,
+} from '../../../common/search-operators.js';
+import {
+	BaseSearchParams,
+	SearchProvider,
+	SearchResult,
+} from '../../../common/types.js';
+import { validate_api_key } from '../../../common/validation.js';
+import { config } from '../../../config/env.js';
+
+const you_result_schema = v.object({
+	title: v.optional(v.string()),
+	url: v.string(),
+	description: v.optional(v.string()),
+	snippets: v.optional(v.array(v.string())),
+});
+
+const you_search_response_schema = v.object({
+	results: v.optional(
+		v.union([
+			v.array(you_result_schema),
+			v.object({
+				web: v.optional(v.array(you_result_schema)),
+				news: v.optional(v.array(you_result_schema)),
+			}),
+		]),
+	),
+});
+
+interface YouSearchRequest {
+	query: string;
+	count: number;
+	include_domains?: string[];
+	exclude_domains?: string[];
+	country?: string;
+	language?: string;
+	freshness?: string;
+}
+
+const you_country_aliases: Record<string, string> = {
+	uk: 'GB',
+	gb: 'GB',
+	usa: 'US',
+	us: 'US',
+};
+
+const you_language_aliases: Record<string, string> = {
+	english: 'EN',
+	en: 'EN',
+	'en-gb': 'EN-GB',
+	japanese: 'JA',
+	ja: 'JA',
+	german: 'DE',
+	de: 'DE',
+	french: 'FR',
+	fr: 'FR',
+	spanish: 'ES',
+	es: 'ES',
+};
+
+const normalize_you_date = (date: string) => {
+	if (/^\d{4}$/.test(date)) return `${date}-01-01`;
+	if (/^\d{4}-\d{2}$/.test(date)) return `${date}-01`;
+	return date;
+};
+
+const normalize_you_country = (location: string) => {
+	const normalized = location.toLowerCase().replace(/[\s_-]+/g, '');
+	return you_country_aliases[normalized] ?? location.toUpperCase();
+};
+
+const normalize_you_language = (language: string) => {
+	const normalized = language.toLowerCase();
+	return you_language_aliases[normalized] ?? language.toUpperCase();
+};
+
+const map_you_freshness = (
+	date_after?: string,
+	date_before?: string,
+) => {
+	if (date_after && date_before) {
+		return `${normalize_you_date(date_after)}to${normalize_you_date(date_before)}`;
+	}
+
+	if (!date_after) return undefined;
+
+	const after = Date.parse(normalize_you_date(date_after));
+	if (Number.isNaN(after)) return undefined;
+
+	const days = (Date.now() - after) / 86_400_000;
+	if (days <= 1) return 'day';
+	if (days <= 7) return 'week';
+	if (days <= 31) return 'month';
+	return 'year';
+};
+
+const collect_you_results = (
+	results:
+		| v.InferOutput<typeof you_result_schema>[]
+		| {
+				web?: v.InferOutput<typeof you_result_schema>[];
+				news?: v.InferOutput<typeof you_result_schema>[];
+		  }
+		| undefined,
+) => {
+	if (!results) return [];
+	if (Array.isArray(results)) return results;
+	return [...(results.web ?? []), ...(results.news ?? [])];
+};
+
+const snippet_from_you_result = (
+	result: v.InferOutput<typeof you_result_schema>,
+) => {
+	if (result.description) return result.description;
+	if (result.snippets?.length) return result.snippets.join(' ');
+	return '';
+};
+
+export class YouSearchProvider implements SearchProvider {
+	name = 'you';
+	description =
+		'Fast LLM-ready web and news search from You.com. Best for current-web and RAG-style snippets. Supports include_domains/exclude_domains, country, language, and freshness (day/week/month/year or YYYY-MM-DDtoYYYY-MM-DD). Query operators such as site:, lang:, loc:, before:, and after: are translated into those fields.';
+
+	async search(params: BaseSearchParams): Promise<SearchResult[]> {
+		const api_key = validate_api_key(
+			config.search.you.api_key,
+			this.name,
+		);
+
+		const parsed_query = parse_search_operators(params.query);
+		const search_params = apply_search_operators(parsed_query);
+
+		const search_request = async () => {
+			try {
+				const include_domains = [
+					...(params.include_domains ?? []),
+					...(search_params.include_domains ?? []),
+				];
+				const exclude_domains = [
+					...(params.exclude_domains ?? []),
+					...(search_params.exclude_domains ?? []),
+				];
+				const freshness = map_you_freshness(
+					search_params.date_after,
+					search_params.date_before,
+				);
+
+				const request_body: YouSearchRequest = {
+					query: sanitize_query(
+						build_query_with_operators({
+							...search_params,
+							include_domains: undefined,
+							exclude_domains: undefined,
+							language: undefined,
+							location: undefined,
+							date_after: freshness
+								? undefined
+								: search_params.date_after,
+							date_before: freshness
+								? undefined
+								: search_params.date_before,
+						}),
+					),
+					count: params.limit ?? 10,
+				};
+
+				if (include_domains.length > 0) {
+					request_body.include_domains = include_domains;
+				}
+				if (exclude_domains.length > 0) {
+					request_body.exclude_domains = exclude_domains;
+				}
+				if (search_params.location) {
+					request_body.country = normalize_you_country(
+						search_params.location,
+					);
+				}
+				if (search_params.language) {
+					request_body.language = normalize_you_language(
+						search_params.language,
+					);
+				}
+				if (freshness) {
+					request_body.freshness = freshness;
+				}
+
+				const raw_data = await http_json(
+					this.name,
+					`${config.search.you.base_url}/v1/search`,
+					{
+						method: 'POST',
+						headers: {
+							Accept: 'application/json',
+							'Content-Type': 'application/json',
+							'X-API-Key': api_key,
+						},
+						body: JSON.stringify(request_body),
+						signal: AbortSignal.timeout(config.search.you.timeout),
+					},
+				);
+				const data = parse_provider_response(
+					this.name,
+					you_search_response_schema,
+					raw_data,
+				);
+
+				return collect_you_results(data.results).map((result) => ({
+					title: result.title ?? result.url,
+					url: result.url,
+					snippet: snippet_from_you_result(result),
+					source_provider: this.name,
+				}));
+			} catch (error) {
+				handle_provider_error(
+					error,
+					this.name,
+					'fetch search results',
+				);
+			}
+		};
+
+		return retry_with_backoff(search_request);
+	}
+}

--- a/src/server/provider-definitions.test.ts
+++ b/src/server/provider-definitions.test.ts
@@ -27,6 +27,7 @@ describe('provider definitions', () => {
 				category: 'search',
 				tools: ['web_search'],
 			},
+			{ id: 'you', category: 'search', tools: ['web_search'] },
 		]);
 
 		expect(
@@ -125,6 +126,12 @@ describe('provider definitions', () => {
 				name: 'exa',
 				mode: 'similar',
 				default_mode: false,
+			},
+			{
+				id: 'you:contents',
+				name: 'you',
+				mode: 'contents',
+				default_mode: true,
 			},
 		]);
 

--- a/src/server/provider-definitions.ts
+++ b/src/server/provider-definitions.ts
@@ -16,11 +16,13 @@ import { FirecrawlMapProvider } from '../providers/processing/firecrawl-map/inde
 import { FirecrawlScrapeProvider } from '../providers/processing/firecrawl-scrape/index.js';
 import { KagiSummarizerProvider } from '../providers/processing/kagi-summarizer/index.js';
 import { TavilyExtractProvider } from '../providers/processing/tavily-extract/index.js';
+import { YouContentsProvider } from '../providers/processing/you-contents/index.js';
 import { BraveSearchProvider } from '../providers/search/brave/index.js';
 import { ExaSearchProvider } from '../providers/search/exa/index.js';
 import { GitHubSearchProvider } from '../providers/search/github/index.js';
 import { KagiSearchProvider } from '../providers/search/kagi/index.js';
 import { TavilySearchProvider } from '../providers/search/tavily/index.js';
+import { YouSearchProvider } from '../providers/search/you/index.js';
 import type { ProviderDefinition } from './provider-registry.js';
 
 export type WebSearchProviderName =
@@ -28,7 +30,8 @@ export type WebSearchProviderName =
 	| 'brave'
 	| 'kagi'
 	| 'exa'
-	| 'kagi_enrichment';
+	| 'kagi_enrichment'
+	| 'you';
 
 export type AISearchProviderName =
 	| 'kagi_fastgpt'
@@ -39,7 +42,8 @@ export type WebExtractProvider =
 	| 'tavily'
 	| 'kagi'
 	| 'firecrawl'
-	| 'exa';
+	| 'exa'
+	| 'you';
 
 export type WebExtractMode =
 	| 'extract'
@@ -124,6 +128,20 @@ export const web_search_provider_definitions = [
 		capabilities: ['specialized_indexes', 'web_enrichment'],
 		api_key: config.enhancement.kagi_enrichment.api_key,
 		create: () => new KagiEnrichmentSearchProvider(),
+	},
+	{
+		id: 'you',
+		name: 'you',
+		category: 'search',
+		api_key_name: 'YOU_API_KEY',
+		tools: ['web_search'],
+		capabilities: [
+			'web_search',
+			'domain_filters',
+			'operator_translation',
+		],
+		api_key: config.search.you.api_key,
+		create: () => new YouSearchProvider(),
 	},
 ] satisfies readonly ProviderDefinition<SearchProvider>[];
 
@@ -277,6 +295,18 @@ export const web_extract_provider_definitions = [
 		modes: ['similar'],
 		capabilities: ['similar_pages'],
 		create: () => new ExaSimilarProvider(),
+	},
+	{
+		id: make_processing_provider_key('you', 'contents'),
+		name: 'you',
+		category: 'processing',
+		api_key: config.processing.you_contents.api_key,
+		api_key_name: 'YOU_API_KEY',
+		tools: ['web_extract'],
+		modes: ['contents'],
+		capabilities: ['content_retrieval'],
+		default_mode: true,
+		create: () => new YouContentsProvider(),
 	},
 ] satisfies readonly ProcessingProviderDefinition[];
 

--- a/src/server/tools/contract.test.ts
+++ b/src/server/tools/contract.test.ts
@@ -17,6 +17,7 @@ const API_KEY_NAMES = [
 	'EXA_API_KEY',
 	'LINKUP_API_KEY',
 	'FIRECRAWL_API_KEY',
+	'YOU_API_KEY',
 ];
 
 const create_mock_server = () => {
@@ -152,6 +153,35 @@ describe('MCP tool contract', () => {
 			v.safeParse(schema, { query: 'test', provider: 'kagi' })
 				.success,
 		).toBe(false);
+		expect(
+			v.safeParse(schema, { query: 'test', provider: 'you' }).success,
+		).toBe(false);
+	});
+
+	it('exposes you on web_search and web_extract only when YOU_API_KEY is set', async () => {
+		const { tools } = await load_contract({
+			YOU_API_KEY: 'you-key',
+		});
+		const search_schema = tools.find(
+			(tool) => tool.definition.name === 'web_search',
+		)!.definition.schema;
+		const extract_schema = tools.find(
+			(tool) => tool.definition.name === 'web_extract',
+		)!.definition.schema;
+
+		expect(
+			v.safeParse(search_schema, {
+				query: 'example',
+				provider: 'you',
+			}).success,
+		).toBe(true);
+		expect(
+			v.safeParse(extract_schema, {
+				url: 'https://example.com',
+				provider: 'you',
+				mode: 'contents',
+			}).success,
+		).toBe(true);
 	});
 
 	it('validates public web_extract payloads and unavailable modes at the MCP layer', async () => {

--- a/src/server/tools/web-extract.ts
+++ b/src/server/tools/web-extract.ts
@@ -55,7 +55,7 @@ export const register_web_extract = (
 		{
 			name: 'web_extract',
 			description:
-				'Extract, process, or summarize web content from URLs. Use when you need to read page content, summarize articles, crawl sites, or extract structured data. Providers: tavily (content extraction), kagi (summarization of pages/videos/podcasts), firecrawl (scraping/crawling/mapping/structured extraction/interactive), exa (content retrieval/similar pages).',
+				'Extract, process, or summarize web content from URLs. Use when you need to read page content, summarize articles, crawl sites, or extract structured data. Providers: tavily (content extraction), kagi (summarization of pages/videos/podcasts), firecrawl (scraping/crawling/mapping/structured extraction/interactive), exa (content retrieval/similar pages), you (Contents API markdown).',
 			annotations: {
 				readOnlyHint: true,
 				destructiveHint: false,
@@ -72,7 +72,7 @@ export const register_web_extract = (
 					v.pipe(
 						v.picklist(web_extract_modes),
 						v.description(
-							'Processing mode. Firecrawl: scrape/crawl/map/extract/actions. Exa: contents/similar. Tavily: extract. Kagi: summarize. Defaults to provider default.',
+							'Processing mode. Firecrawl: scrape/crawl/map/extract/actions. Exa: contents/similar. Tavily: extract. Kagi: summarize. You.com: contents. Defaults to provider default.',
 						),
 					),
 				),

--- a/src/server/tools/web-search.ts
+++ b/src/server/tools/web-search.ts
@@ -41,7 +41,7 @@ export const register_web_search = (
 		{
 			name: 'web_search',
 			description:
-				'Search the web for information. Use when you need to find web pages, articles, or data. Providers: tavily (factual/citations), brave (privacy/operators), kagi (quality/operators), exa (AI-semantic), kagi_enrichment (specialized indexes). Brave/Kagi support query operators like site:, filetype:, lang:, before:, after:.',
+				'Search the web for information. Use when you need to find web pages, articles, or data. Providers: tavily (factual/citations), brave (privacy/operators), kagi (quality/operators), exa (AI-semantic), kagi_enrichment (specialized indexes), you (LLM-ready web/news). Brave/Kagi support query operators like site:, filetype:, lang:, before:, after:.',
 			annotations: {
 				readOnlyHint: true,
 				destructiveHint: false,


### PR DESCRIPTION
## Summary

Part of #197. Adds an independently optional You.com adapter for `web_search` and `web_extract`.

## Problem

Issue #197 asks for a You.com provider (`YOU_API_KEY`) covering search plus extract. Users without the key should see no You.com enum values.

## Approach

- Register search (`you`) and extract (`you:contents`) only when `YOU_API_KEY` is set.
- Search: `POST https://ydc-index.io/v1/search` with `X-API-Key`.
- Extract: `POST https://ydc-index.io/v1/contents` (`formats: ['markdown']`; advanced also requests `metadata`).
- Maps `site:` / `include_domains`, `lang:`, `loc:`, and `before:` / `after:` to You.com `include_domains`, `language`, `country`, and `freshness`.
- Uses `http_json`, config timeouts, retries, and Valibot response parsing.
- Docs and `.env.example` placeholder only.

## Verification

- `pnpm run format`
- `pnpm exec vitest run --testTimeout=15000`

## Impact

No default-behavior change. Missing `YOU_API_KEY` means You.com is not registered and does not appear on the `web_search` / `web_extract` picklists.